### PR TITLE
Handle legacy sapho.db database migration (#64)

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -10,6 +10,27 @@ if (!fs.existsSync(dbDir)) {
   fs.mkdirSync(dbDir, { recursive: true });
 }
 
+// Handle legacy database migration (sapho.db -> sappho.db)
+// Early versions used misspelled "sapho.db" - migrate if found
+if (!process.env.DATABASE_PATH) {
+  const legacyDbPath = path.join(dbDir, 'sapho.db');
+
+  if (!fs.existsSync(dbPath) && fs.existsSync(legacyDbPath)) {
+    console.log('='.repeat(60));
+    console.log('MIGRATING LEGACY DATABASE');
+    console.log('Found old database: sapho.db');
+    console.log('Renaming to: sappho.db');
+    try {
+      fs.renameSync(legacyDbPath, dbPath);
+      console.log('Migration successful!');
+    } catch (err) {
+      console.error('Migration failed:', err.message);
+      console.log('Falling back to legacy database path');
+    }
+    console.log('='.repeat(60));
+  }
+}
+
 let dbReadyResolve;
 const dbReady = new Promise((resolve) => {
   dbReadyResolve = resolve;

--- a/server/services/backupService.js
+++ b/server/services/backupService.js
@@ -178,7 +178,7 @@ async function restoreBackup(backupPath, options = {}) {
         if (fileName === 'manifest.json') {
           const content = await entry.buffer();
           results.manifest = JSON.parse(content.toString());
-        } else if (fileName === 'sappho.db' && restoreDatabase) {
+        } else if ((fileName === 'sappho.db' || fileName === 'sapho.db') && restoreDatabase) {
           // Backup current database first
           if (fs.existsSync(DATABASE_PATH)) {
             const backupName = DATABASE_PATH + '.pre-restore';


### PR DESCRIPTION
## Summary
- Auto-detect and rename old `sapho.db` to `sappho.db` on startup
- Clear migration logging when legacy database is found
- Support restoring from backups that contain old `sapho.db` filename

Early versions of Sappho used a misspelled database filename. This ensures users who upgrade don't lose their data.

Fixes #64

## Test plan
- [ ] Users with `sappho.db` - no change, works as before
- [ ] Users with only `sapho.db` - automatically renamed to `sappho.db`
- [ ] Users with both files - uses `sappho.db` (no migration needed)
- [ ] Restoring from old backups with `sapho.db` inside works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)