### PR TITLE
Add Catch Me Up button to audiobook detail page (#76)

### DIFF
--- a/client/src/pages/AudiobookDetail.css
+++ b/client/src/pages/AudiobookDetail.css
@@ -813,3 +813,259 @@
 .mobile-progress-section {
   display: none;
 }
+
+/* Catch Me Up Section */
+.catch-me-up-section {
+  margin-top: 1.5rem;
+}
+
+.catch-me-up-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1.5rem;
+  background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+  border: none;
+  border-radius: 12px;
+  color: white;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
+}
+
+.catch-me-up-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(99, 102, 241, 0.4);
+}
+
+.catch-me-up-button svg {
+  opacity: 0.9;
+}
+
+/* Recap Loading State */
+.recap-loading {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: rgba(99, 102, 241, 0.1);
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  border-radius: 12px;
+  color: #a5b4fc;
+}
+
+.recap-spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid rgba(165, 180, 252, 0.3);
+  border-top-color: #a5b4fc;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Recap Error State */
+.recap-error {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: 12px;
+  color: #fca5a5;
+}
+
+.recap-error svg {
+  flex-shrink: 0;
+  color: #f87171;
+}
+
+.recap-error span {
+  flex: 1;
+}
+
+.retry-button {
+  padding: 0.5rem 1rem;
+  background: rgba(239, 68, 68, 0.2);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 8px;
+  color: #fca5a5;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.retry-button:hover {
+  background: rgba(239, 68, 68, 0.3);
+}
+
+/* Recap Container */
+.recap-container {
+  background: rgba(31, 41, 55, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  overflow: hidden;
+  transition: all 0.3s;
+}
+
+.recap-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.recap-header:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.recap-header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #e5e7eb;
+  font-weight: 600;
+}
+
+.recap-header-left svg {
+  color: #a5b4fc;
+}
+
+.cached-badge {
+  padding: 0.25rem 0.5rem;
+  background: rgba(99, 102, 241, 0.2);
+  border-radius: 6px;
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: #a5b4fc;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.expand-icon {
+  color: #9ca3af;
+  transition: transform 0.3s;
+}
+
+.expand-icon.expanded {
+  transform: rotate(180deg);
+}
+
+/* Recap Content */
+.recap-content {
+  padding: 0 1.25rem 1.25rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.recap-books-included {
+  padding: 0.75rem 0;
+  font-size: 0.85rem;
+  color: #9ca3af;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  margin-bottom: 1rem;
+}
+
+.recap-books-included span:first-child {
+  color: #6b7280;
+}
+
+.book-tag {
+  color: #a5b4fc;
+}
+
+.recap-text {
+  color: #d1d5db;
+  line-height: 1.7;
+  font-size: 0.95rem;
+}
+
+.recap-text p {
+  margin: 0 0 1rem 0;
+}
+
+.recap-text p:last-child {
+  margin-bottom: 0;
+}
+
+.recap-actions {
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  gap: 0.75rem;
+}
+
+.recap-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: #9ca3af;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.recap-action-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #e5e7eb;
+}
+
+/* Mobile Catch Me Up styles */
+@media (max-width: 768px) {
+  .catch-me-up-section {
+    margin-top: 1rem;
+  }
+
+  .catch-me-up-button {
+    width: 100%;
+    justify-content: center;
+    padding: 1rem;
+  }
+
+  .recap-loading {
+    flex-direction: column;
+    text-align: center;
+    gap: 0.75rem;
+  }
+
+  .recap-error {
+    flex-direction: column;
+    text-align: center;
+    gap: 0.5rem;
+  }
+
+  .recap-error span {
+    text-align: center;
+  }
+
+  .recap-text {
+    font-size: 0.9rem;
+  }
+
+  .recap-books-included {
+    font-size: 0.8rem;
+  }
+
+  .recap-actions {
+    flex-direction: column;
+  }
+
+  .recap-action-btn {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/client/src/pages/AudiobookDetail.jsx
+++ b/client/src/pages/AudiobookDetail.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import axios from 'axios';
 import { getAudiobook, getCoverUrl, getProgress, getDownloadUrl, deleteAudiobook, markFinished, clearProgress, getChapters, getDirectoryFiles, getProfile, toggleFavorite, getRating, setRating } from '../api';
 import EditMetadataModal from '../components/EditMetadataModal';
 import AddToCollectionModal from '../components/AddToCollectionModal';
@@ -21,6 +22,11 @@ export default function AudiobookDetail({ onPlay }) {
   const [isFavorite, setIsFavorite] = useState(false);
   const [showCollectionModal, setShowCollectionModal] = useState(false);
   const [userRating, setUserRating] = useState(null);
+  const [recap, setRecap] = useState(null);
+  const [recapLoading, setRecapLoading] = useState(false);
+  const [recapError, setRecapError] = useState(null);
+  const [recapExpanded, setRecapExpanded] = useState(false);
+  const [aiConfigured, setAiConfigured] = useState(false);
 
   useEffect(() => {
     const checkAdminStatus = async () => {
@@ -36,7 +42,25 @@ export default function AudiobookDetail({ onPlay }) {
 
   useEffect(() => {
     loadAudiobook();
+    checkAiStatus();
+    // Reset recap state when book changes
+    setRecap(null);
+    setRecapExpanded(false);
+    setRecapError(null);
   }, [id]);
+
+  const checkAiStatus = async () => {
+    try {
+      const token = localStorage.getItem('token');
+      const response = await axios.get('/api/settings/ai/status', {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setAiConfigured(response.data.configured);
+    } catch (error) {
+      console.error('Error checking AI status:', error);
+      setAiConfigured(false);
+    }
+  };
 
   const loadAudiobook = async () => {
     try {
@@ -171,6 +195,38 @@ export default function AudiobookDetail({ onPlay }) {
       setUserRating(newRating);
     } catch (error) {
       console.error('Error setting rating:', error);
+    }
+  };
+
+  const loadRecap = async () => {
+    setRecapLoading(true);
+    setRecapError(null);
+
+    try {
+      const token = localStorage.getItem('token');
+      const response = await axios.get(`/api/audiobooks/${id}/recap`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setRecap(response.data);
+      setRecapExpanded(true);
+    } catch (error) {
+      console.error('Error loading recap:', error);
+      setRecapError(error.response?.data?.message || error.response?.data?.error || 'Failed to generate recap');
+    } finally {
+      setRecapLoading(false);
+    }
+  };
+
+  const clearRecapCache = async () => {
+    try {
+      const token = localStorage.getItem('token');
+      await axios.delete(`/api/audiobooks/${id}/recap`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setRecap(null);
+      loadRecap();
+    } catch (error) {
+      console.error('Error clearing recap cache:', error);
     }
   };
 
@@ -341,6 +397,106 @@ export default function AudiobookDetail({ onPlay }) {
                   </div>
                 )}
               </div>
+            </div>
+          )}
+
+          {/* Catch Me Up Section */}
+          {aiConfigured && hasProgress && (
+            <div className="catch-me-up-section">
+              {!recap && !recapLoading && !recapError && (
+                <button className="catch-me-up-button" onClick={loadRecap}>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/>
+                    <polyline points="14 2 14 8 20 8"/>
+                    <line x1="16" y1="13" x2="8" y2="13"/>
+                    <line x1="16" y1="17" x2="8" y2="17"/>
+                    <line x1="10" y1="9" x2="8" y2="9"/>
+                  </svg>
+                  Catch Me Up
+                </button>
+              )}
+
+              {recapLoading && (
+                <div className="recap-loading">
+                  <div className="recap-spinner"></div>
+                  <span>Generating your personalized recap...</span>
+                </div>
+              )}
+
+              {recapError && (
+                <div className="recap-error">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="12" cy="12" r="10"/>
+                    <line x1="12" y1="8" x2="12" y2="12"/>
+                    <line x1="12" y1="16" x2="12.01" y2="16"/>
+                  </svg>
+                  <span>{recapError}</span>
+                  <button className="retry-button" onClick={loadRecap}>Try Again</button>
+                </div>
+              )}
+
+              {recap && (
+                <div className={`recap-container ${recapExpanded ? 'expanded' : ''}`}>
+                  <div className="recap-header" onClick={() => setRecapExpanded(!recapExpanded)}>
+                    <div className="recap-header-left">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/>
+                        <polyline points="14 2 14 8 20 8"/>
+                        <line x1="16" y1="13" x2="8" y2="13"/>
+                        <line x1="16" y1="17" x2="8" y2="17"/>
+                        <line x1="10" y1="9" x2="8" y2="9"/>
+                      </svg>
+                      <span>Book Recap</span>
+                      {recap.cached && (
+                        <span className="cached-badge">Cached</span>
+                      )}
+                    </div>
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="20"
+                      height="20"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className={`expand-icon ${recapExpanded ? 'expanded' : ''}`}
+                    >
+                      <polyline points="6 9 12 15 18 9"/>
+                    </svg>
+                  </div>
+
+                  {recapExpanded && (
+                    <div className="recap-content">
+                      {recap.priorBooks && recap.priorBooks.length > 0 && (
+                        <div className="recap-books-included">
+                          <span>Based on prior books: </span>
+                          {recap.priorBooks.map((book, i) => (
+                            <span key={book.id} className="book-tag">
+                              {book.position ? `#${book.position} ` : ''}{book.title}
+                              {i < recap.priorBooks.length - 1 && ', '}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                      <div className="recap-text">
+                        {recap.recap.split('\n\n').map((paragraph, i) => (
+                          <p key={i}>{paragraph}</p>
+                        ))}
+                      </div>
+                      <div className="recap-actions">
+                        <button className="recap-action-btn" onClick={clearRecapCache}>
+                          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
+                          </svg>
+                          Regenerate
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/server/migrations/013_add_book_recaps.js
+++ b/server/migrations/013_add_book_recaps.js
@@ -1,0 +1,37 @@
+// Migration: Add book_recaps table for caching AI-generated book summaries
+
+module.exports = {
+  up: (db) => {
+    return new Promise((resolve, reject) => {
+      db.run(`
+        CREATE TABLE IF NOT EXISTS book_recaps (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          user_id INTEGER NOT NULL,
+          audiobook_id INTEGER NOT NULL,
+          books_hash TEXT NOT NULL,
+          recap_text TEXT NOT NULL,
+          model_used TEXT,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+          FOREIGN KEY (audiobook_id) REFERENCES audiobooks(id) ON DELETE CASCADE,
+          UNIQUE(user_id, audiobook_id, books_hash)
+        )
+      `, (err) => {
+        if (err) reject(err);
+        else {
+          console.log('Created book_recaps table');
+          resolve();
+        }
+      });
+    });
+  },
+
+  down: (db) => {
+    return new Promise((resolve, reject) => {
+      db.run('DROP TABLE IF EXISTS book_recaps', (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+};

--- a/server/routes/audiobooks.js
+++ b/server/routes/audiobooks.js
@@ -2575,4 +2575,288 @@ router.post('/:id/favorite/toggle', authenticateToken, (req, res) => {
   );
 });
 
+// ============================================
+// Book Recap (Catch Me Up) - AI-powered recap
+// ============================================
+
+// Helper to call OpenAI API
+const callOpenAI = async (prompt, systemPrompt) => {
+  const apiKey = process.env.OPENAI_API_KEY;
+  const model = process.env.OPENAI_MODEL || 'gpt-4o-mini';
+
+  if (!apiKey) {
+    throw new Error('OpenAI API key not configured');
+  }
+
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model: model,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: prompt }
+      ],
+      max_tokens: 4000,
+      temperature: 0.7
+    })
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error?.message || 'OpenAI API request failed');
+  }
+
+  const data = await response.json();
+  return data.choices[0]?.message?.content;
+};
+
+// Helper to call Google Gemini API
+const callGemini = async (prompt, systemPrompt) => {
+  const apiKey = process.env.GEMINI_API_KEY;
+  const model = process.env.GEMINI_MODEL || 'gemini-1.5-flash';
+
+  if (!apiKey) {
+    throw new Error('Gemini API key not configured');
+  }
+
+  const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      contents: [{
+        parts: [{
+          text: `${systemPrompt}\n\n${prompt}`
+        }]
+      }],
+      generationConfig: {
+        maxOutputTokens: 4000,
+        temperature: 0.7
+      }
+    })
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error?.message || 'Gemini API request failed');
+  }
+
+  const data = await response.json();
+  return data.candidates?.[0]?.content?.parts?.[0]?.text;
+};
+
+// Helper to call the configured AI provider
+const callAI = async (prompt, systemPrompt) => {
+  const provider = process.env.AI_PROVIDER || 'openai';
+
+  if (provider === 'gemini') {
+    return callGemini(prompt, systemPrompt);
+  } else {
+    return callOpenAI(prompt, systemPrompt);
+  }
+};
+
+// Get the model used for caching purposes
+const getModelUsed = () => {
+  const provider = process.env.AI_PROVIDER || 'openai';
+  if (provider === 'gemini') {
+    return process.env.GEMINI_MODEL || 'gemini-1.5-flash';
+  }
+  return process.env.OPENAI_MODEL || 'gpt-4o-mini';
+};
+
+// Helper to generate hash for cache key
+const generateRecapHash = (bookId, priorBooks) => {
+  const bookIds = [bookId, ...priorBooks.map(b => b.id)].sort().join(',');
+  return crypto.createHash('md5').update(bookIds).digest('hex');
+};
+
+// Get book recap (catch me up)
+router.get('/:id/recap', authenticateToken, async (req, res) => {
+  const userId = req.user.id;
+  const audiobookId = parseInt(req.params.id);
+  const { getRecapPrompt } = require('./settings');
+
+  try {
+    // Get the audiobook
+    const audiobook = await new Promise((resolve, reject) => {
+      db.get(
+        `SELECT a.*, COALESCE(p.position, 0) as position, COALESCE(p.completed, 0) as completed
+         FROM audiobooks a
+         LEFT JOIN playback_progress p ON a.id = p.audiobook_id AND p.user_id = ?
+         WHERE a.id = ?`,
+        [userId, audiobookId],
+        (err, row) => {
+          if (err) reject(err);
+          else resolve(row);
+        }
+      );
+    });
+
+    if (!audiobook) {
+      return res.status(404).json({ error: 'Audiobook not found' });
+    }
+
+    // Check if user has progress on this book
+    if (audiobook.position === 0 && audiobook.completed !== 1) {
+      return res.status(400).json({
+        error: 'No progress on this book yet',
+        message: 'Start listening to this book to get a recap.'
+      });
+    }
+
+    // Get prior books in series if this is part of a series
+    let priorBooks = [];
+    if (audiobook.series) {
+      priorBooks = await new Promise((resolve, reject) => {
+        db.all(
+          `SELECT a.id, a.title, a.author, a.description, a.series_position,
+                  COALESCE(p.position, 0) as position,
+                  COALESCE(p.completed, 0) as completed
+           FROM audiobooks a
+           LEFT JOIN playback_progress p ON a.id = p.audiobook_id AND p.user_id = ?
+           WHERE a.series = ? AND a.id != ?
+             AND (COALESCE(p.position, 0) > 0 OR COALESCE(p.completed, 0) = 1)
+             AND (a.series_position IS NULL OR a.series_position < ?)
+           ORDER BY a.series_position ASC, a.title ASC`,
+          [userId, audiobook.series, audiobookId, audiobook.series_position || 999],
+          (err, rows) => {
+            if (err) reject(err);
+            else resolve(rows || []);
+          }
+        );
+      });
+    }
+
+    // Generate cache hash
+    const recapHash = generateRecapHash(audiobookId, priorBooks);
+
+    // Check cache first
+    const cached = await new Promise((resolve, reject) => {
+      db.get(
+        `SELECT recap_text, created_at FROM book_recaps
+         WHERE user_id = ? AND audiobook_id = ? AND books_hash = ?`,
+        [userId, audiobookId, recapHash],
+        (err, row) => {
+          if (err) reject(err);
+          else resolve(row);
+        }
+      );
+    });
+
+    if (cached) {
+      return res.json({
+        recap: cached.recap_text,
+        cached: true,
+        cachedAt: cached.created_at,
+        book: { id: audiobook.id, title: audiobook.title },
+        priorBooks: priorBooks.map(b => ({ id: b.id, title: b.title, position: b.series_position }))
+      });
+    }
+
+    // Check if AI is configured
+    const provider = process.env.AI_PROVIDER || 'openai';
+    const hasApiKey = provider === 'gemini'
+      ? !!process.env.GEMINI_API_KEY
+      : !!process.env.OPENAI_API_KEY;
+
+    if (!hasApiKey) {
+      return res.status(400).json({
+        error: 'AI not configured',
+        message: 'Please configure an AI provider in Administration > AI settings.'
+      });
+    }
+
+    // Get the system prompt from settings
+    const systemPrompt = getRecapPrompt();
+
+    // Build prompt
+    let prompt = '';
+
+    if (priorBooks.length > 0) {
+      const priorBooksText = priorBooks.map(b => {
+        const status = b.completed ? 'completed' : 'in progress';
+        return `Book ${b.series_position || '?'}: "${b.title}" (${status})${b.description ? `\nDescription: ${b.description.substring(0, 500)}` : ''}`;
+      }).join('\n\n');
+
+      prompt = `Please provide a detailed recap to help a reader remember what happened before continuing "${audiobook.title}" by ${audiobook.author || 'Unknown Author'}.
+
+This is book ${audiobook.series_position || '?'} in the "${audiobook.series}" series.
+
+PRIOR BOOKS THE READER HAS READ:
+${priorBooksText}
+
+CURRENT BOOK:
+"${audiobook.title}"${audiobook.description ? `\nDescription: ${audiobook.description.substring(0, 500)}` : ''}
+
+Provide a thorough recap of the prior books including major plot points, character developments, and key events. Help the reader remember where the story left off before this book.`;
+    } else {
+      prompt = `Please provide a brief recap/refresher for "${audiobook.title}" by ${audiobook.author || 'Unknown Author'}.
+
+${audiobook.description ? `Description: ${audiobook.description.substring(0, 1000)}` : ''}
+
+The reader has started this book and wants to remember what it's about and any key setup from the beginning. Provide a helpful summary without major spoilers.`;
+    }
+
+    // Call AI provider
+    const recap = await callAI(prompt, systemPrompt);
+
+    // Cache the result
+    await new Promise((resolve, reject) => {
+      db.run(
+        `INSERT OR REPLACE INTO book_recaps (user_id, audiobook_id, books_hash, recap_text, model_used)
+         VALUES (?, ?, ?, ?, ?)`,
+        [userId, audiobookId, recapHash, recap, getModelUsed()],
+        (err) => {
+          if (err) reject(err);
+          else resolve();
+        }
+      );
+    });
+
+    res.json({
+      recap,
+      cached: false,
+      book: { id: audiobook.id, title: audiobook.title },
+      priorBooks: priorBooks.map(b => ({ id: b.id, title: b.title, position: b.series_position }))
+    });
+
+  } catch (error) {
+    console.error('Error generating book recap:', error);
+    res.status(500).json({
+      error: 'Failed to generate recap',
+      message: error.message
+    });
+  }
+});
+
+// Clear cached book recap (force regeneration)
+router.delete('/:id/recap', authenticateToken, async (req, res) => {
+  const userId = req.user.id;
+  const audiobookId = parseInt(req.params.id);
+
+  try {
+    await new Promise((resolve, reject) => {
+      db.run(
+        'DELETE FROM book_recaps WHERE user_id = ? AND audiobook_id = ?',
+        [userId, audiobookId],
+        (err) => {
+          if (err) reject(err);
+          else resolve();
+        }
+      );
+    });
+
+    res.json({ message: 'Recap cache cleared' });
+  } catch (error) {
+    console.error('Error clearing recap cache:', error);
+    res.status(500).json({ error: 'Failed to clear cache' });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- Add AI-powered "Catch Me Up" feature to individual audiobook detail pages
- Create book recap API endpoint (`GET/DELETE /api/audiobooks/:id/recap`)
- Add `book_recaps` database table for caching generated recaps
- For series books, includes recaps of prior books the user has read/listened to
- Reuses same AI provider configuration as series recaps (OpenAI or Gemini)

## Test plan
- [ ] Open an audiobook detail page for a book with progress
- [ ] Verify "Catch Me Up" button appears (requires AI to be configured)
- [ ] Click button and verify recap is generated
- [ ] Verify recap shows "Cached" badge on subsequent views
- [ ] Test "Regenerate" button clears cache and generates new recap
- [ ] For series books, verify prior books are mentioned in recap

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)