### PR TITLE
Add user management details and account controls

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -222,6 +222,9 @@ export const deleteUser = (id) =>
 export const unlockUser = (id) =>
   api.post(`/users/${id}/unlock`);
 
+export const getUserDetails = (id) =>
+  api.get(`/users/${id}/details`);
+
 export const disableUser = (id, reason = null) =>
   api.post(`/users/${id}/disable`, { reason });
 

--- a/client/src/components/settings/UsersSettings.css
+++ b/client/src/components/settings/UsersSettings.css
@@ -1,0 +1,472 @@
+.users-settings {
+  max-width: 1200px;
+}
+
+.users-settings .section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 1.5rem;
+  gap: 1rem;
+}
+
+.users-settings .header-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* User Form */
+.user-form-section {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-secondary);
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.user-form-section h3 {
+  margin: 0 0 1rem 0;
+  color: var(--text-primary);
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.form-group label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.form-group input[type="text"],
+.form-group input[type="email"],
+.form-group input[type="password"] {
+  padding: 0.625rem 0.875rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-secondary);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+}
+
+.form-group input:focus {
+  outline: none;
+  border-color: #3b82f6;
+}
+
+.form-group input.error {
+  border-color: #ef4444;
+}
+
+.error-text {
+  font-size: 0.75rem;
+  color: #ef4444;
+}
+
+.checkbox-group label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  color: var(--text-primary);
+}
+
+.checkbox-group input[type="checkbox"] {
+  width: 1rem;
+  height: 1rem;
+}
+
+.error-banner {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #ef4444;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+/* Users Table */
+.users-table {
+  background: var(--bg-card);
+  border: 1px solid var(--border-secondary);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.users-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.users-table th,
+.users-table td {
+  padding: 0.875rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border-secondary);
+}
+
+.users-table th {
+  background: var(--bg-tertiary);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+}
+
+.users-table tr:last-child td {
+  border-bottom: none;
+}
+
+.users-table tr.disabled-row {
+  opacity: 0.6;
+  background: rgba(239, 68, 68, 0.05);
+}
+
+.user-cell .user-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.user-cell .username {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.user-cell .email {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+/* Status Badges */
+.status-badge {
+  display: inline-block;
+  padding: 0.25rem 0.625rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.status-badge.active {
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+}
+
+.status-badge.locked {
+  background: rgba(245, 158, 11, 0.15);
+  color: #f59e0b;
+}
+
+.status-badge.disabled {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+}
+
+.role-badge {
+  display: inline-block;
+  padding: 0.25rem 0.625rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.role-badge.admin {
+  background: rgba(59, 130, 246, 0.15);
+  color: #3b82f6;
+}
+
+.role-badge.user {
+  background: rgba(156, 163, 175, 0.15);
+  color: #9ca3af;
+}
+
+.date-cell {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.actions-cell {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+/* Buttons */
+.btn-sm {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+}
+
+.btn-warning {
+  background: rgba(245, 158, 11, 0.15);
+  color: #f59e0b;
+  border: 1px solid rgba(245, 158, 11, 0.3);
+}
+
+.btn-warning:hover {
+  background: rgba(245, 158, 11, 0.25);
+}
+
+.btn-success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+  border: 1px solid rgba(34, 197, 94, 0.3);
+}
+
+.btn-success:hover {
+  background: rgba(34, 197, 94, 0.25);
+}
+
+.btn-danger {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+.btn-danger:hover {
+  background: rgba(239, 68, 68, 0.25);
+}
+
+.inline-btn {
+  margin-left: 0.5rem;
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.modal-content {
+  background: var(--bg-card);
+  border-radius: 12px;
+  max-width: 700px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--border-secondary);
+  position: sticky;
+  top: 0;
+  background: var(--bg-card);
+  z-index: 1;
+}
+
+.modal-header h3 {
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.modal-close {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  line-height: 1;
+}
+
+.modal-close:hover {
+  color: var(--text-primary);
+}
+
+/* User Details Modal */
+.user-details-content {
+  padding: 1.5rem;
+}
+
+.details-section {
+  margin-bottom: 1.5rem;
+}
+
+.details-section:last-child {
+  margin-bottom: 0;
+}
+
+.details-section h4 {
+  margin: 0 0 0.75rem 0;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border-secondary);
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+}
+
+.details-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}
+
+.detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.detail-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+}
+
+.detail-value {
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.detail-value.warning {
+  color: #f59e0b;
+}
+
+.disabled-info {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: 6px;
+  padding: 1rem;
+  margin-top: 0.75rem;
+}
+
+.disabled-info p {
+  margin: 0 0 0.5rem 0;
+  color: var(--text-primary);
+}
+
+.disabled-info p:last-of-type {
+  margin-bottom: 0.75rem;
+}
+
+/* Recent Activity */
+.recent-activity-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.activity-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem;
+  background: var(--bg-tertiary);
+  border-radius: 6px;
+  gap: 1rem;
+}
+
+.activity-info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.activity-title {
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.activity-author {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.activity-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-shrink: 0;
+}
+
+.completion-badge {
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.completion-badge.completed {
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+}
+
+.activity-date {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+  .users-settings .section-header {
+    flex-direction: column;
+  }
+
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+
+  .users-table {
+    overflow-x: auto;
+  }
+
+  .actions-cell {
+    flex-direction: column;
+  }
+
+  .details-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .activity-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .activity-meta {
+    width: 100%;
+    justify-content: space-between;
+  }
+}

--- a/client/src/components/settings/UsersSettings.jsx
+++ b/client/src/components/settings/UsersSettings.jsx
@@ -1,0 +1,599 @@
+import { useState, useEffect } from 'react';
+import { getUsers, createUser, updateUser, deleteUser, unlockUser, getUserDetails, disableUser, enableUser } from '../../api';
+import './UsersSettings.css';
+
+export default function UsersSettings({ currentUserId }) {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [editingUser, setEditingUser] = useState(null);
+  const [selectedUser, setSelectedUser] = useState(null);
+  const [userDetails, setUserDetails] = useState(null);
+  const [loadingDetails, setLoadingDetails] = useState(false);
+
+  // Form state
+  const [formData, setFormData] = useState({
+    username: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+    is_admin: false
+  });
+  const [formErrors, setFormErrors] = useState({});
+
+  const loadUsers = async () => {
+    try {
+      setLoading(true);
+      const response = await getUsers();
+      setUsers(response.data);
+      setError(null);
+    } catch (err) {
+      console.error('Error loading users:', err);
+      setError('Failed to load users');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  const loadUserDetails = async (userId) => {
+    try {
+      setLoadingDetails(true);
+      const response = await getUserDetails(userId);
+      setUserDetails(response.data);
+    } catch (err) {
+      console.error('Error loading user details:', err);
+      setUserDetails(null);
+    } finally {
+      setLoadingDetails(false);
+    }
+  };
+
+  const handleViewDetails = async (user) => {
+    setSelectedUser(user);
+    await loadUserDetails(user.id);
+  };
+
+  const handleCloseDetails = () => {
+    setSelectedUser(null);
+    setUserDetails(null);
+  };
+
+  const handleUnlock = async (user) => {
+    try {
+      await unlockUser(user.id);
+      await loadUsers();
+      if (selectedUser?.id === user.id) {
+        await loadUserDetails(user.id);
+      }
+    } catch (err) {
+      console.error('Error unlocking user:', err);
+      alert('Failed to unlock user');
+    }
+  };
+
+  const handleDisable = async (user) => {
+    const reason = prompt('Enter a reason for disabling this account (optional):');
+    try {
+      await disableUser(user.id, reason);
+      await loadUsers();
+      if (selectedUser?.id === user.id) {
+        await loadUserDetails(user.id);
+      }
+    } catch (err) {
+      console.error('Error disabling user:', err);
+      alert(err.response?.data?.error || 'Failed to disable user');
+    }
+  };
+
+  const handleEnable = async (user) => {
+    try {
+      await enableUser(user.id);
+      await loadUsers();
+      if (selectedUser?.id === user.id) {
+        await loadUserDetails(user.id);
+      }
+    } catch (err) {
+      console.error('Error enabling user:', err);
+      alert('Failed to enable user');
+    }
+  };
+
+  const validatePassword = (password) => {
+    const errors = [];
+    if (password.length < 6) errors.push('At least 6 characters');
+    if (!/[A-Z]/.test(password)) errors.push('One uppercase letter');
+    if (!/[a-z]/.test(password)) errors.push('One lowercase letter');
+    if (!/[0-9]/.test(password)) errors.push('One number');
+    if (!/[^A-Za-z0-9]/.test(password)) errors.push('One special character');
+    return errors;
+  };
+
+  const handleCreateUser = async (e) => {
+    e.preventDefault();
+    const errors = {};
+
+    if (!formData.username.trim()) errors.username = 'Username is required';
+    if (!formData.password) errors.password = 'Password is required';
+    else {
+      const pwdErrors = validatePassword(formData.password);
+      if (pwdErrors.length > 0) errors.password = pwdErrors.join(', ');
+    }
+    if (formData.password !== formData.confirmPassword) {
+      errors.confirmPassword = 'Passwords do not match';
+    }
+
+    if (Object.keys(errors).length > 0) {
+      setFormErrors(errors);
+      return;
+    }
+
+    try {
+      await createUser(formData.username, formData.password, formData.email, formData.is_admin);
+      setShowCreateForm(false);
+      setFormData({ username: '', email: '', password: '', confirmPassword: '', is_admin: false });
+      setFormErrors({});
+      await loadUsers();
+    } catch (err) {
+      setFormErrors({ submit: err.response?.data?.error || 'Failed to create user' });
+    }
+  };
+
+  const handleEditUser = async (e) => {
+    e.preventDefault();
+    const errors = {};
+
+    if (!formData.username.trim()) errors.username = 'Username is required';
+    if (formData.password) {
+      const pwdErrors = validatePassword(formData.password);
+      if (pwdErrors.length > 0) errors.password = pwdErrors.join(', ');
+      if (formData.password !== formData.confirmPassword) {
+        errors.confirmPassword = 'Passwords do not match';
+      }
+    }
+
+    if (Object.keys(errors).length > 0) {
+      setFormErrors(errors);
+      return;
+    }
+
+    try {
+      const updates = {
+        username: formData.username,
+        email: formData.email,
+        is_admin: formData.is_admin
+      };
+      if (formData.password) updates.password = formData.password;
+
+      await updateUser(editingUser.id, updates);
+      setEditingUser(null);
+      setFormData({ username: '', email: '', password: '', confirmPassword: '', is_admin: false });
+      setFormErrors({});
+      await loadUsers();
+    } catch (err) {
+      setFormErrors({ submit: err.response?.data?.error || 'Failed to update user' });
+    }
+  };
+
+  const handleDeleteUser = async (user) => {
+    if (!confirm(`Are you sure you want to delete user "${user.username}"? This cannot be undone.`)) {
+      return;
+    }
+
+    try {
+      await deleteUser(user.id);
+      await loadUsers();
+    } catch (err) {
+      alert(err.response?.data?.error || 'Failed to delete user');
+    }
+  };
+
+  const startEdit = (user) => {
+    setEditingUser(user);
+    setFormData({
+      username: user.username,
+      email: user.email || '',
+      password: '',
+      confirmPassword: '',
+      is_admin: !!user.is_admin
+    });
+    setFormErrors({});
+    setShowCreateForm(false);
+  };
+
+  const startCreate = () => {
+    setShowCreateForm(true);
+    setEditingUser(null);
+    setFormData({ username: '', email: '', password: '', confirmPassword: '', is_admin: false });
+    setFormErrors({});
+  };
+
+  const cancelForm = () => {
+    setShowCreateForm(false);
+    setEditingUser(null);
+    setFormData({ username: '', email: '', password: '', confirmPassword: '', is_admin: false });
+    setFormErrors({});
+  };
+
+  const formatDuration = (seconds) => {
+    if (!seconds || seconds === 0) return '0h';
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    if (hours >= 24) {
+      const days = Math.floor(hours / 24);
+      const remainingHours = hours % 24;
+      return `${days}d ${remainingHours}h`;
+    }
+    if (hours > 0) return `${hours}h ${minutes}m`;
+    return `${minutes}m`;
+  };
+
+  const formatDate = (dateStr) => {
+    if (!dateStr) return 'Never';
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  };
+
+  if (loading) {
+    return <div className="loading">Loading users...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="tab-content users-settings">
+        <div className="error-state">
+          <p>{error}</p>
+          <button className="btn btn-primary" onClick={loadUsers}>Retry</button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="tab-content users-settings">
+      <div className="section-header">
+        <div>
+          <h2>User Management</h2>
+          <p className="section-description">
+            Manage user accounts, unlock locked accounts, and view user activity.
+          </p>
+        </div>
+        <div className="header-actions">
+          <button type="button" className="btn btn-secondary" onClick={loadUsers}>
+            Refresh
+          </button>
+          <button type="button" className="btn btn-primary" onClick={startCreate}>
+            Add User
+          </button>
+        </div>
+      </div>
+
+      {/* Create/Edit Form */}
+      {(showCreateForm || editingUser) && (
+        <div className="user-form-section">
+          <h3>{editingUser ? 'Edit User' : 'Create New User'}</h3>
+          <form onSubmit={editingUser ? handleEditUser : handleCreateUser}>
+            <div className="form-row">
+              <div className="form-group">
+                <label>Username</label>
+                <input
+                  type="text"
+                  value={formData.username}
+                  onChange={(e) => setFormData({ ...formData, username: e.target.value })}
+                  className={formErrors.username ? 'error' : ''}
+                />
+                {formErrors.username && <span className="error-text">{formErrors.username}</span>}
+              </div>
+              <div className="form-group">
+                <label>Email</label>
+                <input
+                  type="email"
+                  value={formData.email}
+                  onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                />
+              </div>
+            </div>
+            <div className="form-row">
+              <div className="form-group">
+                <label>{editingUser ? 'New Password (leave blank to keep)' : 'Password'}</label>
+                <input
+                  type="password"
+                  value={formData.password}
+                  onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                  className={formErrors.password ? 'error' : ''}
+                />
+                {formErrors.password && <span className="error-text">{formErrors.password}</span>}
+              </div>
+              <div className="form-group">
+                <label>Confirm Password</label>
+                <input
+                  type="password"
+                  value={formData.confirmPassword}
+                  onChange={(e) => setFormData({ ...formData, confirmPassword: e.target.value })}
+                  className={formErrors.confirmPassword ? 'error' : ''}
+                />
+                {formErrors.confirmPassword && <span className="error-text">{formErrors.confirmPassword}</span>}
+              </div>
+            </div>
+            <div className="form-group checkbox-group">
+              <label>
+                <input
+                  type="checkbox"
+                  checked={formData.is_admin}
+                  onChange={(e) => setFormData({ ...formData, is_admin: e.target.checked })}
+                />
+                Administrator
+              </label>
+            </div>
+            {formErrors.submit && <div className="error-banner">{formErrors.submit}</div>}
+            <div className="form-actions">
+              <button type="button" className="btn btn-secondary" onClick={cancelForm}>Cancel</button>
+              <button type="submit" className="btn btn-primary">
+                {editingUser ? 'Save Changes' : 'Create User'}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Users Table */}
+      <div className="users-table">
+        <table>
+          <thead>
+            <tr>
+              <th>User</th>
+              <th>Status</th>
+              <th>Role</th>
+              <th>Created</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((user) => (
+              <tr key={user.id} className={user.account_disabled ? 'disabled-row' : ''}>
+                <td className="user-cell">
+                  <div className="user-info">
+                    <span className="username">{user.username}</span>
+                    {user.email && <span className="email">{user.email}</span>}
+                  </div>
+                </td>
+                <td className="status-cell">
+                  {user.account_disabled ? (
+                    <span className="status-badge disabled">Disabled</span>
+                  ) : user.is_locked ? (
+                    <span className="status-badge locked">
+                      Locked ({Math.ceil(user.lockout_remaining / 60)}m)
+                    </span>
+                  ) : (
+                    <span className="status-badge active">Active</span>
+                  )}
+                </td>
+                <td>
+                  <span className={`role-badge ${user.is_admin ? 'admin' : 'user'}`}>
+                    {user.is_admin ? 'Admin' : 'User'}
+                  </span>
+                </td>
+                <td className="date-cell">{formatDate(user.created_at)}</td>
+                <td className="actions-cell">
+                  <button
+                    className="btn btn-sm btn-secondary"
+                    onClick={() => handleViewDetails(user)}
+                    title="View details"
+                  >
+                    Details
+                  </button>
+                  {user.is_locked && (
+                    <button
+                      className="btn btn-sm btn-warning"
+                      onClick={() => handleUnlock(user)}
+                      title="Clear login lockout"
+                    >
+                      Unlock
+                    </button>
+                  )}
+                  {user.account_disabled ? (
+                    <button
+                      className="btn btn-sm btn-success"
+                      onClick={() => handleEnable(user)}
+                      title="Enable account"
+                    >
+                      Enable
+                    </button>
+                  ) : user.id !== currentUserId && (
+                    <button
+                      className="btn btn-sm btn-warning"
+                      onClick={() => handleDisable(user)}
+                      title="Disable account"
+                    >
+                      Disable
+                    </button>
+                  )}
+                  <button
+                    className="btn btn-sm btn-secondary"
+                    onClick={() => startEdit(user)}
+                    title="Edit user"
+                  >
+                    Edit
+                  </button>
+                  {user.id !== currentUserId && (
+                    <button
+                      className="btn btn-sm btn-danger"
+                      onClick={() => handleDeleteUser(user)}
+                      title="Delete user"
+                    >
+                      Delete
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* User Details Modal */}
+      {selectedUser && (
+        <div className="modal-overlay" onClick={handleCloseDetails}>
+          <div className="modal-content user-details-modal" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-header">
+              <h3>User Details: {selectedUser.username}</h3>
+              <button className="modal-close" onClick={handleCloseDetails}>&times;</button>
+            </div>
+
+            {loadingDetails ? (
+              <div className="loading">Loading details...</div>
+            ) : userDetails ? (
+              <div className="user-details-content">
+                {/* Account Status */}
+                <div className="details-section">
+                  <h4>Account Status</h4>
+                  <div className="details-grid">
+                    <div className="detail-item">
+                      <span className="detail-label">Status</span>
+                      <span className="detail-value">
+                        {userDetails.user.account_disabled ? (
+                          <span className="status-badge disabled">Disabled</span>
+                        ) : userDetails.loginAttempts.isLocked ? (
+                          <span className="status-badge locked">Locked</span>
+                        ) : (
+                          <span className="status-badge active">Active</span>
+                        )}
+                      </span>
+                    </div>
+                    <div className="detail-item">
+                      <span className="detail-label">Role</span>
+                      <span className="detail-value">
+                        <span className={`role-badge ${userDetails.user.is_admin ? 'admin' : 'user'}`}>
+                          {userDetails.user.is_admin ? 'Administrator' : 'User'}
+                        </span>
+                      </span>
+                    </div>
+                    <div className="detail-item">
+                      <span className="detail-label">Created</span>
+                      <span className="detail-value">{formatDate(userDetails.user.created_at)}</span>
+                    </div>
+                    <div className="detail-item">
+                      <span className="detail-label">Email</span>
+                      <span className="detail-value">{userDetails.user.email || 'Not set'}</span>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Login Attempts */}
+                <div className="details-section">
+                  <h4>Login Security</h4>
+                  <div className="details-grid">
+                    <div className="detail-item">
+                      <span className="detail-label">Failed Attempts</span>
+                      <span className={`detail-value ${userDetails.loginAttempts.count > 0 ? 'warning' : ''}`}>
+                        {userDetails.loginAttempts.count} / 5
+                      </span>
+                    </div>
+                    <div className="detail-item">
+                      <span className="detail-label">Lockout Status</span>
+                      <span className="detail-value">
+                        {userDetails.loginAttempts.isLocked ? (
+                          <>
+                            Locked for {Math.ceil(userDetails.loginAttempts.remainingSeconds / 60)} minutes
+                            <button
+                              className="btn btn-sm btn-warning inline-btn"
+                              onClick={() => handleUnlock(selectedUser)}
+                            >
+                              Unlock
+                            </button>
+                          </>
+                        ) : (
+                          'Not locked'
+                        )}
+                      </span>
+                    </div>
+                  </div>
+                  {userDetails.user.account_disabled && (
+                    <div className="disabled-info">
+                      <p><strong>Account Disabled</strong></p>
+                      <p>Disabled: {formatDate(userDetails.user.disabled_at)}</p>
+                      {userDetails.user.disabled_reason && (
+                        <p>Reason: {userDetails.user.disabled_reason}</p>
+                      )}
+                      <button
+                        className="btn btn-sm btn-success"
+                        onClick={() => handleEnable(selectedUser)}
+                      >
+                        Enable Account
+                      </button>
+                    </div>
+                  )}
+                </div>
+
+                {/* Listening Statistics */}
+                <div className="details-section">
+                  <h4>Listening Statistics</h4>
+                  <div className="details-grid">
+                    <div className="detail-item">
+                      <span className="detail-label">Books Started</span>
+                      <span className="detail-value">{userDetails.listeningStats.booksStarted}</span>
+                    </div>
+                    <div className="detail-item">
+                      <span className="detail-label">Books Completed</span>
+                      <span className="detail-value">{userDetails.listeningStats.booksCompleted}</span>
+                    </div>
+                    <div className="detail-item">
+                      <span className="detail-label">Total Listen Time</span>
+                      <span className="detail-value">
+                        {formatDuration(userDetails.listeningStats.totalListenTimeSeconds)}
+                      </span>
+                    </div>
+                    <div className="detail-item">
+                      <span className="detail-label">Last Activity</span>
+                      <span className="detail-value">
+                        {formatDate(userDetails.listeningStats.lastActivity)}
+                      </span>
+                    </div>
+                    <div className="detail-item">
+                      <span className="detail-label">API Keys</span>
+                      <span className="detail-value">{userDetails.apiKeysCount}</span>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Recent Activity */}
+                {userDetails.recentActivity.length > 0 && (
+                  <div className="details-section">
+                    <h4>Recent Activity</h4>
+                    <div className="recent-activity-list">
+                      {userDetails.recentActivity.map((item) => (
+                        <div key={item.audiobook_id} className="activity-item">
+                          <div className="activity-info">
+                            <span className="activity-title">{item.title}</span>
+                            <span className="activity-author">{item.author}</span>
+                          </div>
+                          <div className="activity-meta">
+                            <span className={`completion-badge ${item.completed ? 'completed' : ''}`}>
+                              {item.completed ? 'Completed' : formatDuration(item.position)}
+                            </span>
+                            <span className="activity-date">{formatDate(item.lastPlayed)}</span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="error-state">Failed to load user details</div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/server/auth.js
+++ b/server/auth.js
@@ -126,6 +126,26 @@ function getLockedAccounts() {
   return locked;
 }
 
+/**
+ * Get failed attempts info for a username
+ * Returns { count, lockedUntil, isLocked, remainingSeconds }
+ */
+function getFailedAttemptsInfo(username) {
+  const record = failedAttempts.get(username);
+  if (!record) {
+    return { count: 0, lockedUntil: null, isLocked: false, remainingSeconds: 0 };
+  }
+  const now = Date.now();
+  const isLocked = record.lockedUntil && record.lockedUntil > now;
+  const remainingSeconds = isLocked ? Math.ceil((record.lockedUntil - now) / 1000) : 0;
+  return {
+    count: record.count || 0,
+    lockedUntil: record.lockedUntil ? new Date(record.lockedUntil).toISOString() : null,
+    isLocked,
+    remainingSeconds
+  };
+}
+
 // Middleware to verify JWT token or API key
 function authenticateToken(req, res, next) {
   // SECURITY: Only accept token from Authorization header, not query string
@@ -470,4 +490,5 @@ module.exports = {
   clearFailedAttempts,
   getLockedAccounts,
   recordFailedAttempt,
+  getFailedAttemptsInfo,
 };


### PR DESCRIPTION
## Summary
- Add user details modal showing login security info, listening stats, and recent activity
- Add unlock button to clear login attempt lockouts for users
- Add disable/enable account functionality with optional reason
- Create dedicated UsersSettings component replacing inline users tab code
- Add `GET /api/users/:id/details` endpoint for detailed user metrics
- Add `getFailedAttemptsInfo()` function to expose login attempt data

## Test plan
- [ ] Navigate to Settings → Users tab
- [ ] Verify users list shows status badges (Active/Locked/Disabled)
- [ ] Click "Details" on a user to view detailed modal
- [ ] Verify modal shows login security, listening stats, recent activity
- [ ] Test unlock button on a locked user
- [ ] Test disable/enable buttons on a user account
- [ ] Verify you cannot disable your own account

🤖 Generated with [Claude Code](https://claude.com/claude-code)