### PR TITLE
Fix orphan directory detection

### DIFF
--- a/client/src/components/settings/OrphanDirectoriesSettings.jsx
+++ b/client/src/components/settings/OrphanDirectoriesSettings.jsx
@@ -156,9 +156,18 @@ export default function OrphanDirectoriesSettings() {
                             style={{ width: '1.25rem', height: '1.25rem' }}
                           />
                           <span className="group-title">{formatPath(dir.path)}</span>
+                          {dir.orphanType === 'metadata_only' && (
+                            <span className="badge badge-cover" style={{ marginLeft: '0.5rem' }}>Metadata Only</span>
+                          )}
+                          {dir.orphanType === 'mixed' && (
+                            <span className="badge badge-progress" style={{ marginLeft: '0.5rem' }}>Mixed</span>
+                          )}
                         </div>
                         <div style={{ display: 'flex', gap: '0.75rem', marginTop: '0.5rem', marginLeft: '2rem' }}>
-                          <span className="match-reason">{dir.fileCount} audio file{dir.fileCount === 1 ? '' : 's'}</span>
+                          <span className="match-reason">{dir.fileCount} file{dir.fileCount === 1 ? '' : 's'}</span>
+                          {dir.audioFileCount > 0 && (
+                            <span className="match-reason">{dir.untrackedAudioCount} untracked audio</span>
+                          )}
                           <span className="match-reason">{formatSize(dir.totalSize)}</span>
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- Normalize file paths to fix false positives from path format differences
- Only check available books (exclude soft-deleted ones) to avoid false positives
- Detect directories with only metadata files (no audio files)
- Add `orphanType` field: `metadata_only`, `untracked_audio`, or `mixed`
- Update UI to show orphan type badges

## Test plan
- [ ] Scan for orphans and verify no false positives (tracked books showing as orphan)
- [ ] Verify directories with only .nfo files are detected
- [ ] Verify "Metadata Only" badge shows for directories without audio files

🤖 Generated with [Claude Code](https://claude.com/claude-code)