### PR TITLE
Fix Jest worker exit warning by adding .unref() to timers

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -21,6 +21,7 @@ if (JWT_SECRET.length < 32) {
 const tokenBlacklist = new Map();
 
 // Clean up expired tokens from blacklist every hour
+// .unref() allows Node to exit even if this timer is still active (fixes Jest warning)
 setInterval(() => {
   const now = Date.now();
   for (const [tokenHash, expiry] of tokenBlacklist.entries()) {
@@ -28,7 +29,7 @@ setInterval(() => {
       tokenBlacklist.delete(tokenHash);
     }
   }
-}, 60 * 60 * 1000);
+}, 60 * 60 * 1000).unref();
 
 // SECURITY: Account lockout tracking (in-memory)
 const failedAttempts = new Map(); // username -> { count, lockedUntil }

--- a/server/services/backupService.js
+++ b/server/services/backupService.js
@@ -267,7 +267,7 @@ function startScheduledBackups(intervalHours = 24, retention = DEFAULT_RETENTION
     } catch (err) {
       console.error('Scheduled backup failed:', err.message);
     }
-  }, 60000); // 1 minute after startup
+  }, 60000).unref(); // 1 minute after startup
 
   // Schedule recurring backups
   backupInterval = setInterval(async () => {
@@ -277,7 +277,7 @@ function startScheduledBackups(intervalHours = 24, retention = DEFAULT_RETENTION
     } catch (err) {
       console.error('Scheduled backup failed:', err.message);
     }
-  }, intervalMs);
+  }, intervalMs).unref();
 }
 
 /**

--- a/server/services/conversionService.js
+++ b/server/services/conversionService.js
@@ -16,7 +16,7 @@ class ConversionService {
     this.activeConversions = new Set();
 
     // Clean up stale jobs every 5 minutes
-    this.cleanupInterval = setInterval(() => this.cleanupStaleJobs(), 5 * 60 * 1000);
+    this.cleanupInterval = setInterval(() => this.cleanupStaleJobs(), 5 * 60 * 1000).unref();
   }
 
   /**

--- a/server/services/libraryScanner.js
+++ b/server/services/libraryScanner.js
@@ -1013,7 +1013,7 @@ function startPeriodicScan(intervalMinutes = 5) {
     } finally {
       isScanning = false;
     }
-  }, intervalMs);
+  }, intervalMs).unref();
 }
 
 /**

--- a/server/services/sessionManager.js
+++ b/server/services/sessionManager.js
@@ -7,7 +7,7 @@ class SessionManager {
     this.sessions = new Map(); // sessionId -> session data
     this.userSessions = new Map(); // userId -> Set of sessionIds
     this.SESSION_TIMEOUT = 5 * 60 * 1000; // 5 minutes - mark stale if no updates
-    this.cleanupInterval = setInterval(() => this.cleanupStaleSessions(), 15 * 1000); // Check every 15 seconds
+    this.cleanupInterval = setInterval(() => this.cleanupStaleSessions(), 15 * 1000).unref(); // Check every 15 seconds
   }
 
   /**
@@ -125,7 +125,7 @@ class SessionManager {
       }
 
       // Remove from sessions map after a delay
-      setTimeout(() => this.sessions.delete(sessionId), 30000); // Keep for 30s for reporting
+      setTimeout(() => this.sessions.delete(sessionId), 30000).unref(); // Keep for 30s for reporting
     }
   }
 

--- a/server/services/unlockService.js
+++ b/server/services/unlockService.js
@@ -215,11 +215,12 @@ async function cleanupExpiredTokens() {
 }
 
 // Run cleanup periodically (every hour)
+// .unref() allows Node to exit even if this timer is still active (fixes Jest warning)
 setInterval(() => {
   cleanupExpiredTokens().catch(err => {
     console.error('Failed to cleanup expired unlock tokens:', err);
   });
-}, 60 * 60 * 1000);
+}, 60 * 60 * 1000).unref();
 
 module.exports = {
   generateUnlockToken,


### PR DESCRIPTION
## Summary
- Added `.unref()` to all `setInterval` and `setTimeout` calls
- Allows Node.js to exit cleanly even when timers are pending
- Eliminates the "worker process has failed to exit gracefully" Jest warning

## Files Updated
- `server/auth.js` - token blacklist cleanup
- `server/services/sessionManager.js` - session cleanup + stopSession delay
- `server/services/unlockService.js` - token cleanup
- `server/services/conversionService.js` - stale job cleanup
- `server/services/libraryScanner.js` - periodic scan
- `server/services/backupService.js` - scheduled backups

## Test plan
- [x] All 576 tests pass
- [x] No more Jest worker exit warning

Fixes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)