### PR TITLE
Fix iOS search modal safe area and admin dropdown zero

### DIFF
--- a/client/src/components/Navigation.jsx
+++ b/client/src/components/Navigation.jsx
@@ -303,7 +303,7 @@ export default function Navigation({ onLogout }) {
                     </svg>
                     Profile
                   </button>
-                  {user?.is_admin && (
+                  {!!user?.is_admin && (
                     <button onClick={() => { navigate('/settings'); setShowUserMenu(false); }}>
                       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                         <circle cx="12" cy="12" r="3"></circle>
@@ -373,7 +373,7 @@ export default function Navigation({ onLogout }) {
               <span>Profile</span>
             </button>
 
-            {user?.is_admin && (
+            {!!user?.is_admin && (
               <button onClick={() => { navigate('/settings'); setShowMobileMenu(false); }}>
                 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <circle cx="12" cy="12" r="3"></circle>

--- a/client/src/components/SearchModal.css
+++ b/client/src/components/SearchModal.css
@@ -176,6 +176,13 @@
     padding-top: 20px;
   }
 
+  /* iOS: account for safe area (notch/Dynamic Island) */
+  @supports (-webkit-touch-callout: none) {
+    .search-modal-overlay {
+      padding-top: calc(20px + env(safe-area-inset-top));
+    }
+  }
+
   .search-modal {
     width: 95%;
     max-height: 85vh;


### PR DESCRIPTION
## Summary
- Add safe area padding for search modal on iOS (notch/Dynamic Island)
- Convert `is_admin` checks to boolean (`!!`) to prevent rendering "0" for non-admins

## Root cause
SQLite stores booleans as 0/1. In React, `{0 && <element>}` renders "0" as text, while `{false && <element>}` renders nothing.

## Test plan
- [ ] Search modal no longer clips on Dynamic Island
- [ ] Non-admin user dropdown shows no "0" where Admin would be

🤖 Generated with [Claude Code](https://claude.com/claude-code)