### PR TITLE
Add folder upload support for multi-part audiobooks

### DIFF
--- a/client/src/pages/Library.css
+++ b/client/src/pages/Library.css
@@ -904,7 +904,30 @@
 .upload-container-inline h2 {
   font-size: 1.25rem;
   color: #fff;
+  margin: 0 0 0.5rem 0;
+}
+
+.upload-description {
+  color: #9ca3af;
+  font-size: 0.9375rem;
   margin: 0 0 1.5rem 0;
+  line-height: 1.5;
+}
+
+.btn-large {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1rem 2rem;
+  font-size: 1rem;
+  border-radius: 12px;
+  width: 100%;
+  margin-bottom: 1.5rem;
+}
+
+.btn-large svg {
+  flex-shrink: 0;
 }
 
 .upload-form {


### PR DESCRIPTION
## Summary
- Wire up existing UploadModal to Library page's Upload tab
- Replace single-file upload form with modal that supports Files and Folder modes
- Enables uploading multi-part MP3 audiobooks by selecting a folder containing all parts

## Test plan
- [ ] Go to Library → Upload tab
- [ ] Click "Select Files or Folder" button
- [ ] Verify modal opens with Files/Folder toggle
- [ ] Test Folder mode with a multi-part MP3 audiobook
- [ ] Verify all parts are combined into a single audiobook entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)