### PR TITLE
Add integration tests for profile and settings routes (#170)

### DIFF
--- a/tests/integration/profile.test.js
+++ b/tests/integration/profile.test.js
@@ -1,0 +1,470 @@
+/**
+ * Integration tests for Profile Routes
+ * Tests: Get profile, update profile, stats, password change, avatar
+ */
+
+const request = require('supertest');
+const {
+  createTestDatabase,
+  createTestUser,
+  generateTestToken,
+  createTestApp,
+  createTestAudiobook
+} = require('./testApp');
+
+describe('Profile Routes', () => {
+  let db;
+  let app;
+  let user1, adminUser;
+  let user1Token, adminToken;
+
+  beforeAll(async () => {
+    db = await createTestDatabase();
+    app = createTestApp(db);
+
+    // Create test users
+    user1 = await createTestUser(db, { username: 'profileuser', password: 'ProfilePass123!' });
+    adminUser = await createTestUser(db, { username: 'profileadmin', password: 'AdminPass123!', isAdmin: true });
+
+    user1Token = generateTestToken(user1);
+    adminToken = generateTestToken(adminUser);
+  });
+
+  afterAll((done) => {
+    db.close(done);
+  });
+
+  describe('GET /api/profile', () => {
+    describe('Authentication', () => {
+      it('returns 401 without authentication', async () => {
+        const res = await request(app)
+          .get('/api/profile')
+          .expect(401);
+
+        expect(res.body.error).toBe('Unauthorized');
+      });
+
+      it('returns profile with valid token', async () => {
+        const res = await request(app)
+          .get('/api/profile')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .expect(200);
+
+        expect(res.body.username).toBe('profileuser');
+      });
+    });
+
+    describe('Response data', () => {
+      it('includes user fields', async () => {
+        const res = await request(app)
+          .get('/api/profile')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .expect(200);
+
+        expect(res.body).toHaveProperty('id');
+        expect(res.body).toHaveProperty('username');
+        expect(res.body).toHaveProperty('email');
+        expect(res.body).toHaveProperty('display_name');
+        expect(res.body).toHaveProperty('avatar');
+        expect(res.body).toHaveProperty('is_admin');
+        expect(res.body).toHaveProperty('must_change_password');
+        expect(res.body).toHaveProperty('created_at');
+      });
+
+      it('does not include password hash', async () => {
+        const res = await request(app)
+          .get('/api/profile')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .expect(200);
+
+        expect(res.body).not.toHaveProperty('password_hash');
+      });
+
+      it('shows correct admin status for regular user', async () => {
+        const res = await request(app)
+          .get('/api/profile')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .expect(200);
+
+        expect(res.body.is_admin).toBe(0);
+      });
+
+      it('shows correct admin status for admin user', async () => {
+        const res = await request(app)
+          .get('/api/profile')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .expect(200);
+
+        expect(res.body.is_admin).toBe(1);
+      });
+
+      it('must_change_password is boolean', async () => {
+        const res = await request(app)
+          .get('/api/profile')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .expect(200);
+
+        expect(typeof res.body.must_change_password).toBe('boolean');
+      });
+    });
+  });
+
+  describe('GET /api/profile/stats', () => {
+    describe('Authentication', () => {
+      it('returns 401 without authentication', async () => {
+        const res = await request(app)
+          .get('/api/profile/stats')
+          .expect(401);
+
+        expect(res.body.error).toBe('Unauthorized');
+      });
+
+      it('returns stats with valid token', async () => {
+        const res = await request(app)
+          .get('/api/profile/stats')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .expect(200);
+
+        expect(res.body).toHaveProperty('totalListenTime');
+        expect(res.body).toHaveProperty('booksStarted');
+        expect(res.body).toHaveProperty('booksCompleted');
+      });
+    });
+
+    describe('Stats calculation', () => {
+      let book1, book2;
+
+      beforeAll(async () => {
+        // Create audiobooks and progress for stats testing
+        book1 = await createTestAudiobook(db, { title: 'Stats Book 1', author: 'Author', duration: 3600 });
+        book2 = await createTestAudiobook(db, { title: 'Stats Book 2', author: 'Author', duration: 7200 });
+
+        // Add progress records
+        await new Promise((resolve, reject) => {
+          db.run(
+            'INSERT INTO playback_progress (user_id, audiobook_id, position, completed) VALUES (?, ?, ?, ?)',
+            [user1.id, book1.id, 1800, 1], // 50% through, completed
+            (err) => err ? reject(err) : resolve()
+          );
+        });
+
+        await new Promise((resolve, reject) => {
+          db.run(
+            'INSERT INTO playback_progress (user_id, audiobook_id, position, completed) VALUES (?, ?, ?, ?)',
+            [user1.id, book2.id, 3600, 0], // 50% through, not completed
+            (err) => err ? reject(err) : resolve()
+          );
+        });
+      });
+
+      it('counts books started', async () => {
+        const res = await request(app)
+          .get('/api/profile/stats')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .expect(200);
+
+        expect(res.body.booksStarted).toBeGreaterThanOrEqual(2);
+      });
+
+      it('counts books completed', async () => {
+        const res = await request(app)
+          .get('/api/profile/stats')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .expect(200);
+
+        expect(res.body.booksCompleted).toBeGreaterThanOrEqual(1);
+      });
+
+      it('calculates total listen time from completed books', async () => {
+        const res = await request(app)
+          .get('/api/profile/stats')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .expect(200);
+
+        expect(res.body.totalListenTime).toBeGreaterThanOrEqual(3600); // At least book1 duration
+      });
+    });
+  });
+
+  describe('PUT /api/profile', () => {
+    describe('Authentication', () => {
+      it('returns 401 without authentication', async () => {
+        const res = await request(app)
+          .put('/api/profile')
+          .send({ displayName: 'New Name' })
+          .expect(401);
+
+        expect(res.body.error).toBe('Unauthorized');
+      });
+    });
+
+    describe('Validation', () => {
+      it('returns 400 with no fields to update', async () => {
+        const res = await request(app)
+          .put('/api/profile')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .send({})
+          .expect(400);
+
+        expect(res.body.error).toBe('No fields to update');
+      });
+
+      it('returns 400 with empty display name', async () => {
+        const res = await request(app)
+          .put('/api/profile')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .send({ displayName: '' })
+          .expect(400);
+
+        expect(res.body.error).toBe('Display name cannot be empty or whitespace-only');
+      });
+
+      it('returns 400 with whitespace-only display name', async () => {
+        const res = await request(app)
+          .put('/api/profile')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .send({ displayName: '   ' })
+          .expect(400);
+
+        expect(res.body.error).toBe('Display name cannot be empty or whitespace-only');
+      });
+
+      it('returns 400 with display name over 100 characters', async () => {
+        const res = await request(app)
+          .put('/api/profile')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .send({ displayName: 'a'.repeat(101) })
+          .expect(400);
+
+        expect(res.body.error).toBe('Display name must be 100 characters or less');
+      });
+    });
+
+    describe('Success', () => {
+      it('updates display name', async () => {
+        const res = await request(app)
+          .put('/api/profile')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .send({ displayName: 'Updated Display Name' })
+          .expect(200);
+
+        expect(res.body.display_name).toBe('Updated Display Name');
+      });
+
+      it('trims whitespace from display name', async () => {
+        const res = await request(app)
+          .put('/api/profile')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .send({ displayName: '  Trimmed Name  ' })
+          .expect(200);
+
+        expect(res.body.display_name).toBe('Trimmed Name');
+      });
+
+      it('updates email', async () => {
+        const res = await request(app)
+          .put('/api/profile')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .send({ displayName: 'Name With Email', email: 'test@example.com' })
+          .expect(200);
+
+        expect(res.body.email).toBe('test@example.com');
+      });
+
+      it('allows null email', async () => {
+        const res = await request(app)
+          .put('/api/profile')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .send({ displayName: 'Name Only', email: null })
+          .expect(200);
+
+        expect(res.body.email).toBeNull();
+      });
+
+      it('returns updated user object', async () => {
+        const res = await request(app)
+          .put('/api/profile')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .send({ displayName: 'Check Response' })
+          .expect(200);
+
+        expect(res.body).toHaveProperty('id');
+        expect(res.body).toHaveProperty('username');
+        expect(res.body).toHaveProperty('display_name');
+        expect(res.body).toHaveProperty('is_admin');
+      });
+    });
+  });
+
+  describe('DELETE /api/profile/avatar', () => {
+    describe('Authentication', () => {
+      it('returns 401 without authentication', async () => {
+        const res = await request(app)
+          .delete('/api/profile/avatar')
+          .expect(401);
+
+        expect(res.body.error).toBe('Unauthorized');
+      });
+    });
+
+    describe('Success', () => {
+      it('removes avatar successfully', async () => {
+        const res = await request(app)
+          .delete('/api/profile/avatar')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .expect(200);
+
+        expect(res.body.message).toBe('Avatar removed successfully');
+      });
+
+      it('avatar is null after removal', async () => {
+        await request(app)
+          .delete('/api/profile/avatar')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .expect(200);
+
+        const profile = await request(app)
+          .get('/api/profile')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .expect(200);
+
+        expect(profile.body.avatar).toBeNull();
+      });
+    });
+  });
+
+  describe('PUT /api/profile/password', () => {
+    let passwordTestUser;
+    let passwordTestToken;
+
+    beforeEach(async () => {
+      // Create fresh user for each password test
+      passwordTestUser = await createTestUser(db, {
+        username: `pwduser${Date.now()}`,
+        password: 'OldPassword123!'
+      });
+      passwordTestToken = generateTestToken(passwordTestUser);
+    });
+
+    describe('Authentication', () => {
+      it('returns 401 without authentication', async () => {
+        const res = await request(app)
+          .put('/api/profile/password')
+          .send({ currentPassword: 'old', newPassword: 'new' })
+          .expect(401);
+
+        expect(res.body.error).toBe('Unauthorized');
+      });
+    });
+
+    describe('Validation', () => {
+      it('returns 400 without current password', async () => {
+        const res = await request(app)
+          .put('/api/profile/password')
+          .set('Authorization', `Bearer ${passwordTestToken}`)
+          .send({ newPassword: 'NewPassword123!' })
+          .expect(400);
+
+        expect(res.body.error).toBe('Current password and new password are required');
+      });
+
+      it('returns 400 without new password', async () => {
+        const res = await request(app)
+          .put('/api/profile/password')
+          .set('Authorization', `Bearer ${passwordTestToken}`)
+          .send({ currentPassword: 'OldPassword123!' })
+          .expect(400);
+
+        expect(res.body.error).toBe('Current password and new password are required');
+      });
+
+      it('returns 400 with short new password', async () => {
+        const res = await request(app)
+          .put('/api/profile/password')
+          .set('Authorization', `Bearer ${passwordTestToken}`)
+          .send({ currentPassword: 'OldPassword123!', newPassword: '12345' })
+          .expect(400);
+
+        expect(res.body.error).toBe('Password must be at least 6 characters');
+      });
+
+      it('returns 401 with wrong current password', async () => {
+        const res = await request(app)
+          .put('/api/profile/password')
+          .set('Authorization', `Bearer ${passwordTestToken}`)
+          .send({ currentPassword: 'WrongPassword', newPassword: 'NewPassword123!' })
+          .expect(401);
+
+        expect(res.body.error).toBe('Current password is incorrect');
+      });
+    });
+
+    describe('Success', () => {
+      it('changes password with correct credentials', async () => {
+        const res = await request(app)
+          .put('/api/profile/password')
+          .set('Authorization', `Bearer ${passwordTestToken}`)
+          .send({ currentPassword: 'OldPassword123!', newPassword: 'NewPassword123!' })
+          .expect(200);
+
+        expect(res.body.message).toBe('Password updated successfully. Please log in again on all devices.');
+      });
+    });
+  });
+
+  describe('Security', () => {
+    it('users can only access their own profile', async () => {
+      const res = await request(app)
+        .get('/api/profile')
+        .set('Authorization', `Bearer ${user1Token}`)
+        .expect(200);
+
+      expect(res.body.username).toBe('profileuser');
+      expect(res.body.username).not.toBe('profileadmin');
+    });
+
+    it('users can only update their own profile', async () => {
+      const res = await request(app)
+        .put('/api/profile')
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ displayName: 'My Name Only' })
+        .expect(200);
+
+      // Verify admin profile wasn't affected
+      const adminProfile = await request(app)
+        .get('/api/profile')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+
+      expect(adminProfile.body.display_name).not.toBe('My Name Only');
+    });
+
+    it('XSS in display name is stored safely', async () => {
+      const res = await request(app)
+        .put('/api/profile')
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ displayName: '<script>alert("xss")</script>' })
+        .expect(200);
+
+      expect(res.body.display_name).toBe('<script>alert("xss")</script>');
+    });
+
+    it('SQL injection in display name is safe', async () => {
+      const res = await request(app)
+        .put('/api/profile')
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send({ displayName: "'; DROP TABLE users; --" })
+        .expect(200);
+
+      expect(res.body.display_name).toBe("'; DROP TABLE users; --");
+
+      // Verify table still exists
+      const profile = await request(app)
+        .get('/api/profile')
+        .set('Authorization', `Bearer ${user1Token}`)
+        .expect(200);
+
+      expect(profile.body.username).toBe('profileuser');
+    });
+  });
+});

