### PR TITLE
Include cover art in WebSocket session broadcasts (#128)

### DIFF
--- a/server/services/websocketManager.js
+++ b/server/services/websocketManager.js
@@ -122,6 +122,7 @@ class WebSocketManager {
           title: session.title,
           author: session.author,
           series: session.series,
+          cover: session.cover,
         },
         playback: {
           state: session.state,


### PR DESCRIPTION
## Summary
- Add `cover` field to WebSocket session broadcasts
- OpsDec can now receive cover art path in real-time session updates
- Fixes #128

## Changes
`server/services/websocketManager.js`:
- Added `cover: session.cover` to the audiobook object in `broadcastSessionUpdate()`

## Test plan
- [ ] Start playback on an audiobook with cover art
- [ ] Verify OpsDec receives cover path in WebSocket `session.update` events
- [ ] OpsDec can construct cover URL: `/api/audiobooks/:id/cover?token=<key>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)