### PR TITLE
Fix reorganize preview response field name

### DIFF
--- a/client/src/components/settings/LibrarySettings.jsx
+++ b/client/src/components/settings/LibrarySettings.jsx
@@ -139,7 +139,7 @@ export default function LibrarySettings() {
     try {
       // First get preview
       const preview = await getOrganizationPreview();
-      const needsMove = preview.data.needsMove || [];
+      const needsMove = preview.data.books || [];
 
       if (needsMove.length === 0) {
         alert('All audiobooks are already in their correct locations. Nothing to reorganize.');


### PR DESCRIPTION
## Summary
Bug fix: The organization preview API returns `books` but the UI was looking for `needsMove`, causing it to always show 0 books needing reorganization.

## Test plan
- [ ] Click "Reorganize Library" 
- [ ] Should now show correct count of books needing reorganization

🤖 Generated with [Claude Code](https://claude.com/claude-code)