### PR TITLE
Match PWA title bar color to navbar

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -13,7 +13,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Sappho" />
-    <meta name="theme-color" content="#3b82f6" />
+    <meta name="theme-color" content="#1a1a1a" />
     <meta name="description" content="Your personal audiobook library" />
 
     <!-- Icons -->

--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -7,7 +7,7 @@
   "scope": "/",
   "display": "standalone",
   "background_color": "#0a0e1a",
-  "theme_color": "#3b82f6",
+  "theme_color": "#1a1a1a",
   "orientation": "portrait-primary",
   "categories": ["entertainment", "music"],
   "prefer_related_applications": false,


### PR DESCRIPTION
## Summary
- Update `theme_color` in manifest.json from #3b82f6 (blue) to #1a1a1a (dark gray)
- Update `theme-color` meta tag in index.html to match

This makes the PWA title bar match the navbar background color for a seamless experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)