### PR TITLE
Fix chapter button not working on desktop (#24)

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -1699,3 +1699,139 @@
   }
 
 }
+
+/* Chapter Modal - works on both desktop and mobile */
+.chapter-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.85);
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  animation: chapterModalFadeIn 0.2s ease-out;
+}
+
+@keyframes chapterModalFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.chapter-modal-content {
+  width: 100%;
+  max-width: 500px;
+  max-height: 80vh;
+  background: #1f2937;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  animation: chapterModalScaleIn 0.2s ease-out;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+}
+
+@keyframes chapterModalScaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.chapter-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1rem 1rem 1rem;
+  border-bottom: 1px solid #374151;
+}
+
+.chapter-modal-header h3 {
+  color: #fff;
+  font-size: 1.25rem;
+  margin: 0;
+  font-weight: 600;
+}
+
+.chapter-modal-close {
+  background: transparent;
+  border: none;
+  color: #9ca3af;
+  cursor: pointer;
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s;
+}
+
+.chapter-modal-close:hover {
+  color: #fff;
+}
+
+.chapter-modal-list {
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.chapter-modal-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem;
+  background: #374151;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.chapter-modal-item:hover {
+  background: #4b5563;
+}
+
+.chapter-modal-item.active {
+  background: #3b82f6;
+}
+
+.chapter-modal-number {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: #1f2937;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: 600;
+  flex-shrink: 0;
+  font-size: 0.875rem;
+}
+
+.chapter-modal-item.active .chapter-modal-number {
+  background: #2563eb;
+}
+
+.chapter-modal-title {
+  flex: 1;
+  color: #e5e7eb;
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.chapter-modal-time {
+  color: #9ca3af;
+  font-size: 0.875rem;
+}


### PR DESCRIPTION
## Summary
- Move chapter modal outside fullscreen wrapper so it renders on desktop view
- Add chapter modal CSS outside mobile media query for desktop support
- Auto-scroll to active chapter when modal opens
- Remove chapter numbers from modal, show only title and timestamp

Fixes #24

## Test plan
- [ ] Open an audiobook with chapters on desktop (wide browser window)
- [ ] Click the chapter indicator button in the mini player bar
- [ ] Verify chapter modal opens and scrolls to the current chapter
- [ ] Click a chapter to navigate to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)