### PR TITLE
Add conversion status check for resilient UI

### DIFF
--- a/server/routes/audiobooks.js
+++ b/server/routes/audiobooks.js
@@ -1482,6 +1482,22 @@ router.delete('/jobs/conversion/:jobId', jobCancelLimiter, authenticateToken, as
   res.json({ message: 'Job cancelled' });
 });
 
+// Get active conversion job for a specific audiobook (admin only)
+router.get('/:id/conversion-status', jobStatusLimiter, authenticateToken, async (req, res) => {
+  if (!req.user.is_admin) {
+    return res.status(403).json({ error: 'Admin access required' });
+  }
+
+  const audiobookId = parseInt(req.params.id, 10);
+  const job = conversionService.getActiveJobForAudiobook(audiobookId);
+
+  if (!job) {
+    return res.json({ active: false });
+  }
+
+  res.json({ active: true, job });
+});
+
 // Search Open Library for metadata (admin only)
 router.get('/:id/search-metadata', authenticateToken, async (req, res) => {
   // Check if user is admin

--- a/server/services/conversionService.js
+++ b/server/services/conversionService.js
@@ -410,6 +410,19 @@ class ConversionService {
   }
 
   /**
+   * Get active job for a specific audiobook
+   */
+  getActiveJobForAudiobook(audiobookId) {
+    for (const job of this.jobs.values()) {
+      if (job.audiobookId === audiobookId &&
+          (job.status === 'starting' || job.status === 'converting')) {
+        return this.getJobStatus(job.id);
+      }
+    }
+    return null;
+  }
+
+  /**
    * Cancel a job
    */
   cancelJob(jobId) {


### PR DESCRIPTION
## Summary
- Add endpoint to check if an audiobook has an active conversion job
- Allows client to resume progress UI after navigation or phone sleep

## Changes
- `conversionService.js`: Add `getActiveJobForAudiobook(audiobookId)` method
- `audiobooks.js`: Add `GET /:id/conversion-status` endpoint

## Test plan
- [ ] Start a conversion
- [ ] Navigate away from detail screen
- [ ] Navigate back - progress UI should resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)