### PR TITLE
Fix favorites routing and improve progress tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,3 +381,4 @@ For security vulnerabilities, use **GitHub Security Advisories** instead of regu
 
 Private vulnerability reporting is enabled - external researchers can report issues privately via the Security tab.
 - don't bypass merge rules in the future. always work on new branch and merge back in via pr / mr.
+- don't use automerge and wait for pipelines to give you results before moving onto something else or declaring success

--- a/client/src/components/Navigation.jsx
+++ b/client/src/components/Navigation.jsx
@@ -284,6 +284,12 @@ export default function Navigation({ onLogout, onOpenUpload }) {
                     </svg>
                     Profile
                   </button>
+                  <button onClick={() => { navigate('/all-books?favorites=true'); setShowUserMenu(false); }}>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
+                    </svg>
+                    Favorites
+                  </button>
                   {user?.is_admin && (
                     <>
                       <button onClick={() => { navigate('/settings'); setShowUserMenu(false); }}>
@@ -361,6 +367,13 @@ export default function Navigation({ onLogout, onOpenUpload }) {
                 <circle cx="12" cy="7" r="4"></circle>
               </svg>
               <span>Profile</span>
+            </button>
+
+            <button onClick={() => { navigate('/all-books?favorites=true'); setShowMobileMenu(false); }}>
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
+              </svg>
+              <span>Favorites</span>
             </button>
 
             {user?.is_admin && (

--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -322,19 +322,4 @@
     flex-shrink: 0 !important;
   }
 
-  /* Make Favorites section scroll horizontally on mobile with standard size */
-  .favorites-section .horizontal-scroll {
-    display: flex !important;
-    overflow-x: auto !important;
-    gap: 0.5rem !important;
-    padding: 0.5rem 0 !important;
-  }
-
-  .favorites-section .audiobook-card {
-    width: calc(33.333vw - 0.5rem) !important;
-    min-width: calc(33.333vw - 0.5rem) !important;
-    height: 0 !important;
-    padding-bottom: calc(33.333vw - 0.5rem) !important;
-    flex-shrink: 0 !important;
-  }
 }

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getCoverUrl, getRecentlyAdded, getInProgress, getUpNext, getFinished, getProgress, getFavorites, toggleFavorite } from '../api';
+import { getCoverUrl, getRecentlyAdded, getInProgress, getUpNext, getFinished, getProgress } from '../api';
 import { useWebSocket } from '../contexts/WebSocketContext';
 import './Home.css';
 
@@ -10,7 +10,6 @@ export default function Home({ onPlay }) {
   const [inProgress, setInProgress] = useState([]);
   const [upNext, setUpNext] = useState([]);
   const [finished, setFinished] = useState([]);
-  const [favorites, setFavorites] = useState([]);
   const [loading, setLoading] = useState(true);
   const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);
   const { subscribe, isConnected } = useWebSocket();
@@ -47,16 +46,10 @@ export default function Home({ onPlay }) {
         return { data: [] };
       });
 
-      const favoritesResponse = await getFavorites().catch(err => {
-        console.error('Error loading favorites:', err);
-        return { data: [] };
-      });
-
       setRecentlyAdded(recentResponse.data);
       setInProgress(progressResponse.data);
       setUpNext(upNextResponse.data);
       setFinished(finishedResponse.data);
-      setFavorites(favoritesResponse.data);
     } catch (error) {
       console.error('Error loading special sections:', error);
     } finally {
@@ -185,16 +178,7 @@ export default function Home({ onPlay }) {
         </div>
       )}
 
-      {favorites.length > 0 && (
-        <div className="horizontal-section favorites-section">
-          <h2>Favorites</h2>
-          <div className="horizontal-scroll">
-            {favorites.map(renderBookCard)}
-          </div>
-        </div>
-      )}
-
-      {inProgress.length === 0 && recentlyAdded.length === 0 && upNext.length === 0 && finished.length === 0 && favorites.length === 0 && (
+      {inProgress.length === 0 && recentlyAdded.length === 0 && upNext.length === 0 && finished.length === 0 && (
         <div className="empty-state">
           <p>No audiobooks found.</p>
           <p>Upload some audiobooks or drop them in the watch directory!</p>


### PR DESCRIPTION
## Summary

- Fix `/favorites` route ordering so it doesn't get matched as `/:id`
- Add Favorites link to user dropdown menu (desktop and mobile)
- Remove Favorites section from Home page (still accessible via Library page and dropdown)
- Lower "Continue Listening" threshold from 20s to 5s
- Don't save progress until user has listened for 5s (prevents tiny accidental progress records)

## Changes

- **server/routes/audiobooks.js**: Move `/favorites` route before `/:id`, add 5s minimum before saving progress
- **client/src/components/Navigation.jsx**: Add Favorites link with star icon to dropdown menus
- **client/src/pages/Home.jsx**: Remove Favorites section and related state/API calls
- **client/src/pages/Home.css**: Remove unused favorites section mobile styles
- **CLAUDE.md**: Add workflow guidance notes

## Test plan

- [ ] Favorites count shows correctly on Library page
- [ ] Favorites link appears in user dropdown (desktop and mobile)
- [ ] Clicking Favorites in dropdown navigates to favorites view
- [ ] No Favorites row on Home page
- [ ] Books with 5+ seconds progress appear in Continue Listening
- [ ] Progress under 5 seconds is not saved to database

🤖 Generated with [Claude Code](https://claude.com/claude-code)