### PR TITLE
Auto-queue next book in series when finishing a book

### DIFF
--- a/server/migrations/017_add_queued_at.js
+++ b/server/migrations/017_add_queued_at.js
@@ -1,0 +1,38 @@
+/**
+ * Migration: Add queued_at column to playback_progress table
+ *
+ * Adds:
+ * - queued_at: Timestamp when a book was queued as "up next" (e.g., after finishing previous book in series)
+ *
+ * This allows distinguishing between books that were accidentally opened (position=0)
+ * and books that were intentionally queued as the next in a series.
+ */
+
+function up(db) {
+  db.run(`
+    ALTER TABLE playback_progress ADD COLUMN queued_at DATETIME
+  `, (err) => {
+    if (err && !err.message.includes('duplicate column')) {
+      console.error('Error adding queued_at column:', err.message);
+    } else if (!err) {
+      console.log('Added queued_at column to playback_progress table');
+    }
+  });
+
+  // Create index for faster filtering of queued books
+  db.run(`
+    CREATE INDEX IF NOT EXISTS idx_playback_progress_queued_at ON playback_progress(queued_at)
+  `, (err) => {
+    if (err) {
+      console.error('Error creating queued_at index:', err.message);
+    } else {
+      console.log('Created index on queued_at column');
+    }
+  });
+}
+
+function down(_db) {
+  console.log('Rollback not supported for this migration');
+}
+
+module.exports = { up, down };


### PR DESCRIPTION
## Summary
- When a user finishes a book that's part of a series, the next unfinished book is automatically queued
- Queued books appear at the top of "Continue Listening"
- New `is_queued` flag in the API response indicates queued books

## Changes
- New migration `017_add_queued_at.js` - adds `queued_at` column to `playback_progress`
- New `queueNextInSeries()` function finds next book by series_position
- Updated in-progress endpoint to include queued books (ordered first)
- `queued_at` is cleared when user starts playing the book

## Test plan
- [ ] Finish a book that's part of a series with multiple books
- [ ] Verify the next book in the series appears at top of Continue Listening
- [ ] Start playing the queued book and verify it behaves normally
- [ ] Finish a standalone book (no series) and verify nothing is queued

🤖 Generated with [Claude Code](https://claude.com/claude-code)