### PR TITLE
Fix iOS content overlap with navbar safe area

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -17,6 +17,13 @@
     padding-bottom: 0;
   }
 
+  /* iOS: account for safe area (notch/Dynamic Island) */
+  @supports (-webkit-touch-callout: none) {
+    .main-content {
+      padding-top: calc(48px + env(safe-area-inset-top));
+    }
+  }
+
   /* Add bottom padding when player is present */
   .app.player-active {
     padding-bottom: calc(70px + env(safe-area-inset-bottom, 0));


### PR DESCRIPTION
## Summary
- Main content padding now accounts for `safe-area-inset-top` on iOS devices
- Matches the navbar height calculation to prevent content overlap on iPhones with notch/Dynamic Island

## Test plan
- [ ] Test on iPhone with notch/Dynamic Island
- [ ] Verify content no longer appears under the navbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)