### PR TITLE
Make collection tiles quarter size

### DIFF
--- a/client/src/pages/Library.css
+++ b/client/src/pages/Library.css
@@ -738,8 +738,8 @@
 
 .collections-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 0.75rem;
 }
 
 .collection-card {
@@ -766,29 +766,26 @@
 }
 
 .public-badge {
-  position: absolute;
-  top: 0.375rem;
-  left: 0.375rem;
-  padding: 0.125rem 0.375rem;
-  background: rgba(16, 185, 129, 0.9);
-  color: #fff;
-  font-size: 0.625rem;
+  padding: 0.0625rem 0.25rem;
+  background: rgba(16, 185, 129, 0.2);
+  color: #10b981;
+  font-size: 0.5625rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.025em;
-  border-radius: 4px;
-  z-index: 5;
+  border-radius: 3px;
+  margin-left: auto;
 }
 
 .collection-details {
-  padding: 0.625rem;
+  padding: 0.5rem;
 }
 
 .collection-title {
-  font-size: 0.8125rem;
+  font-size: 0.6875rem;
   font-weight: 600;
   color: #fff;
-  margin: 0 0 0.25rem 0;
+  margin: 0 0 0.125rem 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -797,22 +794,23 @@
 .collection-meta-row {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  margin-bottom: 0.25rem;
+  gap: 0.25rem;
+  margin-bottom: 0.125rem;
+  flex-wrap: wrap;
 }
 
 .collection-stat {
-  font-size: 0.6875rem;
+  font-size: 0.5625rem;
   color: #9ca3af;
 }
 
 .collection-stat-divider {
-  font-size: 0.6875rem;
+  font-size: 0.5625rem;
   color: #4b5563;
 }
 
 .collection-creator {
-  font-size: 0.625rem;
+  font-size: 0.5rem;
   color: #6b7280;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -821,10 +819,10 @@
 
 .collection-card .delete-btn {
   position: absolute;
-  top: 0.375rem;
-  right: 0.375rem;
-  width: 22px;
-  height: 22px;
+  top: 0.25rem;
+  right: 0.25rem;
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
@@ -837,6 +835,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.collection-card .delete-btn svg {
+  width: 10px;
+  height: 10px;
 }
 
 .collection-card .delete-btn:hover {
@@ -854,19 +857,19 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.25rem;
+  gap: 0.125rem;
   background: linear-gradient(135deg, #374151 0%, #1f2937 100%);
   color: #6b7280;
 }
 
 .collection-placeholder svg {
-  width: 28px;
-  height: 28px;
+  width: 20px;
+  height: 20px;
   opacity: 0.5;
 }
 
 .collection-placeholder span {
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   font-weight: 700;
   color: #4b5563;
 }
@@ -1248,8 +1251,8 @@
   }
 
   .collections-grid {
-    grid-template-columns: repeat(3, 1fr);
-    gap: 0.5rem;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0.375rem;
   }
 
   .collection-card .delete-btn {
@@ -1257,25 +1260,25 @@
   }
 
   .collection-details {
-    padding: 0.5rem;
+    padding: 0.375rem;
   }
 
   .collection-title {
-    font-size: 0.75rem;
+    font-size: 0.5625rem;
   }
 
   .collection-stat,
   .collection-stat-divider {
-    font-size: 0.625rem;
+    font-size: 0.5rem;
   }
 
   .collection-creator {
-    font-size: 0.5625rem;
+    display: none;
   }
 
   .public-badge {
-    font-size: 0.5rem;
-    padding: 0.0625rem 0.25rem;
+    font-size: 0.4375rem;
+    padding: 0.0625rem 0.1875rem;
   }
 
   .upload-container-inline {

--- a/client/src/pages/Library.jsx
+++ b/client/src/pages/Library.jsx
@@ -541,9 +541,6 @@ export default function Library({ onPlay }) {
                     >
                       <div className="collection-cover-area">
                         <RotatingCover bookIds={collection.book_ids} collectionName={collection.name} />
-                        {collection.is_public === 1 && (
-                          <div className="public-badge">Public</div>
-                        )}
                       </div>
                       <div className="collection-details">
                         <h3 className="collection-title">{collection.name}</h3>
@@ -551,6 +548,9 @@ export default function Library({ onPlay }) {
                           <span className="collection-stat">{collection.book_count || 0} books</span>
                           <span className="collection-stat-divider">·</span>
                           <span className="collection-stat">{hours}h</span>
+                          {collection.is_public === 1 && (
+                            <span className="public-badge">Public</span>
+                          )}
                         </div>
                         <div className="collection-creator">
                           by {collection.creator_username}


### PR DESCRIPTION
## Summary
- Makes collection tiles even smaller (quarter of original)
- Moves public badge inline with stats

## Changes
- Tile min-width: 100px (was 140px)
- Public badge now appears as green text in stats row
- Smaller fonts and tighter spacing
- Mobile: 4 columns, hides creator name to fit

## Test plan
- [ ] Verify tiles are much smaller (more fit per row)
- [ ] Verify "Public" badge appears inline after hours
- [ ] Check mobile view (4 columns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)