--- a/tests/integration/settings.test.js
+++ b/tests/integration/settings.test.js
@@ -1,0 +1,535 @@
+/**
+ * Integration tests for Settings Routes
+ * Tests: Server settings, library settings, AI settings (all admin-only)
+ */
+
+const request = require('supertest');
+const {
+  createTestDatabase,
+  createTestUser,
+  generateTestToken,
+  createTestApp
+} = require('./testApp');
+
+describe('Settings Routes', () => {
+  let db;
+  let app;
+  let regularUser, adminUser;
+  let userToken, adminToken;
+
+  beforeAll(async () => {
+    db = await createTestDatabase();
+    app = createTestApp(db);
+
+    // Create test users
+    regularUser = await createTestUser(db, { username: 'settingsuser', password: 'UserPass123!' });
+    adminUser = await createTestUser(db, { username: 'settingsadmin', password: 'AdminPass123!', isAdmin: true });
+
+    userToken = generateTestToken(regularUser);
+    adminToken = generateTestToken(adminUser);
+  });
+
+  afterAll((done) => {
+    db.close(done);
+  });
+
+  describe('GET /api/settings/all', () => {
+    describe('Authorization', () => {
+      it('returns 401 without authentication', async () => {
+        const res = await request(app)
+          .get('/api/settings/all')
+          .expect(401);
+
+        expect(res.body.error).toBe('Unauthorized');
+      });
+
+      it('returns 403 for non-admin users', async () => {
+        const res = await request(app)
+          .get('/api/settings/all')
+          .set('Authorization', `Bearer ${userToken}`)
+          .expect(403);
+
+        expect(res.body.error).toBe('Admin access required');
+      });
+
+      it('returns settings for admin users', async () => {
+        const res = await request(app)
+          .get('/api/settings/all')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .expect(200);
+
+        expect(res.body).toHaveProperty('settings');
+      });
+    });
+
+    describe('Response data', () => {
+      it('includes all settings fields', async () => {
+        const res = await request(app)
+          .get('/api/settings/all')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .expect(200);
+
+        const { settings } = res.body;
+        expect(settings).toHaveProperty('port');
+        expect(settings).toHaveProperty('nodeEnv');
+        expect(settings).toHaveProperty('databasePath');
+        expect(settings).toHaveProperty('dataDir');
+        expect(settings).toHaveProperty('audiobooksDir');
+        expect(settings).toHaveProperty('uploadDir');
+        expect(settings).toHaveProperty('libraryScanInterval');
+        expect(settings).toHaveProperty('autoBackupInterval');
+        expect(settings).toHaveProperty('backupRetention');
+        expect(settings).toHaveProperty('logBufferSize');
+      });
+
+      it('includes lockedFields array', async () => {
+        const res = await request(app)
+          .get('/api/settings/all')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .expect(200);
+
+        expect(res.body).toHaveProperty('lockedFields');
+        expect(Array.isArray(res.body.lockedFields)).toBe(true);
+      });
+    });
+  });
+
+  describe('PUT /api/settings/all', () => {
+    describe('Authorization', () => {
+      it('returns 401 without authentication', async () => {
+        const res = await request(app)
+          .put('/api/settings/all')
+          .send({ port: 3002 })
+          .expect(401);
+
+        expect(res.body.error).toBe('Unauthorized');
+      });
+
+      it('returns 403 for non-admin users', async () => {
+        const res = await request(app)
+          .put('/api/settings/all')
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({ port: 3002 })
+          .expect(403);
+
+        expect(res.body.error).toBe('Admin access required');
+      });
+    });
+
+    describe('Validation', () => {
+      it('returns 400 for invalid port (too low)', async () => {
+        const res = await request(app)
+          .put('/api/settings/all')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ port: 0 })
+          .expect(400);
+
+        expect(res.body.errors).toContain('Port must be between 1 and 65535');
+      });
+
+      it('returns 400 for invalid port (too high)', async () => {
+        const res = await request(app)
+          .put('/api/settings/all')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ port: 70000 })
+          .expect(400);
+
+        expect(res.body.errors).toContain('Port must be between 1 and 65535');
+      });
+
+      it('returns 400 for invalid node environment', async () => {
+        const res = await request(app)
+          .put('/api/settings/all')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ nodeEnv: 'invalid' })
+          .expect(400);
+
+        expect(res.body.errors).toContain('Environment must be "development" or "production"');
+      });
+
+      it('returns 400 for invalid scan interval (too low)', async () => {
+        const res = await request(app)
+          .put('/api/settings/all')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ libraryScanInterval: 0 })
+          .expect(400);
+
+        expect(res.body.errors).toContain('Scan interval must be between 1 and 1440 minutes');
+      });
+
+      it('returns 400 for invalid scan interval (too high)', async () => {
+        const res = await request(app)
+          .put('/api/settings/all')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ libraryScanInterval: 1500 })
+          .expect(400);
+
+        expect(res.body.errors).toContain('Scan interval must be between 1 and 1440 minutes');
+      });
+    });
+
+    describe('Success', () => {
+      it('updates valid settings', async () => {
+        const res = await request(app)
+          .put('/api/settings/all')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ port: 3002 })
+          .expect(200);
+
+        expect(res.body.message).toBe('Settings updated successfully.');
+        expect(res.body.updated).toContain('PORT');
+      });
+
+      it('returns requiresRestart for port and nodeEnv changes', async () => {
+        const res = await request(app)
+          .put('/api/settings/all')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ port: 3002, nodeEnv: 'production' })
+          .expect(200);
+
+        expect(res.body.requiresRestart).toContain('PORT');
+        expect(res.body.requiresRestart).toContain('NODE_ENV');
+      });
+
+      it('updates scan interval without restart', async () => {
+        const res = await request(app)
+          .put('/api/settings/all')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ libraryScanInterval: 10 })
+          .expect(200);
+
+        expect(res.body.updated).toContain('LIBRARY_SCAN_INTERVAL');
+        expect(res.body.requiresRestart).not.toContain('LIBRARY_SCAN_INTERVAL');
+      });
+    });
+  });
+
+  describe('GET /api/settings/library', () => {
+    describe('Authorization', () => {
+      it('returns 403 for non-admin users', async () => {
+        const res = await request(app)
+          .get('/api/settings/library')
+          .set('Authorization', `Bearer ${userToken}`)
+          .expect(403);
+
+        expect(res.body.error).toBe('Admin access required');
+      });
+
+      it('returns library settings for admin', async () => {
+        const res = await request(app)
+          .get('/api/settings/library')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .expect(200);
+
+        expect(res.body).toHaveProperty('libraryPath');
+        expect(res.body).toHaveProperty('uploadPath');
+      });
+    });
+  });
+
+  describe('PUT /api/settings/library', () => {
+    describe('Authorization', () => {
+      it('returns 403 for non-admin users', async () => {
+        const res = await request(app)
+          .put('/api/settings/library')
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({ libraryPath: '/path', uploadPath: '/path' })
+          .expect(403);
+
+        expect(res.body.error).toBe('Admin access required');
+      });
+    });
+
+    describe('Validation', () => {
+      it('returns 400 without libraryPath', async () => {
+        const res = await request(app)
+          .put('/api/settings/library')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ uploadPath: '/path' })
+          .expect(400);
+
+        expect(res.body.error).toBe('All paths are required');
+      });
+
+      it('returns 400 without uploadPath', async () => {
+        const res = await request(app)
+          .put('/api/settings/library')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ libraryPath: '/path' })
+          .expect(400);
+
+        expect(res.body.error).toBe('All paths are required');
+      });
+    });
+
+    describe('Success', () => {
+      it('updates library settings', async () => {
+        const res = await request(app)
+          .put('/api/settings/library')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ libraryPath: '/app/data/audiobooks', uploadPath: '/app/data/uploads' })
+          .expect(200);
+
+        expect(res.body.message).toBe('Library settings updated successfully.');
+      });
+    });
+  });
+
+  describe('GET /api/settings/server', () => {
+    describe('Authorization', () => {
+      it('returns 403 for non-admin users', async () => {
+        const res = await request(app)
+          .get('/api/settings/server')
+          .set('Authorization', `Bearer ${userToken}`)
+          .expect(403);
+
+        expect(res.body.error).toBe('Admin access required');
+      });
+
+      it('returns server settings for admin', async () => {
+        const res = await request(app)
+          .get('/api/settings/server')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .expect(200);
+
+        expect(res.body).toHaveProperty('settings');
+        expect(res.body.settings).toHaveProperty('port');
+        expect(res.body.settings).toHaveProperty('nodeEnv');
+      });
+    });
+  });
+
+  describe('PUT /api/settings/server', () => {
+    describe('Authorization', () => {
+      it('returns 403 for non-admin users', async () => {
+        const res = await request(app)
+          .put('/api/settings/server')
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({ port: 3002 })
+          .expect(403);
+
+        expect(res.body.error).toBe('Admin access required');
+      });
+    });
+
+    describe('Success', () => {
+      it('updates server settings (same as /all)', async () => {
+        const res = await request(app)
+          .put('/api/settings/server')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ port: 3003 })
+          .expect(200);
+
+        expect(res.body.message).toBe('Settings updated successfully.');
+        expect(res.body.updated).toContain('PORT');
+      });
+    });
+  });
+
+  describe('GET /api/settings/ai', () => {
+    describe('Authorization', () => {
+      it('returns 403 for non-admin users', async () => {
+        const res = await request(app)
+          .get('/api/settings/ai')
+          .set('Authorization', `Bearer ${userToken}`)
+          .expect(403);
+
+        expect(res.body.error).toBe('Admin access required');
+      });
+
+      it('returns AI settings for admin', async () => {
+        const res = await request(app)
+          .get('/api/settings/ai')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .expect(200);
+
+        expect(res.body).toHaveProperty('settings');
+        expect(res.body.settings).toHaveProperty('aiProvider');
+        expect(res.body.settings).toHaveProperty('openaiModel');
+        expect(res.body.settings).toHaveProperty('geminiModel');
+      });
+    });
+
+    describe('Security', () => {
+      it('masks API keys in response', async () => {
+        const res = await request(app)
+          .get('/api/settings/ai')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .expect(200);
+
+        const { settings } = res.body;
+        // If API key is set, it should be masked
+        if (settings.openaiApiKey) {
+          expect(settings.openaiApiKey).toBe('••••••••');
+        }
+        if (settings.geminiApiKey) {
+          expect(settings.geminiApiKey).toBe('••••••••');
+        }
+      });
+    });
+  });
+
+  describe('GET /api/settings/ai/status', () => {
+    describe('Authorization', () => {
+      it('returns 401 without authentication', async () => {
+        const res = await request(app)
+          .get('/api/settings/ai/status')
+          .expect(401);
+
+        expect(res.body.error).toBe('Unauthorized');
+      });
+
+      it('allows regular users to check AI status', async () => {
+        const res = await request(app)
+          .get('/api/settings/ai/status')
+          .set('Authorization', `Bearer ${userToken}`)
+          .expect(200);
+
+        expect(res.body).toHaveProperty('configured');
+        expect(res.body).toHaveProperty('provider');
+      });
+
+      it('allows admin users to check AI status', async () => {
+        const res = await request(app)
+          .get('/api/settings/ai/status')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .expect(200);
+
+        expect(res.body).toHaveProperty('configured');
+        expect(res.body).toHaveProperty('provider');
+      });
+    });
+
+    describe('Response data', () => {
+      it('returns boolean configured status', async () => {
+        const res = await request(app)
+          .get('/api/settings/ai/status')
+          .set('Authorization', `Bearer ${userToken}`)
+          .expect(200);
+
+        expect(typeof res.body.configured).toBe('boolean');
+      });
+
+      it('returns string provider', async () => {
+        const res = await request(app)
+          .get('/api/settings/ai/status')
+          .set('Authorization', `Bearer ${userToken}`)
+          .expect(200);
+
+        expect(typeof res.body.provider).toBe('string');
+        expect(['openai', 'gemini']).toContain(res.body.provider);
+      });
+    });
+  });
+
+  describe('PUT /api/settings/ai', () => {
+    describe('Authorization', () => {
+      it('returns 403 for non-admin users', async () => {
+        const res = await request(app)
+          .put('/api/settings/ai')
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({ aiProvider: 'openai' })
+          .expect(403);
+
+        expect(res.body.error).toBe('Admin access required');
+      });
+    });
+
+    describe('Validation', () => {
+      it('returns 400 for invalid AI provider', async () => {
+        const res = await request(app)
+          .put('/api/settings/ai')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ aiProvider: 'invalid' })
+          .expect(400);
+
+        expect(res.body.error).toBe('Invalid AI provider');
+      });
+
+      it('returns 400 for invalid OpenAI model', async () => {
+        const res = await request(app)
+          .put('/api/settings/ai')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ openaiModel: 'invalid-model' })
+          .expect(400);
+
+        expect(res.body.error).toBe('Invalid OpenAI model selected');
+      });
+
+      it('returns 400 for invalid Gemini model', async () => {
+        const res = await request(app)
+          .put('/api/settings/ai')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ geminiModel: 'invalid-model' })
+          .expect(400);
+
+        expect(res.body.error).toBe('Invalid Gemini model selected');
+      });
+    });
+
+    describe('Success', () => {
+      it('updates AI provider', async () => {
+        const res = await request(app)
+          .put('/api/settings/ai')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ aiProvider: 'gemini' })
+          .expect(200);
+
+        expect(res.body.message).toBe('AI settings updated successfully');
+      });
+
+      it('accepts valid OpenAI models', async () => {
+        const validModels = ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo', 'gpt-3.5-turbo'];
+
+        for (const model of validModels) {
+          const res = await request(app)
+            .put('/api/settings/ai')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .send({ openaiModel: model })
+            .expect(200);
+
+          expect(res.body.message).toBe('AI settings updated successfully');
+        }
+      });
+
+      it('accepts valid Gemini models', async () => {
+        const validModels = ['gemini-1.5-flash', 'gemini-1.5-pro', 'gemini-1.0-pro'];
+
+        for (const model of validModels) {
+          const res = await request(app)
+            .put('/api/settings/ai')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .send({ geminiModel: model })
+            .expect(200);
+
+          expect(res.body.message).toBe('AI settings updated successfully');
+        }
+      });
+    });
+  });
+
+  describe('Security', () => {
+    it('non-admin cannot access any settings endpoint', async () => {
+      const endpoints = [
+        { method: 'get', path: '/api/settings/all' },
+        { method: 'put', path: '/api/settings/all' },
+        { method: 'get', path: '/api/settings/library' },
+        { method: 'put', path: '/api/settings/library' },
+        { method: 'get', path: '/api/settings/server' },
+        { method: 'put', path: '/api/settings/server' },
+        { method: 'get', path: '/api/settings/ai' },
+        { method: 'put', path: '/api/settings/ai' }
+      ];
+
+      for (const endpoint of endpoints) {
+        const res = await request(app)
+          [endpoint.method](endpoint.path)
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({})
+          .expect(403);
+
+        expect(res.body.error).toBe('Admin access required');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive integration tests for profile routes (35 tests)
- Add comprehensive integration tests for settings routes (41 tests)
- Extend testApp.js with profile and settings routes implementation
- 76 new tests, all 869 tests passing

## Test coverage includes

### Profile routes
- Get profile with full user data
- Update profile (display name, email)
- User stats (listen time, books started/completed)
- Password change with bcrypt verification
- Avatar management
- Security tests (XSS, SQL injection)

### Settings routes (all admin-only)
- All settings CRUD with validation
- Library settings
- Server settings
- AI settings with masked API keys
- AI status check (available to all users)
- Authorization enforcement on all endpoints

## Test plan
- [x] All tests pass locally (`npm test`)
- [x] Profile security tests verify user isolation
- [x] Settings tests verify admin-only access

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)