### PR TITLE
Add duplicate audiobook detection and merge (#30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,3 +382,4 @@ For security vulnerabilities, use **GitHub Security Advisories** instead of regu
 Private vulnerability reporting is enabled - external researchers can report issues privately via the Security tab.
 - don't bypass merge rules in the future. always work on new branch and merge back in via pr / mr.
 - don't use automerge and wait for pipelines to give you results before moving onto something else or declaring success
+- wait for me to test before shipping

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -287,4 +287,11 @@ export const addFavorite = (id) =>
 export const removeFavorite = (id) =>
   api.delete(`/audiobooks/${id}/favorite`);
 
+// Duplicates
+export const getDuplicates = () =>
+  api.get('/maintenance/duplicates');
+
+export const mergeDuplicates = (keepId, deleteIds, deleteFiles = false) =>
+  api.post('/maintenance/duplicates/merge', { keepId, deleteIds, deleteFiles });
+
 export default api;

--- a/client/src/components/settings/DuplicatesSettings.css
+++ b/client/src/components/settings/DuplicatesSettings.css
@@ -1,0 +1,247 @@
+.duplicates-settings {
+  max-width: 1200px;
+}
+
+.scan-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+
+.scan-results {
+  margin-top: 1rem;
+}
+
+.no-duplicates {
+  background: rgba(34, 197, 94, 0.1);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  border-radius: 8px;
+  padding: 2rem;
+  text-align: center;
+  color: #22c55e;
+}
+
+.results-summary {
+  background: #1f2937;
+  border-radius: 8px;
+  padding: 1rem 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #d1d5db;
+}
+
+.results-summary strong {
+  color: #f59e0b;
+}
+
+.duplicate-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.duplicate-group {
+  background: #1f2937;
+  border: 1px solid #374151;
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+
+.group-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.group-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.group-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #f3f4f6;
+}
+
+.group-author {
+  font-size: 0.875rem;
+  color: #9ca3af;
+}
+
+.match-reason {
+  font-size: 0.75rem;
+  color: #60a5fa;
+  background: rgba(96, 165, 250, 0.1);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  display: inline-block;
+  width: fit-content;
+  margin-top: 0.25rem;
+}
+
+.books-comparison {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.book-card {
+  background: #111827;
+  border: 2px solid #374151;
+  border-radius: 8px;
+  padding: 1rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.book-card:hover {
+  border-color: #6b7280;
+}
+
+.book-card.selected {
+  border-color: #22c55e;
+  background: rgba(34, 197, 94, 0.05);
+}
+
+.book-cover {
+  width: 100%;
+  aspect-ratio: 1;
+  max-width: 120px;
+  margin: 0 auto 1rem;
+  border-radius: 6px;
+  overflow: hidden;
+  background: #374151;
+}
+
+.book-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cover-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b7280;
+  font-size: 0.75rem;
+}
+
+.book-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.badge {
+  font-size: 0.6875rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.badge-keep {
+  background: rgba(34, 197, 94, 0.2);
+  color: #22c55e;
+}
+
+.badge-cover {
+  background: rgba(168, 85, 247, 0.2);
+  color: #a855f7;
+}
+
+.badge-progress {
+  background: rgba(59, 130, 246, 0.2);
+  color: #3b82f6;
+}
+
+.book-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.meta-row {
+  display: flex;
+  font-size: 0.8125rem;
+}
+
+.meta-label {
+  color: #6b7280;
+  min-width: 70px;
+}
+
+.meta-value {
+  color: #d1d5db;
+}
+
+.book-path {
+  font-size: 0.6875rem;
+  color: #6b7280;
+  font-family: 'Courier New', monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-top: 0.5rem;
+  border-top: 1px solid #374151;
+}
+
+.checkbox-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #d1d5db;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.checkbox-inline input {
+  width: 1rem;
+  height: 1rem;
+  cursor: pointer;
+}
+
+@media (max-width: 768px) {
+  .duplicates-settings {
+    max-width: 100%;
+  }
+
+  .scan-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .checkbox-inline {
+    order: -1;
+  }
+
+  .group-header {
+    flex-direction: column;
+  }
+
+  .group-header .btn {
+    width: 100%;
+  }
+
+  .books-comparison {
+    grid-template-columns: 1fr;
+  }
+
+  .book-cover {
+    max-width: 80px;
+  }
+
+  .meta-label {
+    min-width: 60px;
+  }
+}

--- a/client/src/components/settings/DuplicatesSettings.jsx
+++ b/client/src/components/settings/DuplicatesSettings.jsx
@@ -1,0 +1,241 @@
+import { useState } from 'react';
+import { getDuplicates, mergeDuplicates, getCoverUrl } from '../../api';
+import './DuplicatesSettings.css';
+
+export default function DuplicatesSettings() {
+  const [loading, setLoading] = useState(false);
+  const [duplicateGroups, setDuplicateGroups] = useState([]);
+  const [totalDuplicates, setTotalDuplicates] = useState(0);
+  const [scanned, setScanned] = useState(false);
+  const [selectedKeep, setSelectedKeep] = useState({});
+  const [merging, setMerging] = useState({});
+  const [deleteFiles, setDeleteFiles] = useState(false);
+
+  const scanForDuplicates = async () => {
+    setLoading(true);
+    try {
+      const response = await getDuplicates();
+      setDuplicateGroups(response.data.duplicateGroups);
+      setTotalDuplicates(response.data.totalDuplicates);
+      setScanned(true);
+
+      // Initialize selectedKeep with suggested values
+      const initialSelection = {};
+      response.data.duplicateGroups.forEach(group => {
+        initialSelection[group.id] = group.suggestedKeep;
+      });
+      setSelectedKeep(initialSelection);
+    } catch (error) {
+      console.error('Error scanning for duplicates:', error);
+      alert(error.response?.data?.error || 'Failed to scan for duplicates');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleMerge = async (group) => {
+    const keepId = selectedKeep[group.id];
+    const deleteIds = group.books.filter(b => b.id !== keepId).map(b => b.id);
+
+    if (!confirm(`Merge ${group.books.length} duplicates? This will keep 1 book and remove ${deleteIds.length}.${deleteFiles ? ' Files will also be deleted!' : ''}`)) {
+      return;
+    }
+
+    setMerging(prev => ({ ...prev, [group.id]: true }));
+    try {
+      const result = await mergeDuplicates(keepId, deleteIds, deleteFiles);
+      alert(`Merged successfully! Progress from ${result.data.progressTransferred} users transferred.${result.data.filesDeleted > 0 ? ` ${result.data.filesDeleted} files deleted.` : ''}`);
+
+      // Remove this group from the list
+      setDuplicateGroups(prev => prev.filter(g => g.id !== group.id));
+      setTotalDuplicates(prev => prev - deleteIds.length);
+    } catch (error) {
+      console.error('Error merging duplicates:', error);
+      alert(error.response?.data?.error || 'Failed to merge duplicates');
+    } finally {
+      setMerging(prev => ({ ...prev, [group.id]: false }));
+    }
+  };
+
+  const handleMergeAll = async () => {
+    if (!confirm(`Merge all ${duplicateGroups.length} duplicate groups? This will remove ${totalDuplicates} audiobooks.${deleteFiles ? ' Files will also be deleted!' : ''}`)) {
+      return;
+    }
+
+    for (const group of duplicateGroups) {
+      await handleMerge(group);
+    }
+  };
+
+  const formatDuration = (seconds) => {
+    if (!seconds) return '-';
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+  };
+
+  const formatSize = (bytes) => {
+    if (!bytes) return '-';
+    const mb = bytes / (1024 * 1024);
+    if (mb > 1024) {
+      return `${(mb / 1024).toFixed(1)} GB`;
+    }
+    return `${mb.toFixed(0)} MB`;
+  };
+
+  const formatPath = (filePath) => {
+    if (!filePath) return '-';
+    // Show just the last 2-3 parts of the path
+    const parts = filePath.split('/');
+    return parts.slice(-3).join('/');
+  };
+
+  return (
+    <div className="tab-content duplicates-settings">
+      <div className="section-header">
+        <div>
+          <h2>Duplicate Detection</h2>
+          <p className="section-description">
+            Find and merge duplicate audiobooks in your library. Duplicates are detected by matching title + author, ISBN/ASIN, or similar duration and file size.
+          </p>
+        </div>
+      </div>
+
+      <div className="scan-controls">
+        <button
+          className="btn btn-primary"
+          onClick={scanForDuplicates}
+          disabled={loading}
+        >
+          {loading ? 'Scanning...' : scanned ? 'Rescan' : 'Scan for Duplicates'}
+        </button>
+
+        {scanned && duplicateGroups.length > 0 && (
+          <>
+            <label className="checkbox-inline">
+              <input
+                type="checkbox"
+                checked={deleteFiles}
+                onChange={(e) => setDeleteFiles(e.target.checked)}
+              />
+              <span>Delete files (not just database entries)</span>
+            </label>
+            <button
+              className="btn btn-danger"
+              onClick={handleMergeAll}
+              disabled={loading}
+            >
+              Merge All ({duplicateGroups.length} groups)
+            </button>
+          </>
+        )}
+      </div>
+
+      {scanned && (
+        <div className="scan-results">
+          {duplicateGroups.length === 0 ? (
+            <div className="no-duplicates">
+              <p>No duplicates found in your library.</p>
+            </div>
+          ) : (
+            <>
+              <div className="results-summary">
+                Found <strong>{duplicateGroups.length}</strong> duplicate groups with <strong>{totalDuplicates}</strong> extra copies
+              </div>
+
+              <div className="duplicate-groups">
+                {duplicateGroups.map(group => (
+                  <div key={group.id} className="duplicate-group">
+                    <div className="group-header">
+                      <div className="group-info">
+                        <span className="group-title">{group.books[0].title}</span>
+                        <span className="group-author">by {group.books[0].author || 'Unknown'}</span>
+                        <span className="match-reason">{group.matchReason}</span>
+                      </div>
+                      <button
+                        className="btn btn-primary btn-small"
+                        onClick={() => handleMerge(group)}
+                        disabled={merging[group.id]}
+                      >
+                        {merging[group.id] ? 'Merging...' : `Merge (keep 1, remove ${group.books.length - 1})`}
+                      </button>
+                    </div>
+
+                    <div className="books-comparison">
+                      {group.books.map(book => (
+                        <div
+                          key={book.id}
+                          className={`book-card ${selectedKeep[group.id] === book.id ? 'selected' : ''}`}
+                          onClick={() => setSelectedKeep(prev => ({ ...prev, [group.id]: book.id }))}
+                        >
+                          <div className="book-cover">
+                            {book.hasCover ? (
+                              <img
+                                src={getCoverUrl(book.id)}
+                                alt={book.title}
+                                onError={(e) => {
+                                  e.target.style.display = 'none';
+                                  e.target.nextSibling.style.display = 'flex';
+                                }}
+                              />
+                            ) : null}
+                            <div className="cover-placeholder" style={{ display: book.hasCover ? 'none' : 'flex' }}>
+                              No Cover
+                            </div>
+                          </div>
+
+                          <div className="book-details">
+                            <div className="book-badges">
+                              {selectedKeep[group.id] === book.id && (
+                                <span className="badge badge-keep">Will Keep</span>
+                              )}
+                              {book.hasUserCover && (
+                                <span className="badge badge-cover">Custom Cover</span>
+                              )}
+                              {book.progress.userCount > 0 && (
+                                <span className="badge badge-progress">
+                                  {book.progress.userCount} user{book.progress.userCount > 1 ? 's' : ''} with progress
+                                </span>
+                              )}
+                            </div>
+
+                            <div className="book-meta">
+                              <div className="meta-row">
+                                <span className="meta-label">Duration:</span>
+                                <span className="meta-value">{formatDuration(book.duration)}</span>
+                              </div>
+                              <div className="meta-row">
+                                <span className="meta-label">Size:</span>
+                                <span className="meta-value">{formatSize(book.file_size)}</span>
+                              </div>
+                              {book.narrator && (
+                                <div className="meta-row">
+                                  <span className="meta-label">Narrator:</span>
+                                  <span className="meta-value">{book.narrator}</span>
+                                </div>
+                              )}
+                              {(book.isbn || book.asin) && (
+                                <div className="meta-row">
+                                  <span className="meta-label">ID:</span>
+                                  <span className="meta-value">{book.isbn || book.asin}</span>
+                                </div>
+                              )}
+                            </div>
+
+                            <div className="book-path" title={book.file_path}>
+                              {formatPath(book.file_path)}
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -8,6 +8,7 @@ import LogsSettings from '../components/settings/LogsSettings';
 import AISettings from '../components/settings/AISettings';
 import StatisticsSettings from '../components/settings/StatisticsSettings';
 import BackupSettings from '../components/settings/BackupSettings';
+import DuplicatesSettings from '../components/settings/DuplicatesSettings';
 import './Settings.css';
 
 export default function Settings() {
@@ -237,6 +238,8 @@ export default function Settings() {
         return <StatisticsSettings />;
       case 'backup':
         return <BackupSettings />;
+      case 'duplicates':
+        return <DuplicatesSettings />;
       case 'logs':
         return <LogsSettings />;
       case 'ai':
@@ -648,6 +651,12 @@ export default function Settings() {
           onClick={() => setActiveTab('backup')}
         >
           Backup
+        </button>
+        <button
+          className={`tab-button ${activeTab === 'duplicates' ? 'active' : ''}`}
+          onClick={() => setActiveTab('duplicates')}
+        >
+          Duplicates
         </button>
         <button
           className={`tab-button ${activeTab === 'logs' ? 'active' : ''}`}

--- a/server/routes/maintenance.js
+++ b/server/routes/maintenance.js
@@ -884,4 +884,334 @@ router.post('/force-rescan', authenticateToken, async (req, res) => {
   });
 });
 
+// Detect duplicate audiobooks
+router.get('/duplicates', authenticateToken, async (req, res) => {
+  if (!req.user.is_admin) {
+    return res.status(403).json({ error: 'Admin access required' });
+  }
+
+  try {
+    console.log('Scanning for duplicate audiobooks...');
+
+    // Get all audiobooks with relevant fields
+    const audiobooks = await new Promise((resolve, reject) => {
+      db.all(
+        `SELECT id, title, author, narrator, duration, file_size, file_path,
+                isbn, asin, series, series_position, cover_image, cover_path,
+                created_at
+         FROM audiobooks
+         ORDER BY title, author`,
+        (err, rows) => {
+          if (err) reject(err);
+          else resolve(rows || []);
+        }
+      );
+    });
+
+    // Get playback progress for each audiobook
+    const progressMap = new Map();
+    const progressData = await new Promise((resolve, reject) => {
+      db.all(
+        `SELECT audiobook_id, COUNT(*) as user_count, MAX(position) as max_position
+         FROM playback_progress
+         GROUP BY audiobook_id`,
+        (err, rows) => {
+          if (err) reject(err);
+          else resolve(rows || []);
+        }
+      );
+    });
+    for (const p of progressData) {
+      progressMap.set(p.audiobook_id, { userCount: p.user_count, maxPosition: p.max_position });
+    }
+
+    const duplicateGroups = [];
+    const processed = new Set();
+
+    for (let i = 0; i < audiobooks.length; i++) {
+      if (processed.has(audiobooks[i].id)) continue;
+
+      const book = audiobooks[i];
+      const matches = [book];
+
+      for (let j = i + 1; j < audiobooks.length; j++) {
+        if (processed.has(audiobooks[j].id)) continue;
+
+        const candidate = audiobooks[j];
+        let isDuplicate = false;
+        let matchReason = '';
+
+        // Match by ISBN/ASIN (exact match)
+        if (book.isbn && candidate.isbn && book.isbn === candidate.isbn) {
+          isDuplicate = true;
+          matchReason = 'Same ISBN';
+        } else if (book.asin && candidate.asin && book.asin === candidate.asin) {
+          isDuplicate = true;
+          matchReason = 'Same ASIN';
+        }
+        // Match by title + author (case-insensitive, trimmed)
+        else if (book.title && candidate.title && book.author && candidate.author) {
+          const titleMatch = book.title.toLowerCase().trim() === candidate.title.toLowerCase().trim();
+          const authorMatch = book.author.toLowerCase().trim() === candidate.author.toLowerCase().trim();
+          if (titleMatch && authorMatch) {
+            isDuplicate = true;
+            matchReason = 'Same title and author';
+          }
+        }
+        // Match by similar duration + file size (within tolerance)
+        else if (book.duration && candidate.duration && book.file_size && candidate.file_size) {
+          const durationDiff = Math.abs(book.duration - candidate.duration) / Math.max(book.duration, candidate.duration);
+          const sizeDiff = Math.abs(book.file_size - candidate.file_size) / Math.max(book.file_size, candidate.file_size);
+          // Within 2% duration and 15% size could be same book different quality
+          if (durationDiff < 0.02 && sizeDiff < 0.15) {
+            // Also check if titles are similar (Levenshtein-like simple check)
+            if (book.title && candidate.title) {
+              const t1 = book.title.toLowerCase().replace(/[^a-z0-9]/g, '');
+              const t2 = candidate.title.toLowerCase().replace(/[^a-z0-9]/g, '');
+              if (t1 === t2 || t1.includes(t2) || t2.includes(t1)) {
+                isDuplicate = true;
+                matchReason = 'Similar duration and file size';
+              }
+            }
+          }
+        }
+
+        if (isDuplicate) {
+          candidate.matchReason = matchReason;
+          matches.push(candidate);
+          processed.add(candidate.id);
+        }
+      }
+
+      if (matches.length > 1) {
+        // Add progress info to each match
+        const matchesWithProgress = matches.map(m => ({
+          ...m,
+          progress: progressMap.get(m.id) || { userCount: 0, maxPosition: 0 },
+          hasCover: !!(m.cover_image || m.cover_path),
+          hasUserCover: !!m.cover_path,
+        }));
+
+        // Sort by quality indicators (most metadata, user cover, most progress)
+        matchesWithProgress.sort((a, b) => {
+          // Prefer user-set cover
+          if (a.hasUserCover !== b.hasUserCover) return b.hasUserCover - a.hasUserCover;
+          // Prefer more user progress
+          if (a.progress.userCount !== b.progress.userCount) return b.progress.userCount - a.progress.userCount;
+          // Prefer larger file (higher quality)
+          if (a.file_size !== b.file_size) return (b.file_size || 0) - (a.file_size || 0);
+          // Prefer older (original)
+          return new Date(a.created_at) - new Date(b.created_at);
+        });
+
+        duplicateGroups.push({
+          id: `group-${duplicateGroups.length + 1}`,
+          matchReason: matches[1].matchReason,
+          books: matchesWithProgress,
+          suggestedKeep: matchesWithProgress[0].id,
+        });
+
+        processed.add(book.id);
+      }
+    }
+
+    console.log(`Found ${duplicateGroups.length} duplicate groups`);
+
+    res.json({
+      duplicateGroups,
+      totalDuplicates: duplicateGroups.reduce((sum, g) => sum + g.books.length - 1, 0),
+    });
+  } catch (error) {
+    console.error('Error detecting duplicates:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Merge duplicate audiobooks
+router.post('/duplicates/merge', authenticateToken, async (req, res) => {
+  if (!req.user.is_admin) {
+    return res.status(403).json({ error: 'Admin access required' });
+  }
+
+  const { keepId, deleteIds, deleteFiles } = req.body;
+
+  if (!keepId || !Array.isArray(deleteIds) || deleteIds.length === 0) {
+    return res.status(400).json({ error: 'Must specify keepId and deleteIds array' });
+  }
+
+  // Ensure keepId is not in deleteIds
+  if (deleteIds.includes(keepId)) {
+    return res.status(400).json({ error: 'Cannot delete the audiobook being kept' });
+  }
+
+  try {
+    console.log(`Merging duplicates: keeping ${keepId}, deleting ${deleteIds.join(', ')}`);
+
+    // Get the audiobook to keep
+    const keepBook = await new Promise((resolve, reject) => {
+      db.get('SELECT * FROM audiobooks WHERE id = ?', [keepId], (err, row) => {
+        if (err) reject(err);
+        else resolve(row);
+      });
+    });
+
+    if (!keepBook) {
+      return res.status(404).json({ error: 'Audiobook to keep not found' });
+    }
+
+    // Get audiobooks to delete
+    const deleteBooks = await new Promise((resolve, reject) => {
+      db.all(
+        `SELECT * FROM audiobooks WHERE id IN (${deleteIds.map(() => '?').join(',')})`,
+        deleteIds,
+        (err, rows) => {
+          if (err) reject(err);
+          else resolve(rows || []);
+        }
+      );
+    });
+
+    if (deleteBooks.length === 0) {
+      return res.status(404).json({ error: 'No audiobooks to delete found' });
+    }
+
+    // Transfer playback progress from deleted books to kept book
+    let progressTransferred = 0;
+    for (const deleteBook of deleteBooks) {
+      // Get progress from the book being deleted
+      const progressRecords = await new Promise((resolve, reject) => {
+        db.all(
+          'SELECT * FROM playback_progress WHERE audiobook_id = ?',
+          [deleteBook.id],
+          (err, rows) => {
+            if (err) reject(err);
+            else resolve(rows || []);
+          }
+        );
+      });
+
+      for (const progress of progressRecords) {
+        // Check if user already has progress on the kept book
+        const existingProgress = await new Promise((resolve, reject) => {
+          db.get(
+            'SELECT * FROM playback_progress WHERE user_id = ? AND audiobook_id = ?',
+            [progress.user_id, keepId],
+            (err, row) => {
+              if (err) reject(err);
+              else resolve(row);
+            }
+          );
+        });
+
+        if (existingProgress) {
+          // Keep the more advanced progress
+          if (progress.position > existingProgress.position) {
+            await new Promise((resolve, reject) => {
+              db.run(
+                'UPDATE playback_progress SET position = ?, completed = ?, updated_at = ? WHERE user_id = ? AND audiobook_id = ?',
+                [progress.position, progress.completed, progress.updated_at, progress.user_id, keepId],
+                (err) => {
+                  if (err) reject(err);
+                  else resolve();
+                }
+              );
+            });
+            progressTransferred++;
+          }
+        } else {
+          // Create new progress record for kept book
+          await new Promise((resolve, reject) => {
+            db.run(
+              'INSERT INTO playback_progress (user_id, audiobook_id, position, completed, updated_at) VALUES (?, ?, ?, ?, ?)',
+              [progress.user_id, keepId, progress.position, progress.completed, progress.updated_at],
+              (err) => {
+                if (err) reject(err);
+                else resolve();
+              }
+            );
+          });
+          progressTransferred++;
+        }
+      }
+    }
+
+    // Delete progress records for deleted books
+    await new Promise((resolve, reject) => {
+      db.run(
+        `DELETE FROM playback_progress WHERE audiobook_id IN (${deleteIds.map(() => '?').join(',')})`,
+        deleteIds,
+        (err) => {
+          if (err) reject(err);
+          else resolve();
+        }
+      );
+    });
+
+    // Delete chapters for deleted books
+    await new Promise((resolve, reject) => {
+      db.run(
+        `DELETE FROM audiobook_chapters WHERE audiobook_id IN (${deleteIds.map(() => '?').join(',')})`,
+        deleteIds,
+        (err) => {
+          if (err) reject(err);
+          else resolve();
+        }
+      );
+    });
+
+    // Delete the duplicate audiobook records
+    await new Promise((resolve, reject) => {
+      db.run(
+        `DELETE FROM audiobooks WHERE id IN (${deleteIds.map(() => '?').join(',')})`,
+        deleteIds,
+        (err) => {
+          if (err) reject(err);
+          else resolve();
+        }
+      );
+    });
+
+    // Optionally delete the actual files
+    let filesDeleted = 0;
+    if (deleteFiles) {
+      for (const deleteBook of deleteBooks) {
+        try {
+          if (deleteBook.file_path && fs.existsSync(deleteBook.file_path)) {
+            // Delete the entire directory if it only contains this audiobook
+            const dir = path.dirname(deleteBook.file_path);
+            const files = fs.readdirSync(dir);
+            const audioFiles = files.filter(f => /\.(m4b|m4a|mp3|flac|ogg)$/i.test(f));
+
+            if (audioFiles.length === 1) {
+              // Safe to delete entire directory
+              fs.rmSync(dir, { recursive: true, force: true });
+              console.log(`Deleted directory: ${dir}`);
+            } else {
+              // Just delete the audio file
+              fs.unlinkSync(deleteBook.file_path);
+              console.log(`Deleted file: ${deleteBook.file_path}`);
+            }
+            filesDeleted++;
+          }
+        } catch (error) {
+          console.error(`Failed to delete file ${deleteBook.file_path}:`, error.message);
+        }
+      }
+    }
+
+    console.log(`✅ Merge complete: ${deleteBooks.length} duplicates removed, ${progressTransferred} progress records transferred`);
+
+    res.json({
+      success: true,
+      kept: keepId,
+      deleted: deleteIds,
+      progressTransferred,
+      filesDeleted,
+    });
+  } catch (error) {
+    console.error('Error merging duplicates:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- Add duplicate detection API that finds duplicates by title+author, ISBN/ASIN, or similar duration/file size
- Add merge functionality that transfers playback progress and optionally deletes files
- Add Duplicates tab in Settings with side-by-side comparison UI

## Test plan
- [x] Navigate to Settings → Duplicates
- [x] Click "Scan for Duplicates"
- [x] Verify duplicate groups are displayed with proper metadata comparison
- [x] Select which book to keep in each group
- [x] Test merge with "Delete files" option unchecked (DB only)
- [ ] Test merge with "Delete files" option checked

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)