### PR TITLE
Add detailed preview modal for library reorganization

### DIFF
--- a/client/src/components/settings/LibrarySettings.css
+++ b/client/src/components/settings/LibrarySettings.css
@@ -338,3 +338,181 @@
     margin-top: 0.5rem;
   }
 }
+
+/* Reorganization Preview Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.modal-content {
+  background: #1f2937;
+  border: 1px solid #374151;
+  border-radius: 12px;
+  max-width: 700px;
+  width: 100%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid #374151;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #f3f4f6;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  color: #9ca3af;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+}
+
+.modal-close:hover {
+  color: #f3f4f6;
+}
+
+.modal-body {
+  padding: 1.5rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.preview-summary {
+  color: #d1d5db;
+  margin: 0 0 1.25rem 0;
+  font-size: 0.9375rem;
+}
+
+.preview-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.preview-item {
+  background: #111827;
+  border: 1px solid #374151;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.preview-book-title {
+  font-weight: 600;
+  color: #f3f4f6;
+  font-size: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.preview-book-author {
+  color: #9ca3af;
+  font-size: 0.875rem;
+  margin-bottom: 0.75rem;
+}
+
+.preview-paths {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.preview-path {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.preview-path .path-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.preview-path.from .path-label {
+  color: #f87171;
+}
+
+.preview-path.to .path-label {
+  color: #4ade80;
+}
+
+.preview-path code {
+  background: #0d1117;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  color: #d1d5db;
+  font-family: 'Courier New', monospace;
+  word-break: break-all;
+  line-height: 1.4;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid #374151;
+}
+
+@media (max-width: 768px) {
+  .modal-content {
+    max-height: 90vh;
+  }
+
+  .modal-header {
+    padding: 1rem;
+  }
+
+  .modal-header h3 {
+    font-size: 1.125rem;
+  }
+
+  .modal-body {
+    padding: 1rem;
+  }
+
+  .preview-item {
+    padding: 0.875rem;
+  }
+
+  .preview-book-title {
+    font-size: 0.9375rem;
+  }
+
+  .preview-path code {
+    font-size: 0.6875rem;
+    padding: 0.375rem 0.5rem;
+  }
+
+  .modal-footer {
+    padding: 0.875rem 1rem;
+    flex-direction: column-reverse;
+  }
+
+  .modal-footer .btn {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a preview modal when clicking "Reorganize Library" that shows exactly which books will be moved
- Each book displays its title, author, current path (red), and target path (green)
- Users can review all changes before confirming the reorganization
- Modal is scrollable for large lists and responsive on mobile

## Test plan
- [ ] Click "Reorganize Library" button
- [ ] Verify preview modal appears with list of books to be moved
- [ ] Check that paths are displayed correctly with From/To labels
- [ ] Verify Cancel button closes modal without making changes
- [ ] Verify Confirm button proceeds with reorganization

🤖 Generated with [Claude Code](https://claude.com/claude-code)