### PR TITLE
Fix iOS mini player floating above bottom edge

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -1068,6 +1068,17 @@
     transform: none !important;
   }
 
+  /* iOS: ensure player is truly docked to bottom */
+  @supports (-webkit-touch-callout: none) {
+    .audio-player {
+      /* Use padding-bottom for safe area, not margin */
+      padding-bottom: env(safe-area-inset-bottom) !important;
+      /* Ensure no gap at bottom */
+      margin-bottom: 0 !important;
+      bottom: 0 !important;
+    }
+  }
+
   .player-info {
     padding: 20px 12px 12px 12px !important;
     margin-bottom: 0 !important;


### PR DESCRIPTION
## Summary
- Add explicit iOS-specific styles to ensure audio player is docked to bottom
- Reinforce `bottom: 0` and `margin-bottom: 0` for iOS devices

## Test plan
- [ ] Test on iPhone - mini player should be flush with bottom of screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)