### PR TITLE
Make collection tiles smaller with more info

### DIFF
--- a/client/src/pages/Library.css
+++ b/client/src/pages/Library.css
@@ -738,13 +738,14 @@
 
 .collections-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
   gap: 1rem;
 }
 
 .collection-card {
   position: relative;
-  border-radius: 12px;
+  background: #1f2937;
+  border-radius: 8px;
   overflow: hidden;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -752,8 +753,8 @@
 
 @media (hover: hover) {
   .collection-card:hover {
-    transform: scale(1.03);
-    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3);
   }
 }
 
@@ -764,58 +765,66 @@
   background: #111827;
 }
 
-.collection-overlay {
+.public-badge {
   position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 1rem;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.9) 0%, rgba(0, 0, 0, 0.6) 60%, transparent 100%);
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
+  top: 0.375rem;
+  left: 0.375rem;
+  padding: 0.125rem 0.375rem;
+  background: rgba(16, 185, 129, 0.9);
+  color: #fff;
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  border-radius: 4px;
+  z-index: 5;
 }
 
-.collection-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+.collection-details {
+  padding: 0.625rem;
 }
 
 .collection-title {
-  font-size: 0.9375rem;
+  font-size: 0.8125rem;
   font-weight: 600;
   color: #fff;
-  margin: 0;
+  margin: 0 0 0.25rem 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 }
 
-.collection-info {
+.collection-meta-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.375rem;
+  margin-bottom: 0.25rem;
 }
 
