### PR TITLE
Add DELETE endpoint for audiobook files

### DIFF
--- a/server/routes/audiobooks.js
+++ b/server/routes/audiobooks.js
@@ -785,7 +785,6 @@ router.delete('/:id/files', authenticateToken, (req, res) => {
 
     // Verify the file is in the audiobook's directory (security check)
     const audiobookDir = path.dirname(audiobook.file_path);
-    const requestedFileDir = path.dirname(file_path);
 
     if (!file_path.startsWith(audiobookDir)) {
       return res.status(403).json({ error: 'Cannot delete files outside audiobook directory' });


### PR DESCRIPTION
## Summary
- Adds admin-only `DELETE /api/audiobooks/:id/files` endpoint to delete individual files from an audiobook's directory
- Includes security checks to prevent deletion outside audiobook directory
- Prevents deletion of the main audiobook file

## Test plan
- [ ] Test deleting a file from the Flutter app's book detail dropdown
- [ ] Verify non-admin users cannot delete files
- [ ] Verify files outside audiobook directory cannot be deleted
- [ ] Verify main audiobook file cannot be deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)