### PR TITLE
Fix cover art embedding and file reorganization issues

### DIFF
--- a/server/routes/audiobooks.js
+++ b/server/routes/audiobooks.js
@@ -1232,7 +1232,7 @@ router.put('/:id', authenticateToken, async (req, res) => {
           if (newCoverPath !== currentBook.cover_path) {
             try {
               fs.renameSync(currentBook.cover_path, newCoverPath);
-            } catch (renameErr) {
+            } catch (_renameErr) {
               fs.copyFileSync(currentBook.cover_path, newCoverPath);
               if (fs.existsSync(newCoverPath)) {
                 fs.unlinkSync(currentBook.cover_path);


### PR DESCRIPTION
## Summary
- Add User-Agent headers to cover download requests to fix Amazon CDN rejections
- Improve file reorganization to use atomic rename with copy+delete fallback
- Add cover art embedding support for MP3 files in ffmpeg path

Fixes #79

## Changes

### 1. Cover Download Headers
The `downloadCover()` function now sends proper HTTP headers:
- `User-Agent`: Required by Amazon CDN (was returning 403 without it)
- `Accept` and `Accept-Language`: Standard headers for compatibility

### 2. File Reorganization Improvements
When author/title changes trigger file reorganization:
- Try atomic `renameSync` first (fast, no duplicates possible)
- Fall back to copy+delete if rename fails (cross-filesystem moves)
- Verify file size matches before deleting original
- Prevents duplicate files from being created

### 3. MP3 Cover Art Embedding
Added cover art embedding to the ffmpeg path:
- Previously only M4B/M4A files got cover art (via tone)
- Now MP3 files also get embedded cover art
- Uses proper ID3v2 version 3 tags

## Test plan
- [ ] Test metadata lookup and apply with cover art on M4B file
- [ ] Test metadata lookup and apply with cover art on MP3 file
- [ ] Test updating author/title to verify no duplicate files created
- [ ] Verify cover images display correctly after embedding

🤖 Generated with [Claude Code](https://claude.com/claude-code)