### PR TITLE
Fix mobile login: password visibility toggle and field contrast

### DIFF
--- a/client/src/pages/Login.css
+++ b/client/src/pages/Login.css
@@ -46,6 +46,7 @@
   color: #d1d5db;
 }
 
+
 .error-message {
   padding: 12px;
   background: #7f1d1d;
@@ -162,4 +163,67 @@
 .username-display {
   margin-top: 8px;
   color: #d1d5db;
+}
+
+/* Password Toggle */
+.password-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.password-input-wrapper .input {
+  padding-right: 48px;
+  background: #1f1f1f !important;
+  border: 1px solid #374151 !important;
+}
+
+.password-toggle {
+  position: absolute;
+  right: 8px;
+  background: none;
+  border: none;
+  padding: 8px;
+  cursor: pointer;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: color 0.2s;
+}
+
+.password-toggle:hover {
+  color: #9ca3af;
+}
+
+.password-toggle:focus {
+  outline: none;
+}
+
+/* Mobile Responsive */
+@media (max-width: 480px) {
+  .login-page {
+    padding: 16px;
+    align-items: flex-start;
+    padding-top: 10vh;
+  }
+
+  .login-container {
+    padding: 24px 20px;
+    border-radius: 8px;
+  }
+
+  .login-logo {
+    height: 40px;
+    margin-bottom: 4px;
+  }
+
+  .login-form {
+    gap: 16px;
+  }
+
+  .login-btn {
+    margin-top: 8px;
+  }
 }

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -5,6 +5,7 @@ import './Login.css';
 export default function Login({ onLogin }) {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -214,13 +215,34 @@ export default function Login({ onLogin }) {
 
           <div className="form-group">
             <label>Password</label>
-            <input
-              type="password"
-              className="input"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-            />
+            <div className="password-input-wrapper">
+              <input
+                type={showPassword ? 'text' : 'password'}
+                className="input"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+              <button
+                type="button"
+                className="password-toggle"
+                onClick={() => setShowPassword(!showPassword)}
+                tabIndex={-1}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+              >
+                {showPassword ? (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/>
+                    <line x1="1" y1="1" x2="23" y2="23"/>
+                  </svg>
+                ) : (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                    <circle cx="12" cy="12" r="3"/>
+                  </svg>
+                )}
+              </button>
+            </div>
           </div>
 
           <button type="submit" className="btn btn-primary login-btn" disabled={loading}>


### PR DESCRIPTION
## Summary
- Add eye icon toggle to show/hide password on login form
- Fix password field visibility on mobile (was blending into background due to CSS specificity issues)
- Add mobile responsive styles for login page (reduced padding, better positioning)

## Test plan
- [ ] Open login page on mobile device
- [ ] Verify both username and password fields are visible
- [ ] Tap eye icon to show/hide password
- [ ] Verify fields have proper contrast against background

🤖 Generated with [Claude Code](https://claude.com/claude-code)