### PR TITLE
Redesign collection tiles and clean up navigation

### DIFF
--- a/client/src/components/Navigation.jsx
+++ b/client/src/components/Navigation.jsx
@@ -296,36 +296,14 @@ export default function Navigation({ onLogout }) {
                     </svg>
                     Profile
                   </button>
-                  <button onClick={() => { navigate('/library?tab=reading-list'); setShowUserMenu(false); }}>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path>
-                      <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path>
-                    </svg>
-                    Reading List
-                  </button>
-                  <button onClick={() => { navigate('/library?tab=collections'); setShowUserMenu(false); }}>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
-                    </svg>
-                    Collections
-                  </button>
                   {user?.is_admin && (
-                    <>
-                      <button onClick={() => { navigate('/settings'); setShowUserMenu(false); }}>
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                          <circle cx="12" cy="12" r="3"></circle>
-                          <path d="M12 1v6m0 6v6"/>
-                        </svg>
-                        Admin
-                      </button>
-                      <button onClick={() => { navigate('/library?tab=upload'); setShowUserMenu(false); }}>
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                          <line x1="12" y1="5" x2="12" y2="19"></line>
-                          <line x1="5" y1="12" x2="19" y2="12"></line>
-                        </svg>
-                        Upload
-                      </button>
-                    </>
+                    <button onClick={() => { navigate('/settings'); setShowUserMenu(false); }}>
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <circle cx="12" cy="12" r="3"></circle>
+                        <path d="M12 1v6m0 6v6"/>
+                      </svg>
+                      Admin
+                    </button>
                   )}
                   <button onClick={() => { onLogout(); setShowUserMenu(false); }}>
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -388,39 +366,14 @@ export default function Navigation({ onLogout }) {
               <span>Profile</span>
             </button>
 
-            <button onClick={() => { navigate('/library?tab=reading-list'); setShowMobileMenu(false); }}>
-              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path>
-                <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path>
-              </svg>
-              <span>Reading List</span>
-            </button>
-
-            <button onClick={() => { navigate('/library?tab=collections'); setShowMobileMenu(false); }}>
-              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
-              </svg>
-              <span>Collections</span>
-            </button>
-
             {user?.is_admin && (
-              <>
-                <button onClick={() => { navigate('/settings'); setShowMobileMenu(false); }}>
-                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <circle cx="12" cy="12" r="3"></circle>
-                    <path d="M12 1v6m0 6v6"/>
-                  </svg>
-                  <span>Admin</span>
-                </button>
-
-                <button onClick={() => { navigate('/library?tab=upload'); setShowMobileMenu(false); }}>
-                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <line x1="12" y1="5" x2="12" y2="19"></line>
-                    <line x1="5" y1="12" x2="19" y2="12"></line>
-                  </svg>
-                  <span>Upload</span>
-                </button>
-              </>
+              <button onClick={() => { navigate('/settings'); setShowMobileMenu(false); }}>
+                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="12" cy="12" r="3"></circle>
+                  <path d="M12 1v6m0 6v6"/>
+                </svg>
+                <span>Admin</span>
+              </button>
             )}
 
             <button onClick={() => { onLogout(); setShowMobileMenu(false); }} className="logout-button">

--- a/client/src/pages/Library.css
+++ b/client/src/pages/Library.css
@@ -738,71 +738,104 @@
 
 .collections-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 1rem;
 }
 
 .collection-card {
   position: relative;
-  background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
-  border: 1px solid #374151;
   border-radius: 12px;
   overflow: hidden;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 @media (hover: hover) {
   .collection-card:hover {
-    border-color: #3b82f6;
-    transform: translateY(-4px);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+    transform: scale(1.03);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
   }
 }
 
-.collection-card .delete-btn {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background: rgba(239, 68, 68, 0.9);
-  border: none;
-  color: #fff;
-  font-size: 14px;
-  font-weight: bold;
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.2s ease;
-  z-index: 10;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.collection-card:hover .delete-btn {
-  opacity: 1;
-}
-
-.collection-covers {
+.collection-cover-area {
   position: relative;
   width: 100%;
   aspect-ratio: 1;
   background: #111827;
 }
 
-.collection-book-count {
+.collection-overlay {
   position: absolute;
-  top: 0.5rem;
-  left: 0.5rem;
-  padding: 0.25rem 0.5rem;
-  background: rgba(0, 0, 0, 0.7);
-  border-radius: 6px;
-  font-size: 0.75rem;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 1rem;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.9) 0%, rgba(0, 0, 0, 0.6) 60%, transparent 100%);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+.collection-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.collection-title {
+  font-size: 0.9375rem;
   font-weight: 600;
   color: #fff;
-  z-index: 5;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+}
+
+.collection-info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.collection-book-count {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
+  font-weight: 500;
+}
+
+.visibility-icon {
+  color: rgba(255, 255, 255, 0.6);
+  flex-shrink: 0;
+}
+
+.collection-card .delete-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  opacity: 0;
+  transition: all 0.2s ease;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.collection-card .delete-btn:hover {
+  background: rgba(239, 68, 68, 0.9);
+}
+
+.collection-card:hover .delete-btn {
+  opacity: 1;
 }
 
 .collection-placeholder {
@@ -818,12 +851,13 @@
 }
 
 .collection-placeholder svg {
-  width: 48px;
-  height: 48px;
+  width: 40px;
+  height: 40px;
+  opacity: 0.5;
 }
 
 .collection-placeholder span {
-  font-size: 2rem;
+  font-size: 2.5rem;
   font-weight: 700;
   color: #4b5563;
 }
@@ -837,56 +871,6 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-}
-
-.collection-card-content {
-  padding: 1rem;
-}
-
-.title-with-visibility {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.25rem;
-}
-
-.collection-title {
-  font-size: 1rem;
-  font-weight: 600;
-  color: #fff;
-  margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex: 1;
-}
-
-.visibility-tag {
-  padding: 0.125rem 0.5rem;
-  border-radius: 4px;
-  font-size: 0.625rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  flex-shrink: 0;
-}
-
-.visibility-tag.public {
-  background: rgba(16, 185, 129, 0.2);
-  color: #10b981;
-}
-
-.visibility-tag.private {
-  background: rgba(107, 114, 128, 0.2);
-  color: #9ca3af;
-}
-
-.collection-description {
-  font-size: 0.8125rem;
-  color: #9ca3af;
-  margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 /* ===========================================
@@ -1254,21 +1238,25 @@
     gap: 0.75rem;
   }
 
+  .collections-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.75rem;
+  }
+
   .collection-card .delete-btn {
     opacity: 1;
   }
 
-  .collection-card-content {
+  .collection-overlay {
     padding: 0.75rem;
   }
 
   .collection-title {
-    font-size: 0.875rem;
+    font-size: 0.8125rem;
   }
 
-  .visibility-tag {
-    font-size: 0.5625rem;
-    padding: 0.125rem 0.375rem;
+  .collection-book-count {
+    font-size: 0.6875rem;
   }
 
   .upload-container-inline {

--- a/client/src/pages/Library.jsx
+++ b/client/src/pages/Library.jsx
@@ -537,30 +537,38 @@ export default function Library({ onPlay }) {
                     className="collection-card"
                     onClick={() => navigate(`/collections/${collection.id}`)}
                   >
+                    <div className="collection-cover-area">
+                      <RotatingCover bookIds={collection.book_ids} collectionName={collection.name} />
+                      <div className="collection-overlay">
+                        <div className="collection-meta">
+                          <h3 className="collection-title">{collection.name}</h3>
+                          <div className="collection-info">
+                            <span className="collection-book-count">
+                              {collection.book_count || 0} {(collection.book_count || 0) === 1 ? 'book' : 'books'}
+                            </span>
+                            {collection.is_public === 1 && (
+                              <svg className="visibility-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                <circle cx="12" cy="12" r="10"></circle>
+                                <line x1="2" y1="12" x2="22" y2="12"></line>
+                                <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+                              </svg>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                     {collection.is_owner === 1 && (
                       <button
                         className="delete-btn"
                         onClick={(e) => handleDeleteCollection(e, collection)}
                         title="Delete collection"
                       >
-                        x
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <line x1="18" y1="6" x2="6" y2="18"></line>
+                          <line x1="6" y1="6" x2="18" y2="18"></line>
+                        </svg>
                       </button>
                     )}
-                    <div className="collection-covers">
-                      <div className="collection-book-count">{collection.book_count || 0}</div>
-                      <RotatingCover bookIds={collection.book_ids} collectionName={collection.name} />
-                    </div>
-                    <div className="collection-card-content">
-                      <div className="title-with-visibility">
-                        <h3 className="collection-title">{collection.name}</h3>
-                        <span className={`visibility-tag ${collection.is_public === 1 ? 'public' : 'private'}`}>
-                          {collection.is_public === 1 ? 'Public' : 'Private'}
-                        </span>
-                      </div>
-                      {collection.description && (
-                        <p className="collection-description">{collection.description}</p>
-                      )}
-                    </div>
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- Redesigns collection cards with a modern overlay style
- Removes redundant navigation menu items (now accessible via Library tabs)

## Changes
- Collection tiles now show title and book count overlaid on the cover image
- Gradient overlay for better text readability
- Globe icon indicates public collections (instead of tag)
- Delete button has blur backdrop, turns red on hover
- Removed Reading List, Collections, Upload from user dropdown menus (desktop and mobile)

## Test plan
- [ ] Navigate to Library > Collections tab
- [ ] Verify collection tiles show cover with overlaid title/count
- [ ] Verify public collections show globe icon
- [ ] Hover over owned collection to see delete button
- [ ] Open user dropdown menu - should only show Profile, Admin (if admin), Logout
- [ ] Check mobile menu - same items removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)