### PR TITLE
Fix: Restrict audiobook deletion to admin users only

### DIFF
--- a/server/routes/audiobooks.js
+++ b/server/routes/audiobooks.js
@@ -5,7 +5,7 @@ const rateLimit = require('express-rate-limit');
 const db = require('../database');
 const fs = require('fs');
 const path = require('path');
-const { authenticateToken, authenticateMediaToken } = require('../auth');
+const { authenticateToken, authenticateMediaToken, requireAdmin } = require('../auth');
 const { organizeAudiobook, needsOrganization } = require('../services/fileOrganizer');
 const activityService = require('../services/activityService');
 const conversionService = require('../services/conversionService');
@@ -782,12 +782,7 @@ router.get('/:id/directory-files', authenticateToken, (req, res) => {
 });
 
 // Delete a specific file from an audiobook directory (admin only)
-router.delete('/:id/files', authenticateToken, (req, res) => {
-  // Check if user is admin
-  if (!req.user.is_admin) {
-    return res.status(403).json({ error: 'Admin access required' });
-  }
-
+router.delete('/:id/files', authenticateToken, requireAdmin, (req, res) => {
   const { file_path } = req.body;
   if (!file_path) {
     return res.status(400).json({ error: 'file_path is required' });
@@ -912,8 +907,8 @@ router.get('/:id/download', authenticateToken, (req, res) => {
   });
 });
 
-// Delete audiobook
-router.delete('/:id', authenticateToken, (req, res) => {
+// Delete audiobook (admin only)
+router.delete('/:id', authenticateToken, requireAdmin, (req, res) => {
   db.get('SELECT * FROM audiobooks WHERE id = ?', [req.params.id], (err, audiobook) => {
     if (err) {
       return res.status(500).json({ error: err.message });

--- a/tests/integration/authorization.test.js
+++ b/tests/integration/authorization.test.js
@@ -116,4 +116,46 @@ describe('Authorization Tests', () => {
       expect(response2.body.error).toBe('Invalid username or password');
     });
   });
+
+  describe('Admin-Only Endpoints', () => {
+    test('non-admin users cannot delete audiobooks', async () => {
+      const response = await request(app)
+        .delete('/api/audiobooks/1')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(403);
+
+      expect(response.body.error).toBe('Admin access required');
+    });
+
+    test('admin users can access delete audiobook endpoint', async () => {
+      // This will return 404 since audiobook doesn't exist, but proves admin access works
+      const response = await request(app)
+        .delete('/api/audiobooks/999')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(404);
+
+      expect(response.body.error).toBe('Audiobook not found');
+    });
+
+    test('non-admin users cannot delete audiobook files', async () => {
+      const response = await request(app)
+        .delete('/api/audiobooks/1/files')
+        .set('Authorization', `Bearer ${userToken}`)
+        .send({ file_path: '/some/path' })
+        .expect(403);
+
+      expect(response.body.error).toBe('Admin access required');
+    });
+
+    test('admin users can access delete files endpoint', async () => {
+      // This will return 404 since audiobook doesn't exist, but proves admin access works
+      const response = await request(app)
+        .delete('/api/audiobooks/999/files')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ file_path: '/some/path' })
+        .expect(404);
+
+      expect(response.body.error).toBe('Audiobook not found');
+    });
+  });
 });

--- a/tests/integration/testApp.js
+++ b/tests/integration/testApp.js
@@ -578,6 +578,32 @@ function createTestApp(db) {
     });
   });
 
+  // Delete audiobook endpoint (admin only)
+  app.delete('/api/audiobooks/:id', requireAdmin, (req, res) => {
+    db.get('SELECT * FROM audiobooks WHERE id = ?', [req.params.id], (err, audiobook) => {
+      if (err) return res.status(500).json({ error: 'Database error' });
+      if (!audiobook) return res.status(404).json({ error: 'Audiobook not found' });
+
+      db.run('DELETE FROM audiobooks WHERE id = ?', [req.params.id], (err) => {
+        if (err) return res.status(500).json({ error: 'Database error' });
+        res.json({ message: 'Audiobook deleted successfully' });
+      });
+    });
+  });
+
+  // Delete audiobook files endpoint (admin only)
+  app.delete('/api/audiobooks/:id/files', requireAdmin, (req, res) => {
+    const { file_path } = req.body;
+    if (!file_path) return res.status(400).json({ error: 'file_path is required' });
+
+    db.get('SELECT * FROM audiobooks WHERE id = ?', [req.params.id], (err, audiobook) => {
+      if (err) return res.status(500).json({ error: 'Database error' });
+      if (!audiobook) return res.status(404).json({ error: 'Audiobook not found' });
+
+      res.json({ message: 'File deleted successfully' });
+    });
+  });
+
   return app;
 }
 


### PR DESCRIPTION
## Summary
- Adds `requireAdmin` middleware to `DELETE /api/audiobooks/:id` endpoint to prevent non-admin users from deleting audiobooks
- Adds `requireAdmin` middleware to `DELETE /api/audiobooks/:id/files` endpoint for consistency (previously had inline check)
- Removes redundant inline admin check from files endpoint (now using standard middleware)

## Security Impact
**Critical fix** - Previously any authenticated user could delete any audiobook from the library, causing potential data loss and security concerns.

## Test Plan
- [x] Added 4 new integration tests for admin-only delete authorization
- [x] Tests verify non-admin users get 403 Forbidden
- [x] Tests verify admin users can access endpoints
- [x] All 242 tests passing

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)