### PR TITLE
Add progress bar with speed, ETA, cancel and retry for uploads

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -67,7 +67,7 @@ export const convertToM4B = (id) =>
 export const searchMetadata = (id, params) =>
   api.get(`/audiobooks/${id}/search-metadata`, { params });
 
-export const uploadAudiobook = (file, metadata) => {
+export const uploadAudiobook = (file, metadata, { onProgress, cancelToken } = {}) => {
   const formData = new FormData();
   formData.append('audiobook', file);
   if (metadata) {
@@ -79,10 +79,12 @@ export const uploadAudiobook = (file, metadata) => {
     headers: {
       'Content-Type': 'multipart/form-data',
     },
+    onUploadProgress: onProgress,
+    cancelToken,
   });
 };
 
-export const uploadMultiFileAudiobook = (files, bookName = null) => {
+export const uploadMultiFileAudiobook = (files, bookName = null, { onProgress, cancelToken } = {}) => {
   const formData = new FormData();
   // Sort files by name to maintain order
   const sortedFiles = [...files].sort((a, b) =>
@@ -103,6 +105,8 @@ export const uploadMultiFileAudiobook = (files, bookName = null) => {
     headers: {
       'Content-Type': 'multipart/form-data',
     },
+    onUploadProgress: onProgress,
+    cancelToken,
   });
 };
 

--- a/client/src/components/UploadModal.css
+++ b/client/src/components/UploadModal.css
@@ -332,3 +332,115 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+.upload-modal .btn-danger {
+  background: #dc2626;
+  color: white;
+}
+
+.upload-modal .btn-danger:hover:not(:disabled) {
+  background: #b91c1c;
+}
+
+/* Overall progress bar */
+.overall-progress {
+  background: #1f2937;
+  border-radius: 8px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.progress-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.progress-percent {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #60a5fa;
+}
+
+.progress-details {
+  font-size: 0.875rem;
+  color: #9ca3af;
+}
+
+.progress-bar-container {
+  height: 8px;
+  background: #374151;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #3b82f6, #60a5fa);
+  border-radius: 4px;
+  transition: width 0.2s ease-out;
+}
+
+.progress-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.progress-speed {
+  font-size: 0.875rem;
+  color: #10b981;
+  font-weight: 500;
+}
+
+.progress-eta {
+  font-size: 0.875rem;
+  color: #9ca3af;
+}
+
+/* Per-file progress bar */
+.file-progress-bar {
+  width: 100%;
+  height: 4px;
+  background: #374151;
+  border-radius: 2px;
+  overflow: hidden;
+  margin-top: 0.25rem;
+}
+
+.file-progress-fill {
+  height: 100%;
+  background: #3b82f6;
+  border-radius: 2px;
+  transition: width 0.2s ease-out;
+}
+
+/* Retry button */
+.retry-btn {
+  background: #374151;
+  border: none;
+  color: #60a5fa;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.retry-btn:hover {
+  background: #4b5563;
+  color: #93c5fd;
+}
+
+/* Cancelled status */
+.file-status.cancelled {
+  color: #9ca3af;
+  background: rgba(156, 163, 175, 0.2);
+}
+
+.file-item.cancelled {
+  background: rgba(156, 163, 175, 0.1);
+}


### PR DESCRIPTION
## Summary
- Show overall upload progress with percentage bar, upload speed (MB/s), and estimated time remaining
- Add cancel button to abort in-progress uploads
- Add retry button for individual failed file uploads
- Track per-file progress for multiple file uploads
- Navigate to uploaded audiobook detail page on success

Closes #3

## Test plan
- [ ] Upload a single audiobook file and verify progress bar shows percentage, speed, and ETA
- [ ] Upload multiple files and verify per-file progress tracking works
- [ ] Cancel an upload mid-progress and verify the upload stops
- [ ] Test retry functionality on a failed upload
- [ ] Verify successful upload navigates to audiobook detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)