### PR TITLE
Add Reorganize Library button to Settings UI

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -301,6 +301,13 @@ export const getOrphanDirectories = () =>
 export const deleteOrphanDirectories = (paths) =>
   api.delete('/maintenance/orphan-directories', { data: { paths } });
 
+// Library Organization
+export const getOrganizationPreview = () =>
+  api.get('/maintenance/organize/preview');
+
+export const organizeLibrary = () =>
+  api.post('/maintenance/organize');
+
 // Collections
 export const getCollections = () =>
   api.get('/collections');


### PR DESCRIPTION
## Summary
- Add API functions for organization preview and organize library
- Add "Reorganize Library" button in Administration > Library Management section
- Shows count of books that need moving before confirming
- Moves audiobooks to match Author/Series/Book folder structure

## Test plan
- [ ] Go to Administration > Library tab
- [ ] Click "Reorganize Library" button
- [ ] Verify preview shows count of books needing reorganization
- [ ] Confirm and verify books are moved to correct folders

🤖 Generated with [Claude Code](https://claude.com/claude-code)