### PR TITLE
Add content-based hash for stable audiobook identification

### DIFF
--- a/server/migrations/015_add_content_hash.js
+++ b/server/migrations/015_add_content_hash.js
@@ -1,0 +1,91 @@
+// Migration: Add content_hash for stable audiobook identification
+const crypto = require('crypto');
+
+function generateContentHash(title, author, duration) {
+  const input = `${(title || '').toLowerCase().trim()}|${(author || '').toLowerCase().trim()}|${Math.floor(duration || 0)}`;
+  return crypto.createHash('sha256').update(input).digest('hex').substring(0, 16);
+}
+
+module.exports = {
+  up: (db) => {
+    return new Promise((resolve) => {
+      db.serialize(() => {
+        // Add content_hash column
+        db.run(`
+          ALTER TABLE audiobooks ADD COLUMN content_hash VARCHAR(16)
+        `, (err) => {
+          if (err && !err.message.includes('duplicate column')) {
+            console.error('Error adding content_hash column:', err.message);
+          } else {
+            console.log('Added content_hash column to audiobooks');
+          }
+        });
+
+        // Backfill existing audiobooks with computed hashes
+        db.all('SELECT id, title, author, duration FROM audiobooks WHERE content_hash IS NULL', [], (err, rows) => {
+          if (err) {
+            console.error('Error fetching audiobooks for backfill:', err.message);
+            resolve();
+            return;
+          }
+
+          if (!rows || rows.length === 0) {
+            console.log('No audiobooks to backfill');
+            // Create index after backfill
+            db.run('CREATE UNIQUE INDEX IF NOT EXISTS idx_audiobooks_content_hash ON audiobooks(content_hash)', (indexErr) => {
+              if (indexErr) console.warn('Index creation warning:', indexErr.message);
+              else console.log('Created unique index on content_hash');
+              resolve();
+            });
+            return;
+          }
+
+          console.log(`Backfilling content_hash for ${rows.length} audiobooks...`);
+
+          let completed = 0;
+          const hashCounts = {};
+
+          rows.forEach((row) => {
+            let hash = generateContentHash(row.title, row.author, row.duration);
+
+            // Handle duplicates by appending counter
+            if (hashCounts[hash]) {
+              hashCounts[hash]++;
+              hash = hash.substring(0, 12) + hashCounts[hash].toString().padStart(4, '0');
+              console.warn(`Duplicate hash detected for audiobook ${row.id}, using ${hash}`);
+            } else {
+              hashCounts[hash] = 1;
+            }
+
+            db.run('UPDATE audiobooks SET content_hash = ? WHERE id = ?', [hash, row.id], (updateErr) => {
+              if (updateErr) {
+                console.error(`Error updating audiobook ${row.id}:`, updateErr.message);
+              }
+              completed++;
+
+              if (completed === rows.length) {
+                console.log(`Backfilled ${completed} audiobooks with content_hash`);
+                // Create index after backfill
+                db.run('CREATE UNIQUE INDEX IF NOT EXISTS idx_audiobooks_content_hash ON audiobooks(content_hash)', (indexErr) => {
+                  if (indexErr) console.warn('Index creation warning:', indexErr.message);
+                  else console.log('Created unique index on content_hash');
+                  resolve();
+                });
+              }
+            });
+          });
+        });
+      });
+    });
+  },
+
+  down: (db) => {
+    return new Promise((resolve) => {
+      db.run('DROP INDEX IF EXISTS idx_audiobooks_content_hash', (err) => {
+        if (err) console.warn('Drop index warning:', err.message);
+        // Note: SQLite doesn't support DROP COLUMN easily
+        resolve();
+      });
+    });
+  }
+};

--- a/server/utils/contentHash.js
+++ b/server/utils/contentHash.js
@@ -1,0 +1,59 @@
+const crypto = require('crypto');
+
+/**
+ * Generate a stable content-based hash for an audiobook.
+ * This hash remains consistent across rescans and database rebuilds.
+ *
+ * @param {string} title - Book title
+ * @param {string} author - Book author
+ * @param {number} duration - Duration in seconds
+ * @returns {string} 16-character hex hash
+ */
+function generateContentHash(title, author, duration) {
+  const normalizedTitle = (title || '').toLowerCase().trim();
+  const normalizedAuthor = (author || '').toLowerCase().trim();
+  const normalizedDuration = Math.floor(duration || 0);
+
+  const input = `${normalizedTitle}|${normalizedAuthor}|${normalizedDuration}`;
+  return crypto.createHash('sha256').update(input).digest('hex').substring(0, 16);
+}
+
+/**
+ * Generate a fallback hash based on file path when metadata is insufficient.
+ *
+ * @param {string} filePath - Path to the audio file
+ * @returns {string} 16-character hex hash
+ */
+function generateFilePathHash(filePath) {
+  const normalizedPath = (filePath || '').toLowerCase().trim();
+  return crypto.createHash('sha256').update(normalizedPath).digest('hex').substring(0, 16);
+}
+
+/**
+ * Generate the best available content hash for an audiobook.
+ * Uses metadata if available, falls back to file path hash.
+ *
+ * @param {Object} metadata - Audiobook metadata
+ * @param {string} metadata.title - Book title
+ * @param {string} metadata.author - Book author
+ * @param {number} metadata.duration - Duration in seconds
+ * @param {string} filePath - Path to the audio file
+ * @returns {string} 16-character hex hash
+ */
+function generateBestHash(metadata, filePath) {
+  const { title, author, duration } = metadata || {};
+
+  // If we have sufficient metadata, use content hash
+  if (title && (author || duration)) {
+    return generateContentHash(title, author, duration);
+  }
+
+  // Fall back to file path hash
+  return generateFilePathHash(filePath);
+}
+
+module.exports = {
+  generateContentHash,
+  generateFilePathHash,
+  generateBestHash
+};


### PR DESCRIPTION
## Summary
- Adds `content_hash` column to audiobooks table for stable identification
- Hash is SHA256(title|author|duration) truncated to 16 hex chars
- Falls back to file path hash when metadata is insufficient
- Backfills existing audiobooks during migration

## Changes
- Migration 015: Add `content_hash` column with backfill and unique index
- New utility: `server/utils/contentHash.js` with hash generation functions
- Updated `libraryScanner.js`: Generate hash on import, check for duplicates by hash
- Updated `fileProcessor.js`: Include content_hash in database saves
- Updated `upload.js`: Generate content_hash for multi-file uploads

## Why
This ensures audiobooks maintain consistent identifiers across rescans and database rebuilds, which is critical for external integrations like OpsDec that reference books by ID.

Fixes #91

## Test plan
- [ ] Verify migration runs and backfills existing books with content_hash
- [ ] Import a new audiobook and verify content_hash is generated
- [ ] Force rescan and verify same audiobook gets same content_hash
- [ ] Test multi-file upload generates correct content_hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)