### PR TITLE
Relax password minimum length from 12 to 6 characters

### DIFF
--- a/.github/scripts/owasp-api2-scanner.js
+++ b/.github/scripts/owasp-api2-scanner.js
@@ -327,7 +327,7 @@ function checkPasswordPolicy() {
       'server/routes/auth.js',
       1,
       'Registration endpoint has no password complexity requirements.',
-      'Enforce minimum 12 characters with complexity requirements.'
+      'Enforce minimum 6 characters with complexity requirements.'
     );
   }
 
@@ -341,7 +341,7 @@ function checkPasswordPolicy() {
       'server/routes/profile.js',
       line,
       'Password change only requires 6 character minimum, which is too weak.',
-      'Increase minimum to 12 characters and add complexity requirements.'
+      'Increase minimum to 6 characters and add complexity requirements.'
     );
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ docker-compose down
      - **Session tokens** - Short-lived, returned on login for browser/app use
      - **API keys** - Long-lived, managed via `/api/api-keys` for external integrations
    - Default admin created on first startup with password "admin" (forced password change on first login)
-   - Password requirements: 12+ characters, uppercase, lowercase, number, special character
+   - Password requirements: 6+ characters, uppercase, lowercase, number, special character
 
 5. **Session Management** (`services/sessionManager.js`):
    - In-memory tracking of active playback sessions (not persisted to DB)

--- a/client/src/components/ForcePasswordChange.jsx
+++ b/client/src/components/ForcePasswordChange.jsx
@@ -20,8 +20,8 @@ export default function ForcePasswordChange({ onPasswordChanged, onLogout }) {
       return;
     }
 
-    if (passwordData.newPassword.length < 12) {
-      setError('Password must be at least 12 characters long');
+    if (passwordData.newPassword.length < 6) {
+      setError('Password must be at least 6 characters long');
       return;
     }
 
@@ -107,7 +107,7 @@ export default function ForcePasswordChange({ onPasswordChanged, onLogout }) {
               required
             />
             <p className="help-text">
-              Must be at least 12 characters with uppercase, lowercase, number, and special character.
+              Must be at least 6 characters with uppercase, lowercase, number, and special character.
             </p>
           </div>
 

--- a/server/auth.js
+++ b/server/auth.js
@@ -248,8 +248,8 @@ function requireAdmin(req, res, next) {
 // SECURITY: Password complexity validation
 function validatePassword(password) {
   const errors = [];
-  if (password.length < 12) {
-    errors.push('Password must be at least 12 characters long');
+  if (password.length < 6) {
+    errors.push('Password must be at least 6 characters long');
   }
   if (!/[A-Z]/.test(password)) {
     errors.push('Password must contain at least one uppercase letter');

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -5,9 +5,9 @@
 const { validatePassword } = require('../../server/auth');
 
 describe('validatePassword', () => {
-  test('rejects passwords shorter than 12 characters', () => {
-    const errors = validatePassword('Short1!abc');
-    expect(errors).toContain('Password must be at least 12 characters long');
+  test('rejects passwords shorter than 6 characters', () => {
+    const errors = validatePassword('Ab1!');
+    expect(errors).toContain('Password must be at least 6 characters long');
   });
 
   test('rejects passwords without uppercase letters', () => {


### PR DESCRIPTION
## Summary
- Reduces minimum password length from 12 to 6 characters
- Keeps complexity requirements (uppercase, lowercase, number, special character)

## Changes
- `server/auth.js`: Update `validatePassword()` to require 6 chars
- `client/src/components/ForcePasswordChange.jsx`: Update validation and help text
- `tests/unit/auth.test.js`: Update test case for new minimum
- `.github/scripts/owasp-api2-scanner.js`: Update recommendations
- `CLAUDE.md`: Update documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)