### PR TITLE
Detect empty directories as orphans

### DIFF
--- a/client/src/components/settings/OrphanDirectoriesSettings.jsx
+++ b/client/src/components/settings/OrphanDirectoriesSettings.jsx
@@ -156,6 +156,9 @@ export default function OrphanDirectoriesSettings() {
                             style={{ width: '1.25rem', height: '1.25rem' }}
                           />
                           <span className="group-title">{formatPath(dir.path)}</span>
+                          {dir.orphanType === 'empty' && (
+                            <span className="badge" style={{ marginLeft: '0.5rem', background: 'rgba(107, 114, 128, 0.2)', color: '#9ca3af' }}>Empty</span>
+                          )}
                           {dir.orphanType === 'metadata_only' && (
                             <span className="badge badge-cover" style={{ marginLeft: '0.5rem' }}>Metadata Only</span>
                           )}


### PR DESCRIPTION
## Summary
- Detect completely empty directories (no files, no subdirectories)
- Add 'empty' orphan type with gray badge in UI
- Empty dirs now shown alongside metadata-only and untracked audio dirs

## Test plan
- [ ] Scan for orphans - empty directories should now appear
- [ ] Verify "Empty" badge shows for directories with no contents
- [ ] Delete empty directories and verify cleanup works

🤖 Generated with [Claude Code](https://claude.com/claude-code)