### PR TITLE
Fix batch add-to-collection using wrong table name

### DIFF
--- a/server/routes/audiobooks.js
+++ b/server/routes/audiobooks.js
@@ -3046,10 +3046,10 @@ router.post('/batch/add-to-collection', authenticateToken, async (req, res) => {
   }
 
   try {
-    // Verify collection belongs to user
+    // Verify collection belongs to user OR is public
     const collection = await new Promise((resolve, reject) => {
       db.get(
-        'SELECT id FROM collections WHERE id = ? AND user_id = ?',
+        'SELECT id FROM user_collections WHERE id = ? AND (user_id = ? OR is_public = 1)',
         [collection_id, userId],
         (err, row) => {
           if (err) reject(err);


### PR DESCRIPTION
## Summary
- Fix batch add-to-collection endpoint that was querying the wrong table (`collections` instead of `user_collections`)
- Also added support for public collections to match the single add endpoint behavior

The batch endpoint in `audiobooks.js` was using `SELECT id FROM collections` but the correct table is `user_collections`.

## Test plan
- [ ] Test batch add to collection from Android app's All Books screen
- [ ] Verify books are correctly added to collections

🤖 Generated with [Claude Code](https://claude.com/claude-code)