### PR TITLE
Fix sort settings to be independent per screen

### DIFF
--- a/client/src/pages/AllBooks.jsx
+++ b/client/src/pages/AllBooks.jsx
@@ -32,20 +32,32 @@ function normalizeGenreString(genreStr, genreMappings) {
   return Array.from(normalized);
 }
 
+// Get storage key prefix based on current URL to keep settings independent per screen
+function getStoragePrefix() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('favorites') === 'true') return 'readingList_';
+  if (params.get('genre')) return `genre_${params.get('genre')}_`;
+  return 'allBooks_';
+}
+
 export default function AllBooks({ onPlay }) {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const genreFilter = searchParams.get('genre');
   const favoritesOnly = searchParams.get('favorites') === 'true';
+
+  // Compute storage prefix for this view (changes when URL params change)
+  const storagePrefix = favoritesOnly ? 'readingList_' : (genreFilter ? `genre_${genreFilter}_` : 'allBooks_');
+
   const [audiobooks, setAudiobooks] = useState([]);
   const [genreMappings, setGenreMappings] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [sortBy, setSortBy] = useState(() => localStorage.getItem('sortBy') || 'title');
-  const [sortOrder, setSortOrder] = useState(() => localStorage.getItem('sortOrder') || 'asc');
-  const [progressFilter, setProgressFilter] = useState(() => localStorage.getItem('progressFilter') || 'all');
-  const [durationFilter, setDurationFilter] = useState(() => localStorage.getItem('durationFilter') || 'all');
-  const [dateAddedFilter, setDateAddedFilter] = useState(() => localStorage.getItem('dateAddedFilter') || 'all');
-  const [narratorFilter, setNarratorFilter] = useState(() => localStorage.getItem('narratorFilter') || 'all');
+  const [sortBy, setSortBy] = useState(() => localStorage.getItem(getStoragePrefix() + 'sortBy') || 'title');
+  const [sortOrder, setSortOrder] = useState(() => localStorage.getItem(getStoragePrefix() + 'sortOrder') || 'asc');
+  const [progressFilter, setProgressFilter] = useState(() => localStorage.getItem(getStoragePrefix() + 'progressFilter') || 'all');
+  const [durationFilter, setDurationFilter] = useState(() => localStorage.getItem(getStoragePrefix() + 'durationFilter') || 'all');
+  const [dateAddedFilter, setDateAddedFilter] = useState(() => localStorage.getItem(getStoragePrefix() + 'dateAddedFilter') || 'all');
+  const [narratorFilter, setNarratorFilter] = useState(() => localStorage.getItem(getStoragePrefix() + 'narratorFilter') || 'all');
   const [showFilters, setShowFilters] = useState(false);
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState(new Set());
@@ -55,30 +67,40 @@ export default function AllBooks({ onPlay }) {
   const longPressTimer = useRef(null);
   const longPressTriggered = useRef(false);
 
-  // Save preferences to localStorage
+  // Save preferences to localStorage (using per-screen prefix)
   useEffect(() => {
-    localStorage.setItem('sortBy', sortBy);
-  }, [sortBy]);
+    localStorage.setItem(storagePrefix + 'sortBy', sortBy);
+  }, [sortBy, storagePrefix]);
 
   useEffect(() => {
-    localStorage.setItem('sortOrder', sortOrder);
-  }, [sortOrder]);
+    localStorage.setItem(storagePrefix + 'sortOrder', sortOrder);
+  }, [sortOrder, storagePrefix]);
 
   useEffect(() => {
-    localStorage.setItem('progressFilter', progressFilter);
-  }, [progressFilter]);
+    localStorage.setItem(storagePrefix + 'progressFilter', progressFilter);
+  }, [progressFilter, storagePrefix]);
 
   useEffect(() => {
-    localStorage.setItem('durationFilter', durationFilter);
-  }, [durationFilter]);
+    localStorage.setItem(storagePrefix + 'durationFilter', durationFilter);
+  }, [durationFilter, storagePrefix]);
 
   useEffect(() => {
-    localStorage.setItem('dateAddedFilter', dateAddedFilter);
-  }, [dateAddedFilter]);
+    localStorage.setItem(storagePrefix + 'dateAddedFilter', dateAddedFilter);
+  }, [dateAddedFilter, storagePrefix]);
 
   useEffect(() => {
-    localStorage.setItem('narratorFilter', narratorFilter);
-  }, [narratorFilter]);
+    localStorage.setItem(storagePrefix + 'narratorFilter', narratorFilter);
+  }, [narratorFilter, storagePrefix]);
+
+  // Reset filter/sort state when switching between views (All Books vs Reading List vs Genre)
+  useEffect(() => {
+    setSortBy(localStorage.getItem(storagePrefix + 'sortBy') || 'title');
+    setSortOrder(localStorage.getItem(storagePrefix + 'sortOrder') || 'asc');
+    setProgressFilter(localStorage.getItem(storagePrefix + 'progressFilter') || 'all');
+    setDurationFilter(localStorage.getItem(storagePrefix + 'durationFilter') || 'all');
+    setDateAddedFilter(localStorage.getItem(storagePrefix + 'dateAddedFilter') || 'all');
+    setNarratorFilter(localStorage.getItem(storagePrefix + 'narratorFilter') || 'all');
+  }, [storagePrefix]);
 
   useEffect(() => {
     loadData();


### PR DESCRIPTION
## Summary

Fixes #88 - Sort settings now work independently on each screen.

Previously, changing the sort on All Books would also affect Reading List (and vice versa) because they shared the same localStorage keys.

## Changes

- Add storage key prefix based on view type:
  - `allBooks_` for All Books view
  - `readingList_` for Reading List (favorites) view
  - `genre_{name}_` for genre-filtered views
- Each view now maintains its own independent settings for:
  - Sort field (title, author, series, etc.)
  - Sort order (asc/desc)
  - Progress filter
  - Duration filter
  - Date added filter
  - Narrator filter
- Settings persist to localStorage independently per screen
- When navigating between views, settings are restored from the appropriate storage keys

## Test plan

- [ ] Go to All Books, set sort to "Author"
- [ ] Go to Reading List, verify sort is "Title" (default)
- [ ] Set Reading List sort to "Series"
- [ ] Go back to All Books, verify sort is still "Author"
- [ ] Refresh the page, verify both screens retain their settings
- [ ] Test with genre-filtered view (e.g., /all-books?genre=Fiction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)