### PR TITLE
Add reading list markers to homescreen and fix PWA modal button cutoff

### DIFF
--- a/client/src/components/AddToCollectionModal.css
+++ b/client/src/components/AddToCollectionModal.css
@@ -3,7 +3,7 @@
   border-radius: 16px;
   width: 100%;
   max-width: 400px;
-  max-height: 80vh;
+  max-height: calc(80vh - env(safe-area-inset-bottom, 0px));
   display: flex;
   flex-direction: column;
   border: 1px solid #374151;
@@ -191,7 +191,11 @@
 
 @media (max-width: 768px) {
   .add-to-collection-modal {
-    max-height: 70vh;
+    max-height: calc(70vh - env(safe-area-inset-bottom, 0px));
     margin: 1rem;
+  }
+
+  .modal-footer {
+    padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
   }
 }

--- a/client/src/components/EditMetadataModal.css
+++ b/client/src/components/EditMetadataModal.css
@@ -1,9 +1,10 @@
 .edit-metadata-modal {
   max-width: 600px;
   width: 95%;
-  max-height: 90vh;
+  max-height: calc(90vh - env(safe-area-inset-bottom, 0px));
   overflow-y: auto;
   position: relative;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 /* Saving Overlay - use fixed positioning to cover entire modal regardless of scroll */
@@ -739,6 +740,7 @@
 
   .edit-metadata-modal .modal-actions {
     flex-direction: column;
+    padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
   }
 
   .result-item {

--- a/client/src/components/Navigation.jsx
+++ b/client/src/components/Navigation.jsx
@@ -151,8 +151,8 @@ export default function Navigation({ onLogout, onOpenUpload }) {
           </Link>
           <Link to="/library" className={`nav-link ${location.pathname === '/library' ? 'active' : ''}`} title="Library">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
-              <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
+              <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>
+              <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>
             </svg>
             <span className="nav-link-text">Library</span>
           </Link>
@@ -198,8 +198,8 @@ export default function Navigation({ onLogout, onOpenUpload }) {
           </Link>
           <Link to="/library" className={`nav-link ${location.pathname === '/library' ? 'active' : ''}`} title="Library">
             <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
-              <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
+              <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>
+              <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>
             </svg>
           </Link>
           <button

--- a/client/src/components/UploadModal.css
+++ b/client/src/components/UploadModal.css
@@ -1,6 +1,8 @@
 .upload-modal {
   max-width: 600px;
   width: 90%;
+  max-height: calc(90vh - env(safe-area-inset-bottom, 0px));
+  overflow-y: auto;
 }
 
 .modal-header {
@@ -443,4 +445,11 @@
 
 .file-item.cancelled {
   background: rgba(156, 163, 175, 0.1);
+}
+
+/* PWA safe area support */
+@media (max-width: 768px) {
+  .upload-modal .modal-actions {
+    padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+  }
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -179,6 +179,19 @@ body {
   transform: translateY(-2px);
 }
 
+/* Reading list ribbon marker */
+.favorite-ribbon {
+  position: absolute;
+  top: -3px;
+  right: 8px;
+  width: 18px;
+  height: 28px;
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  z-index: 2;
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 50% 80%, 0 100%);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
 .audio-player {
   position: fixed;
   bottom: 0;

--- a/client/src/pages/AllBooks.css
+++ b/client/src/pages/AllBooks.css
@@ -423,10 +423,74 @@
   .all-books-header {
     padding: 1rem 1rem;
     margin-bottom: 0.5rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
   }
 
   .all-books-count {
     font-size: 1.125rem;
+    order: 1;
+  }
+
+  .back-button {
+    padding: 0.375rem 0.75rem;
+    font-size: 0.875rem;
+    order: 0;
+  }
+
+  .all-books-controls {
+    width: 100%;
+    gap: 0.5rem;
+    order: 2;
+    flex-direction: column;
+  }
+
+  /* Hide labels on mobile for cleaner look */
+  .all-books-filter label,
+  .all-books-sort label {
+    display: none;
+  }
+
+  .all-books-filter {
+    width: 100%;
+  }
+
+  .all-books-sort {
+    width: 100%;
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .filter-select,
+  .sort-select {
+    width: 100%;
+    font-size: 16px; /* Prevent iOS zoom */
+    padding: 0.75rem 2.5rem 0.75rem 0.75rem;
+    border-radius: 8px;
+    background-color: #1f2937;
+    color: #fff;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
+  .sort-order-btn {
+    min-width: 44px;
+    height: 44px;
+    font-size: 1.25rem;
+  }
+
+  /* Row for filter button and selection controls */
+  .filters-toggle-btn {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    font-size: 0.95rem;
+    justify-content: center;
+  }
+
+  .filters-toggle-btn svg {
+    width: 16px;
+    height: 16px;
   }
 
   .audiobook-grid {
@@ -498,58 +562,6 @@
     -webkit-line-clamp: 3;
   }
 
-  .back-button {
-    padding: 0.375rem 0.75rem;
-    font-size: 0.875rem;
-  }
-
-  .all-books-controls {
-    width: 100%;
-    gap: 0.75rem;
-  }
-
-  .all-books-filter {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .all-books-filter label {
-    font-size: 0.875rem;
-  }
-
-  .filter-select {
-    flex: 1;
-    min-width: 0;
-    font-size: 0.875rem;
-    padding: 0.375rem 1.75rem 0.375rem 0.5rem;
-  }
-
-  .all-books-sort {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .all-books-sort label {
-    font-size: 0.875rem;
-  }
-
-  .sort-select {
-    flex: 1;
-    min-width: 0;
-    font-size: 0.875rem;
-    padding: 0.375rem 1.75rem 0.375rem 0.5rem;
-  }
-
-  .filters-toggle-btn {
-    padding: 0.375rem 0.75rem;
-    font-size: 0.875rem;
-  }
-
-  .filters-toggle-btn svg {
-    width: 14px;
-    height: 14px;
-  }
-
   .filters-panel {
     flex-direction: column;
     margin: 0 0.5rem 1rem;
@@ -562,6 +574,8 @@
 
   .filter-group select {
     width: 100%;
+    font-size: 16px; /* Prevent iOS zoom */
+    padding: 0.75rem 2.5rem 0.75rem 0.75rem;
   }
 
   .clear-filters-btn {

--- a/client/src/pages/AllBooks.jsx
+++ b/client/src/pages/AllBooks.jsx
@@ -331,6 +331,9 @@ export default function AllBooks({ onPlay }) {
           <div className="audiobook-cover-placeholder" style={{ display: book.cover_image ? 'none' : 'flex' }}>
             <h3>{book.title}</h3>
           </div>
+          {book.is_favorite && (
+            <div className="favorite-ribbon" title="In Reading List"></div>
+          )}
           {progressPercent > 0 && (
             <div className="progress-bar-overlay">
               <div

--- a/client/src/pages/AuthorDetail.jsx
+++ b/client/src/pages/AuthorDetail.jsx
@@ -181,6 +181,11 @@ export default function AuthorDetail({ onPlay }) {
                     <span>{book.title}</span>
                   </div>
 
+                  {/* Favorite ribbon */}
+                  {book.is_favorite && (
+                    <div className="favorite-ribbon" title="In Reading List"></div>
+                  )}
+
                   {/* Play overlay */}
                   <div className="book-play-overlay">
                     <button

--- a/client/src/pages/CollectionDetail.jsx
+++ b/client/src/pages/CollectionDetail.jsx
@@ -179,6 +179,9 @@ export default function CollectionDetail() {
                   alt={book.title}
                   onError={(e) => e.target.src = '/placeholder-cover.png'}
                 />
+                {book.is_favorite && (
+                  <div className="favorite-ribbon" title="In Reading List"></div>
+                )}
                 {getProgress(book) > 0 && (
                   <div className="progress-bar">
                     <div className="progress-fill" style={{ width: `${getProgress(book)}%` }} />

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -117,6 +117,9 @@ export default function Home({ onPlay }) {
             <h3>{book.title}</h3>
           </div>
         )}
+        {book.is_favorite && (
+          <div className="favorite-ribbon" title="In Reading List"></div>
+        )}
         {book.progress && (book.progress.position > 0 || book.progress.completed === 1) && book.duration && (
           <div className="progress-bar-overlay">
             <div

--- a/client/src/pages/SeriesDetail.jsx
+++ b/client/src/pages/SeriesDetail.jsx
@@ -188,6 +188,9 @@ export default function SeriesDetail({ onPlay }) {
               <h3>{book.title}</h3>
             </div>
           )}
+          {book.is_favorite && (
+            <div className="favorite-ribbon" title="In Reading List"></div>
+          )}
           {book.progress && (book.progress.position > 0 || book.progress.completed === 1) && book.duration && (
             <div className="progress-bar-overlay">
               <div

--- a/server/routes/audiobooks.js
+++ b/server/routes/audiobooks.js
@@ -2268,12 +2268,14 @@ router.get('/meta/recent', authenticateToken, (req, res) => {
   const userId = req.user.id;
 
   db.all(
-    `SELECT a.*, p.position as progress_position, p.completed as progress_completed
+    `SELECT a.*, p.position as progress_position, p.completed as progress_completed,
+            CASE WHEN f.id IS NOT NULL THEN 1 ELSE 0 END as is_favorite
      FROM audiobooks a
      LEFT JOIN playback_progress p ON a.id = p.audiobook_id AND p.user_id = ?
+     LEFT JOIN user_favorites f ON a.id = f.audiobook_id AND f.user_id = ?
      ORDER BY a.created_at DESC
      LIMIT ?`,
-    [userId, limit],
+    [userId, userId, limit],
     (err, audiobooks) => {
       if (err) {
         return res.status(500).json({ error: err.message });
@@ -2282,6 +2284,7 @@ router.get('/meta/recent', authenticateToken, (req, res) => {
       // Transform progress fields into nested object
       const transformedAudiobooks = audiobooks.map(book => ({
         ...book,
+        is_favorite: !!book.is_favorite,
         progress: book.progress_position !== null ? {
           position: book.progress_position,
           completed: book.progress_completed
@@ -2302,13 +2305,15 @@ router.get('/meta/in-progress', authenticateToken, (req, res) => {
   const limit = parseInt(req.query.limit) || 10;
 
   db.all(
-    `SELECT a.*, p.position as progress_position, p.completed as progress_completed, p.updated_at as last_played
+    `SELECT a.*, p.position as progress_position, p.completed as progress_completed, p.updated_at as last_played,
+            CASE WHEN f.id IS NOT NULL THEN 1 ELSE 0 END as is_favorite
      FROM audiobooks a
      INNER JOIN playback_progress p ON a.id = p.audiobook_id
+     LEFT JOIN user_favorites f ON a.id = f.audiobook_id AND f.user_id = ?
      WHERE p.user_id = ? AND p.completed = 0 AND p.position >= 5
      ORDER BY p.updated_at DESC
      LIMIT ?`,
-    [req.user.id, limit],
+    [req.user.id, req.user.id, limit],
     (err, audiobooks) => {
       if (err) {
         return res.status(500).json({ error: err.message });
@@ -2317,6 +2322,7 @@ router.get('/meta/in-progress', authenticateToken, (req, res) => {
       // Transform progress fields into nested object
       const transformedAudiobooks = audiobooks.map(book => ({
         ...book,
+        is_favorite: !!book.is_favorite,
         progress: {
           position: book.progress_position,
           completed: book.progress_completed
@@ -2373,6 +2379,7 @@ router.get('/meta/up-next', authenticateToken, (req, res) => {
        SELECT a.*,
               p.position as progress_position,
               p.completed as progress_completed,
+              CASE WHEN f.id IS NOT NULL THEN 1 ELSE 0 END as is_favorite,
               ROW_NUMBER() OVER (
                 PARTITION BY a.series
                 ORDER BY COALESCE(a.series_index, a.series_position, 0) ASC
@@ -2380,6 +2387,7 @@ router.get('/meta/up-next', authenticateToken, (req, res) => {
        FROM audiobooks a
        INNER JOIN SeriesWithProgress s ON a.series = s.series
        LEFT JOIN playback_progress p ON a.id = p.audiobook_id AND p.user_id = ?
+       LEFT JOIN user_favorites f ON a.id = f.audiobook_id AND f.user_id = ?
        WHERE (a.series_index IS NOT NULL OR a.series_position IS NOT NULL)
        AND (p.position IS NULL OR p.position = 0)
        AND (p.completed IS NULL OR p.completed = 0)
@@ -2388,7 +2396,7 @@ router.get('/meta/up-next', authenticateToken, (req, res) => {
      WHERE row_num = 1
      ORDER BY series ASC
      LIMIT ?`,
-    [req.user.id, req.user.id, limit],
+    [req.user.id, req.user.id, req.user.id, limit],
     (err, audiobooks) => {
       if (err) {
         console.error('Error in up-next query:', err);
@@ -2398,6 +2406,7 @@ router.get('/meta/up-next', authenticateToken, (req, res) => {
       // Transform progress fields into nested object
       const transformedAudiobooks = audiobooks.map(book => ({
         ...book,
+        is_favorite: !!book.is_favorite,
         progress: book.progress_position !== null ? {
           position: book.progress_position,
           completed: book.progress_completed
@@ -2418,13 +2427,15 @@ router.get('/meta/finished', authenticateToken, (req, res) => {
   const limit = parseInt(req.query.limit) || 10;
 
   db.all(
-    `SELECT a.*, p.position as progress_position, p.completed as progress_completed
+    `SELECT a.*, p.position as progress_position, p.completed as progress_completed,
+            CASE WHEN f.id IS NOT NULL THEN 1 ELSE 0 END as is_favorite
      FROM audiobooks a
      INNER JOIN playback_progress p ON a.id = p.audiobook_id
+     LEFT JOIN user_favorites f ON a.id = f.audiobook_id AND f.user_id = ?
      WHERE p.user_id = ? AND p.completed = 1
      ORDER BY RANDOM()
      LIMIT ?`,
-    [req.user.id, limit],
+    [req.user.id, req.user.id, limit],
     (err, audiobooks) => {
       if (err) {
         return res.status(500).json({ error: err.message });
@@ -2433,6 +2444,7 @@ router.get('/meta/finished', authenticateToken, (req, res) => {
       // Transform progress fields into nested object
       const transformedAudiobooks = audiobooks.map(book => ({
         ...book,
+        is_favorite: !!book.is_favorite,
         progress: {
           position: book.progress_position,
           completed: book.progress_completed


### PR DESCRIPTION
## Summary
- Add `is_favorite` to home page API endpoints (recently-added, in-progress, up-next, finished)
- Display star marker on book cards in homescreen for books in reading list
- Add safe-area-inset-bottom support to EditMetadataModal, UploadModal, and AddToCollectionModal
- Fixes bottom buttons being cut off in PWA mode on iOS devices

## Test plan
- [ ] Check homescreen displays star markers on books that are in reading list
- [ ] Test PWA mode - open Edit Metadata modal and verify bottom buttons (Save & Embed, Convert to M4B) are fully visible
- [ ] Test Upload modal bottom buttons in PWA mode
- [ ] Test Add to Collection modal bottom buttons in PWA mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)