### PR TITLE
Add sort by rating and series average rating (#96, #95)

### DIFF
--- a/client/src/pages/AllBooks.jsx
+++ b/client/src/pages/AllBooks.jsx
@@ -298,6 +298,15 @@ export default function AllBooks({ onPlay }) {
         const bPlayed = b.progress?.updated_at ? new Date(b.progress.updated_at) : new Date(0);
         result = bPlayed - aPlayed;
         break;
+      case 'rating':
+        // Sort by user rating first, then average rating, unrated at end
+        const aRating = a.user_rating || a.average_rating || 0;
+        const bRating = b.user_rating || b.average_rating || 0;
+        // Put unrated books at the end
+        if (aRating === 0 && bRating !== 0) return 1;
+        if (bRating === 0 && aRating !== 0) return -1;
+        result = bRating - aRating; // Higher ratings first by default
+        break;
       default:
         result = 0;
     }
@@ -522,6 +531,7 @@ export default function AllBooks({ onPlay }) {
                   <option value="recently-played">Recently Listened</option>
                   <option value="duration">Duration</option>
                   <option value="progress">Progress</option>
+                  <option value="rating">Rating</option>
                 </select>
               </div>
             </div>

--- a/client/src/pages/SeriesList.css
+++ b/client/src/pages/SeriesList.css
@@ -236,6 +236,19 @@
   flex-wrap: wrap;
 }
 
+.series-rating {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: #fbbf24;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.series-rating svg {
+  flex-shrink: 0;
+}
+
 .completion-badge {
   display: inline-flex;
   align-items: center;

--- a/client/src/pages/SeriesList.jsx
+++ b/client/src/pages/SeriesList.jsx
@@ -84,6 +84,14 @@ export default function SeriesList() {
               <div className="series-card-content">
                 <h3 className="series-title">{series.series}</h3>
                 <div className="series-stats">
+                  {series.average_rating && (
+                    <span className="series-rating">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="#fbbf24" stroke="#fbbf24" strokeWidth="1.5">
+                        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+                      </svg>
+                      {series.average_rating}
+                    </span>
+                  )}
                   {series.completed_count > 0 && (
                     <span className="completion-badge">
                       {series.completed_count}/{series.book_count} read


### PR DESCRIPTION
## Summary
- Add `user_rating` and `average_rating` fields to audiobooks list API for sorting
- Add "Rating" sort option to All Books dropdown (sorts by user rating first, then average rating; unrated books go to end)
- Add `average_rating` to series meta API (aggregated from all books in series)
- Display average rating with star icon on Series List page

## Changes
- **server/routes/audiobooks.js**: Added LEFT JOIN to user_ratings, subquery for average rating in both audiobooks and series endpoints
- **client/src/pages/AllBooks.jsx**: Added rating sort case and dropdown option
- **client/src/pages/SeriesList.jsx**: Added rating display to series cards
- **client/src/pages/SeriesList.css**: Added styling for rating display

## Test plan
- [ ] Go to All Books, select "Rating" sort option - verify books with ratings appear first, sorted by rating (high to low)
- [ ] Rate a few books and verify user rating takes precedence over average
- [ ] Go to Series page and verify series with rated books show average rating with star icon

Closes #96, Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)