-.collection-book-count {
-  font-size: 0.75rem;
-  color: rgba(255, 255, 255, 0.7);
-  font-weight: 500;
+.collection-stat {
+  font-size: 0.6875rem;
+  color: #9ca3af;
 }
 
-.visibility-icon {
-  color: rgba(255, 255, 255, 0.6);
-  flex-shrink: 0;
+.collection-stat-divider {
+  font-size: 0.6875rem;
+  color: #4b5563;
+}
+
+.collection-creator {
+  font-size: 0.625rem;
+  color: #6b7280;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .collection-card .delete-btn {
   position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-  width: 28px;
-  height: 28px;
+  top: 0.375rem;
+  right: 0.375rem;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
@@ -845,19 +854,19 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  gap: 0.25rem;
   background: linear-gradient(135deg, #374151 0%, #1f2937 100%);
   color: #6b7280;
 }
 
 .collection-placeholder svg {
-  width: 40px;
-  height: 40px;
+  width: 28px;
+  height: 28px;
   opacity: 0.5;
 }
 
 .collection-placeholder span {
-  font-size: 2.5rem;
+  font-size: 1.5rem;
   font-weight: 700;
   color: #4b5563;
 }
@@ -1239,24 +1248,34 @@
   }
 
   .collections-grid {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 0.75rem;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.5rem;
   }
 
   .collection-card .delete-btn {
     opacity: 1;
   }
 
-  .collection-overlay {
-    padding: 0.75rem;
+  .collection-details {
+    padding: 0.5rem;
   }
 
   .collection-title {
-    font-size: 0.8125rem;
+    font-size: 0.75rem;
   }
 
-  .collection-book-count {
-    font-size: 0.6875rem;
+  .collection-stat,
+  .collection-stat-divider {
+    font-size: 0.625rem;
+  }
+
+  .collection-creator {
+    font-size: 0.5625rem;
+  }
+
+  .public-badge {
+    font-size: 0.5rem;
+    padding: 0.0625rem 0.25rem;
   }
 
   .upload-container-inline {

--- a/client/src/pages/Library.jsx
+++ b/client/src/pages/Library.jsx
@@ -531,46 +531,46 @@ export default function Library({ onPlay }) {
               </div>
             ) : (
               <div className="collections-grid">
-                {collections.map((collection) => (
-                  <div
-                    key={collection.id}
-                    className="collection-card"
-                    onClick={() => navigate(`/collections/${collection.id}`)}
-                  >
-                    <div className="collection-cover-area">
-                      <RotatingCover bookIds={collection.book_ids} collectionName={collection.name} />
-                      <div className="collection-overlay">
-                        <div className="collection-meta">
-                          <h3 className="collection-title">{collection.name}</h3>
-                          <div className="collection-info">
-                            <span className="collection-book-count">
-                              {collection.book_count || 0} {(collection.book_count || 0) === 1 ? 'book' : 'books'}
-                            </span>
-                            {collection.is_public === 1 && (
-                              <svg className="visibility-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                                <circle cx="12" cy="12" r="10"></circle>
-                                <line x1="2" y1="12" x2="22" y2="12"></line>
-                                <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
-                              </svg>
-                            )}
-                          </div>
+                {collections.map((collection) => {
+                  const hours = Math.floor((collection.total_duration || 0) / 3600);
+                  return (
+                    <div
+                      key={collection.id}
+                      className="collection-card"
+                      onClick={() => navigate(`/collections/${collection.id}`)}
+                    >
+                      <div className="collection-cover-area">
+                        <RotatingCover bookIds={collection.book_ids} collectionName={collection.name} />
+                        {collection.is_public === 1 && (
+                          <div className="public-badge">Public</div>
+                        )}
+                      </div>
+                      <div className="collection-details">
+                        <h3 className="collection-title">{collection.name}</h3>
+                        <div className="collection-meta-row">
+                          <span className="collection-stat">{collection.book_count || 0} books</span>
+                          <span className="collection-stat-divider">·</span>
+                          <span className="collection-stat">{hours}h</span>
+                        </div>
+                        <div className="collection-creator">
+                          by {collection.creator_username}
                         </div>
                       </div>
+                      {collection.is_owner === 1 && (
+                        <button
+                          className="delete-btn"
+                          onClick={(e) => handleDeleteCollection(e, collection)}
+                          title="Delete collection"
+                        >
+                          <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <line x1="18" y1="6" x2="6" y2="18"></line>
+                            <line x1="6" y1="6" x2="18" y2="18"></line>
+                          </svg>
+                        </button>
+                      )}
                     </div>
-                    {collection.is_owner === 1 && (
-                      <button
-                        className="delete-btn"
-                        onClick={(e) => handleDeleteCollection(e, collection)}
-                        title="Delete collection"
-                      >
-                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                          <line x1="18" y1="6" x2="6" y2="18"></line>
-                          <line x1="6" y1="6" x2="18" y2="18"></line>
-                        </svg>
-                      </button>
-                    )}
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             )}
           </div>

--- a/server/routes/collections.js
+++ b/server/routes/collections.js
@@ -27,12 +27,14 @@ router.get('/', collectionLimiter, authenticateToken, (req, res) => {
     `SELECT c.*,
             u.username as creator_username,
             COUNT(ci.id) as book_count,
+            COALESCE(SUM(a.duration), 0) as total_duration,
             (SELECT GROUP_CONCAT(ci2.audiobook_id) FROM collection_items ci2
              WHERE ci2.collection_id = c.id
              ORDER BY ci2.position ASC LIMIT 10) as book_ids,
             CASE WHEN c.user_id = ? THEN 1 ELSE 0 END as is_owner
      FROM user_collections c
      LEFT JOIN collection_items ci ON c.id = ci.collection_id
+     LEFT JOIN audiobooks a ON ci.audiobook_id = a.id
      LEFT JOIN users u ON c.user_id = u.id
      WHERE c.user_id = ? OR c.is_public = 1
      GROUP BY c.id


### PR DESCRIPTION
## Summary
- Makes collection tiles about half the previous size
- Shows more info: creator name, total hours, book count
- More obvious public indicator with green badge

## Changes
- Backend: Added `total_duration` to collections API
- Frontend: Redesigned tiles with details section below cover
- Green "Public" badge in top-left corner
- Shows "by username" for creator
- Mobile: 3 columns instead of 2

## Test plan
- [ ] Navigate to Library > Collections
- [ ] Verify tiles are smaller (more fit per row)
- [ ] Verify public collections show green "Public" badge
- [ ] Verify hours and book count display
- [ ] Verify creator name shows below title
- [ ] Test mobile layout (3 columns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)