### PR TITLE
Fix reorganization stats showing undefined

### DIFF
--- a/client/src/components/settings/LibrarySettings.jsx
+++ b/client/src/components/settings/LibrarySettings.jsx
@@ -163,7 +163,7 @@ export default function LibrarySettings() {
     setShowPreview(false);
     try {
       const result = await apiOrganizeLibrary();
-      const stats = result.data;
+      const stats = result.data.stats;
       alert(`Reorganization complete!\nMoved: ${stats.moved}\nSkipped: ${stats.skipped}\nErrors: ${stats.errors}`);
 
       if (stats.moved > 0) {


### PR DESCRIPTION
## Summary
Fixed the reorganization completion message showing `undefined` for moved/skipped/errors counts.

The API returns `{ success, message, stats: { moved, skipped, errors } }` but the frontend was reading `result.data` directly instead of `result.data.stats`.

## Test plan
- [ ] Run reorganization and verify stats show correct numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)