### PR TITLE
Add proper unit tests for backupService and conversionService (#153)

### DIFF
--- a/tests/unit/conversionService.test.js
+++ b/tests/unit/conversionService.test.js
@@ -1,336 +1,934 @@
 /**
  * Unit tests for Conversion Service
- * Tests conversion logic, FFmpeg argument building, and job management
+ * Tests conversion logic, job management, and status tracking
  */
 
-describe('Conversion Service - Utility Functions', () => {
-  describe('Supported format validation', () => {
-    const supportedFormats = ['.m4a', '.mp3', '.mp4', '.ogg', '.flac'];
+// Mock dependencies before requiring the module
+jest.mock('child_process', () => ({
+  spawn: jest.fn()
+}));
 
-    function validateFormat(filePath) {
-      const path = require('path');
-      const ext = path.extname(filePath).toLowerCase();
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  statSync: jest.fn(),
+  renameSync: jest.fn(),
+  unlinkSync: jest.fn()
+}));
 
-      if (ext === '.m4b') {
-        return { error: 'File is already M4B format' };
-      }
-      if (!supportedFormats.includes(ext)) {
-        return { error: `Unsupported format: ${ext}. Supported: ${supportedFormats.join(', ')}` };
-      }
-      return { valid: true };
-    }
+jest.mock('../../server/services/websocketManager', () => ({
+  broadcastJobUpdate: jest.fn(),
+  broadcastLibraryUpdate: jest.fn()
+}));
 
-    it('accepts .m4a files', () => {
-      expect(validateFormat('/test/book.m4a').valid).toBe(true);
-    });
+const { spawn } = require('child_process');
+const fs = require('fs');
+const websocketManager = require('../../server/services/websocketManager');
+const conversionService = require('../../server/services/conversionService');
 
-    it('accepts .mp3 files', () => {
-      expect(validateFormat('/test/book.mp3').valid).toBe(true);
-    });
-
-    it('accepts .mp4 files', () => {
-      expect(validateFormat('/test/book.mp4').valid).toBe(true);
-    });
-
-    it('accepts .ogg files', () => {
-      expect(validateFormat('/test/book.ogg').valid).toBe(true);
-    });
-
-    it('accepts .flac files', () => {
-      expect(validateFormat('/test/book.flac').valid).toBe(true);
-    });
-
-    it('rejects already M4B files', () => {
-      expect(validateFormat('/test/book.m4b').error).toBe('File is already M4B format');
-    });
-
-    it('rejects unsupported formats', () => {
-      expect(validateFormat('/test/book.wav').error).toContain('Unsupported format');
-    });
-
-    it('handles uppercase extensions', () => {
-      expect(validateFormat('/test/book.MP3').valid).toBe(true);
-    });
+describe('Conversion Service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    // Suppress console output during tests
+    jest.spyOn(console, 'log').mockImplementation();
+    jest.spyOn(console, 'error').mockImplementation();
+    jest.spyOn(console, 'warn').mockImplementation();
+    // Clear internal state
+    conversionService.jobs.clear();
+    conversionService.activeConversions.clear();
+    // Default mock behavior
+    fs.existsSync.mockReturnValue(true);
+    fs.statSync.mockReturnValue({ size: 1024 });
   });
 
-  describe('Title sanitization', () => {
-    function sanitizeTitle(title) {
-      return (title || 'audiobook')
-        .replace(/[<>:"/\\|?*]/g, '')
-        .replace(/\s+/g, ' ')
-        .trim()
-        .substring(0, 100);
-    }
-
-    it('removes invalid filename characters', () => {
-      expect(sanitizeTitle('Test: Book / Part 1')).toBe('Test Book Part 1');
-    });
-
-    it('removes angle brackets', () => {
-      expect(sanitizeTitle('Book <Title>')).toBe('Book Title');
-    });
-
-    it('removes quotes', () => {
-      expect(sanitizeTitle('Book "Title"')).toBe('Book Title');
-    });
-
-    it('normalizes whitespace', () => {
-      expect(sanitizeTitle('Book    Title')).toBe('Book Title');
-    });
-
-    it('trims leading/trailing whitespace', () => {
-      expect(sanitizeTitle('  Book Title  ')).toBe('Book Title');
-    });
-
-    it('truncates to 100 characters', () => {
-      const longTitle = 'A'.repeat(150);
-      expect(sanitizeTitle(longTitle).length).toBe(100);
-    });
-
-    it('uses default for empty title', () => {
-      expect(sanitizeTitle('')).toBe('audiobook');
-    });
-
-    it('uses default for null title', () => {
-      expect(sanitizeTitle(null)).toBe('audiobook');
-    });
+  afterEach(() => {
+    jest.useRealTimers();
+    console.log.mockRestore();
+    console.error.mockRestore();
+    console.warn.mockRestore();
   });
 
-  describe('FFmpeg argument building', () => {
-    function buildFFmpegArgs(job) {
-      const path = require('path');
-
-      if (job.isMultiFile && job.sourceFiles.length > 1) {
-        // Multifile - use concat demuxer
-        return [
-          '-f', 'concat',
-          '-safe', '0',
-          '-i', job.concatListPath,
-          '-vn',
-          '-c:a', 'aac',
-          '-b:a', '128k',
-          '-ar', '44100',
-          '-ac', '1',
-          '-f', 'ipod',
-          '-progress', 'pipe:1',
-          '-y', job.tempPath
-        ];
-      } else if (job.ext === '.m4a' || job.ext === '.mp4') {
-        // M4A/MP4 - stream copy
-        return [
-          '-i', job.sourceFiles[0].path,
-          '-c', 'copy',
-          '-f', 'ipod',
-          '-y', job.tempPath
-        ];
-      } else {
-        // MP3, OGG, FLAC - re-encode to AAC
-        return [
-          '-i', job.sourceFiles[0].path,
-          '-vn',
-          '-c:a', 'aac',
-          '-b:a', '128k',
-          '-ar', '44100',
-          '-ac', '1',
-          '-f', 'ipod',
-          '-progress', 'pipe:1',
-          '-y', job.tempPath
-        ];
-      }
-    }
-
-    it('builds stream copy args for M4A', () => {
-      const job = {
-        isMultiFile: false,
-        sourceFiles: [{ path: '/test/book.m4a' }],
-        tempPath: '/test/output.m4b',
-        ext: '.m4a',
-      };
-
-      const args = buildFFmpegArgs(job);
-
-      expect(args).toContain('-c');
-      expect(args).toContain('copy');
-      expect(args).toContain('-f');
-      expect(args).toContain('ipod');
+  describe('getJobStatus', () => {
+    test('returns null for non-existent job', () => {
+      const result = conversionService.getJobStatus('non-existent-id');
+      expect(result).toBeNull();
     });
 
-    it('builds re-encode args for MP3', () => {
-      const job = {
-        isMultiFile: false,
-        sourceFiles: [{ path: '/test/book.mp3' }],
-        tempPath: '/test/output.m4b',
-        ext: '.mp3',
-      };
-
-      const args = buildFFmpegArgs(job);
-
-      expect(args).toContain('-c:a');
-      expect(args).toContain('aac');
-      expect(args).toContain('-b:a');
-      expect(args).toContain('128k');
-    });
-
-    it('builds concat args for multifile', () => {
-      const job = {
-        isMultiFile: true,
-        sourceFiles: [
-          { path: '/test/ch1.mp3' },
-          { path: '/test/ch2.mp3' },
-        ],
-        tempPath: '/test/output.m4b',
-        concatListPath: '/test/concat.txt',
-        ext: '.mp3',
-      };
-
-      const args = buildFFmpegArgs(job);
-
-      expect(args).toContain('-f');
-      expect(args).toContain('concat');
-      expect(args).toContain('-safe');
-      expect(args).toContain('0');
-    });
-
-    it('includes output format ipod for M4B compatibility', () => {
-      const job = {
-        isMultiFile: false,
-        sourceFiles: [{ path: '/test/book.mp3' }],
-        tempPath: '/test/output.m4b',
-        ext: '.mp3',
-      };
-
-      const args = buildFFmpegArgs(job);
-
-      expect(args).toContain('-f');
-      expect(args).toContain('ipod');
-    });
-
-    it('includes overwrite flag', () => {
-      const job = {
-        isMultiFile: false,
-        sourceFiles: [{ path: '/test/book.mp3' }],
-        tempPath: '/test/output.m4b',
-        ext: '.mp3',
-      };
-
-      const args = buildFFmpegArgs(job);
-
-      expect(args).toContain('-y');
-    });
-  });
-
-  describe('Job status structure', () => {
-    function createJobStatus(job) {
-      return {
-        id: job.id,
-        audiobookId: job.audiobookId,
-        audiobookTitle: job.audiobookTitle,
-        status: job.status,
-        progress: job.progress,
-        message: job.message,
-        error: job.error,
-        startedAt: job.startedAt,
-        completedAt: job.completedAt,
-      };
-    }
-
-    it('includes all required fields', () => {
-      const job = {
-        id: 'test-123',
+    test('returns job status for existing job', () => {
+      // Create a mock job
+      conversionService.jobs.set('test-job-id', {
+        id: 'test-job-id',
         audiobookId: 1,
         audiobookTitle: 'Test Book',
         status: 'converting',
         progress: 50,
-        message: 'Converting: 50%',
+        message: 'Converting...',
         error: null,
-        startedAt: new Date().toISOString(),
-        completedAt: null,
+        startedAt: '2024-01-15T10:00:00Z',
+        completedAt: null
+      });
+
+      const result = conversionService.getJobStatus('test-job-id');
+
+      expect(result).toEqual({
+        id: 'test-job-id',
+        audiobookId: 1,
+        audiobookTitle: 'Test Book',
+        status: 'converting',
+        progress: 50,
+        message: 'Converting...',
+        error: null,
+        startedAt: '2024-01-15T10:00:00Z',
+        completedAt: null
+      });
+    });
+  });
+
+  describe('getActiveJobs', () => {
+    test('returns empty array when no jobs', () => {
+      const result = conversionService.getActiveJobs();
+      expect(result).toEqual([]);
+    });
+
+    test('returns only active jobs', () => {
+      conversionService.jobs.set('job-1', {
+        id: 'job-1',
+        audiobookId: 1,
+        status: 'converting',
+        progress: 50,
+        message: 'Converting...'
+      });
+      conversionService.jobs.set('job-2', {
+        id: 'job-2',
+        audiobookId: 2,
+        status: 'completed',
+        progress: 100,
+        message: 'Done'
+      });
+      conversionService.jobs.set('job-3', {
+        id: 'job-3',
+        audiobookId: 3,
+        status: 'starting',
+        progress: 0,
+        message: 'Starting...'
+      });
+
+      const result = conversionService.getActiveJobs();
+
+      expect(result.length).toBe(2);
+      expect(result.map(j => j.id)).toContain('job-1');
+      expect(result.map(j => j.id)).toContain('job-3');
+      expect(result.map(j => j.id)).not.toContain('job-2');
+    });
+  });
+
+  describe('getActiveJobForAudiobook', () => {
+    test('returns null when no active job for audiobook', () => {
+      const result = conversionService.getActiveJobForAudiobook(999);
+      expect(result).toBeNull();
+    });
+
+    test('returns active job for audiobook', () => {
+      conversionService.jobs.set('job-1', {
+        id: 'job-1',
+        audiobookId: 5,
+        status: 'converting',
+        progress: 30,
+        message: 'Converting...'
+      });
+
+      const result = conversionService.getActiveJobForAudiobook(5);
+
+      expect(result).not.toBeNull();
+      expect(result.id).toBe('job-1');
+      expect(result.audiobookId).toBe(5);
+    });
+
+    test('ignores completed jobs', () => {
+      conversionService.jobs.set('job-1', {
+        id: 'job-1',
+        audiobookId: 5,
+        status: 'completed',
+        progress: 100,
+        message: 'Done'
+      });
+
+      const result = conversionService.getActiveJobForAudiobook(5);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('cancelJob', () => {
+    test('returns error for non-existent job', () => {
+      const result = conversionService.cancelJob('non-existent');
+      expect(result.error).toBe('Job not found');
+    });
+
+    test('returns error for completed job', () => {
+      conversionService.jobs.set('job-1', {
+        id: 'job-1',
+        status: 'completed'
+      });
+
+      const result = conversionService.cancelJob('job-1');
+      expect(result.error).toBe('Job already finished');
+    });
+
+    test('returns error for failed job', () => {
+      conversionService.jobs.set('job-1', {
+        id: 'job-1',
+        status: 'failed'
+      });
+
+      const result = conversionService.cancelJob('job-1');
+      expect(result.error).toBe('Job already finished');
+    });
+
+    test('cancels active job successfully', () => {
+      const mockProcess = { kill: jest.fn() };
+      conversionService.jobs.set('job-1', {
+        id: 'job-1',
+        audiobookId: 1,
+        status: 'converting',
+        process: mockProcess,
+        dir: '/test/dir',
+        tempPath: '/test/temp.m4b',
+        tempCoverPath: '/test/cover.jpg',
+        concatListPath: '/test/concat.txt'
+      });
+      conversionService.activeConversions.add('/test/dir');
+
+      const result = conversionService.cancelJob('job-1');
+
+      expect(result.success).toBe(true);
+      expect(mockProcess.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(websocketManager.broadcastJobUpdate).toHaveBeenCalled();
+    });
+
+    test('cancels job without process', () => {
+      conversionService.jobs.set('job-1', {
+        id: 'job-1',
+        audiobookId: 1,
+        status: 'starting',
+        process: null,
+        dir: '/test/dir'
+      });
+      conversionService.activeConversions.add('/test/dir');
+
+      const result = conversionService.cancelJob('job-1');
+
+      expect(result.success).toBe(true);
+      expect(conversionService.activeConversions.has('/test/dir')).toBe(false);
+    });
+  });
+
+  describe('isDirectoryLocked', () => {
+    test('returns false for unlocked directory', () => {
+      expect(conversionService.isDirectoryLocked('/unlocked/dir')).toBe(false);
+    });
+
+    test('returns true for locked directory', () => {
+      conversionService.activeConversions.add('/locked/dir');
+      expect(conversionService.isDirectoryLocked('/locked/dir')).toBe(true);
+    });
+  });
+
+  describe('cleanupStaleJobs', () => {
+    test('removes old completed jobs', () => {
+      const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+      conversionService.jobs.set('old-job', {
+        id: 'old-job',
+        status: 'completed',
+        startedAt: twoHoursAgo
+      });
+
+      conversionService.cleanupStaleJobs();
+
+      expect(conversionService.jobs.has('old-job')).toBe(false);
+    });
+
+    test('removes old failed jobs', () => {
+      const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+      conversionService.jobs.set('old-job', {
+        id: 'old-job',
+        status: 'failed',
+        startedAt: twoHoursAgo
+      });
+
+      conversionService.cleanupStaleJobs();
+
+      expect(conversionService.jobs.has('old-job')).toBe(false);
+    });
+
+    test('keeps recent completed jobs', () => {
+      const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+      conversionService.jobs.set('recent-job', {
+        id: 'recent-job',
+        status: 'completed',
+        startedAt: tenMinutesAgo
+      });
+
+      conversionService.cleanupStaleJobs();
+
+      expect(conversionService.jobs.has('recent-job')).toBe(true);
+    });
+
+    test('fails stuck jobs', () => {
+      const mockProcess = { kill: jest.fn() };
+      const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+      conversionService.jobs.set('stuck-job', {
+        id: 'stuck-job',
+        audiobookId: 1,
+        status: 'converting',
+        process: mockProcess,
+        dir: '/test/dir',
+        startedAt: threeHoursAgo
+      });
+      conversionService.activeConversions.add('/test/dir');
+
+      conversionService.cleanupStaleJobs();
+
+      const job = conversionService.jobs.get('stuck-job');
+      expect(job.status).toBe('failed');
+      expect(job.error).toBe('Conversion timed out');
+      expect(mockProcess.kill).toHaveBeenCalledWith('SIGTERM');
+    });
+  });
+
+  describe('cleanupJobFiles', () => {
+    test('cleans up temp files when they exist', () => {
+      fs.existsSync.mockReturnValue(true);
+      const job = {
+        tempPath: '/test/temp.m4b',
+        tempCoverPath: '/test/cover.jpg',
+        concatListPath: '/test/concat.txt'
       };
 
-      const status = createJobStatus(job);
+      conversionService.cleanupJobFiles(job);
 
-      expect(status).toHaveProperty('id', 'test-123');
-      expect(status).toHaveProperty('audiobookId', 1);
-      expect(status).toHaveProperty('status', 'converting');
-      expect(status).toHaveProperty('progress', 50);
+      expect(fs.unlinkSync).toHaveBeenCalledWith('/test/temp.m4b');
+    });
+
+    test('handles cleanup errors gracefully', () => {
+      fs.existsSync.mockReturnValue(true);
+      fs.unlinkSync.mockImplementation(() => {
+        throw new Error('Permission denied');
+      });
+      const job = {
+        tempPath: '/test/temp.m4b'
+      };
+
+      // Should not throw
+      expect(() => conversionService.cleanupJobFiles(job)).not.toThrow();
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to clean up'),
+        expect.any(String)
+      );
+    });
+
+    test('skips non-existent files', () => {
+      fs.existsSync.mockReturnValue(false);
+      const job = {
+        tempPath: '/test/temp.m4b',
+        tempCoverPath: '/test/cover.jpg'
+      };
+
+      conversionService.cleanupJobFiles(job);
+
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
     });
   });
 
-  describe('Progress calculation', () => {
-    function calculateProgress(currentTime, totalDuration) {
-      // Progress is scaled to 10-90% range for conversion phase
-      const rawProgress = Math.min((currentTime / totalDuration) * 100, 100);
-      return Math.round(10 + (rawProgress * 0.8));
-    }
+  describe('broadcastJobStatus', () => {
+    test('broadcasts job status via websocket', () => {
+      const job = {
+        id: 'job-1',
+        audiobookId: 1,
+        audiobookTitle: 'Test Book',
+        status: 'converting',
+        progress: 50,
+        message: 'Converting...',
+        error: null
+      };
 
-    it('starts at 10%', () => {
-      expect(calculateProgress(0, 3600)).toBe(10);
-    });
+      conversionService.broadcastJobStatus(job);
 
-    it('ends at 90%', () => {
-      expect(calculateProgress(3600, 3600)).toBe(90);
-    });
-
-    it('calculates middle progress correctly', () => {
-      // 50% raw = 10 + (50 * 0.8) = 10 + 40 = 50
-      expect(calculateProgress(1800, 3600)).toBe(50);
-    });
-
-    it('does not exceed 90% during conversion', () => {
-      expect(calculateProgress(4000, 3600)).toBe(90);
-    });
-  });
-
-  describe('Stale job detection', () => {
-    function isJobStale(startedAt, maxAgeHours = 2) {
-      const startTime = new Date(startedAt).getTime();
-      const maxAge = maxAgeHours * 60 * 60 * 1000;
-      return Date.now() - startTime > maxAge;
-    }
-
-    it('returns false for recent job', () => {
-      const recentStart = new Date().toISOString();
-      expect(isJobStale(recentStart)).toBe(false);
-    });
-
-    it('returns true for job older than 2 hours', () => {
-      const oldStart = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
-      expect(isJobStale(oldStart)).toBe(true);
-    });
-
-    it('uses custom max age', () => {
-      const oneHourAgo = new Date(Date.now() - 1.5 * 60 * 60 * 1000).toISOString();
-      expect(isJobStale(oneHourAgo, 1)).toBe(true);
-      expect(isJobStale(oneHourAgo, 2)).toBe(false);
+      expect(websocketManager.broadcastJobUpdate).toHaveBeenCalledWith(
+        'conversion',
+        'converting',
+        {
+          jobId: 'job-1',
+          audiobookId: 1,
+          audiobookTitle: 'Test Book',
+          progress: 50,
+          message: 'Converting...',
+          error: null
+        }
+      );
     });
   });
 
-  describe('Concat list file generation', () => {
-    function generateConcatList(sourceFiles) {
-      return sourceFiles
-        .map(f => `file '${f.path.replace(/'/g, "'\\''")}'`)
-        .join('\n');
-    }
+  describe('startConversion', () => {
+    test('returns error for M4B file', async () => {
+      const audiobook = {
+        id: 1,
+        title: 'Test Book',
+        file_path: '/test/book.m4b',
+        is_multi_file: false
+      };
+      const mockDb = {};
 
-    it('generates correct format', () => {
-      const files = [
-        { path: '/test/ch1.mp3' },
-        { path: '/test/ch2.mp3' },
-      ];
+      const result = await conversionService.startConversion(audiobook, mockDb);
 
-      const content = generateConcatList(files);
-
-      expect(content).toBe("file '/test/ch1.mp3'\nfile '/test/ch2.mp3'");
+      expect(result.error).toBe('File is already M4B format');
     });
 
-    it('escapes single quotes in paths', () => {
-      const files = [
-        { path: "/test/book's chapter.mp3" },
-      ];
+    test('returns error for unsupported format', async () => {
+      const audiobook = {
+        id: 1,
+        title: 'Test Book',
+        file_path: '/test/book.wav',
+        is_multi_file: false
+      };
+      const mockDb = {};
 
-      const content = generateConcatList(files);
+      const result = await conversionService.startConversion(audiobook, mockDb);
 
-      expect(content).toContain("\\'");
+      expect(result.error).toContain('Unsupported format');
+    });
+
+    test('returns error when file not found', async () => {
+      fs.existsSync.mockReturnValue(false);
+      const audiobook = {
+        id: 1,
+        title: 'Test Book',
+        file_path: '/test/book.mp3',
+        is_multi_file: false
+      };
+      const mockDb = {};
+
+      const result = await conversionService.startConversion(audiobook, mockDb);
+
+      expect(result.error).toContain('Audio file not found');
+    });
+
+    test('starts conversion for valid single file', async () => {
+      fs.existsSync.mockReturnValue(true);
+      spawn.mockReturnValue({
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        on: jest.fn((event, cb) => {
+          if (event === 'close') setTimeout(() => cb(0), 10);
+        })
+      });
+
+      const audiobook = {
+        id: 1,
+        title: 'Test Book',
+        file_path: '/test/book.mp3',
+        duration: 3600,
+        is_multi_file: false
+      };
+      const mockDb = {
+        run: jest.fn((query, params, cb) => cb && cb(null))
+      };
+
+      const result = await conversionService.startConversion(audiobook, mockDb);
+
+      expect(result.jobId).toBeDefined();
+      expect(result.status).toBe('started');
+      expect(conversionService.jobs.has(result.jobId)).toBe(true);
+    });
+
+    test('handles multifile audiobook with chapters', async () => {
+      fs.existsSync.mockReturnValue(true);
+      spawn.mockReturnValue({
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        on: jest.fn()
+      });
+
+      const audiobook = {
+        id: 1,
+        title: 'Test Book',
+        file_path: '/test/chapter1.mp3',
+        duration: 3600,
+        is_multi_file: 1
+      };
+      const mockDb = {
+        all: jest.fn((query, params, cb) => cb(null, [
+          { file_path: '/test/chapter1.mp3', duration: 1800, title: 'Chapter 1' },
+          { file_path: '/test/chapter2.mp3', duration: 1800, title: 'Chapter 2' }
+        ])),
+        run: jest.fn((query, params, cb) => cb && cb(null))
+      };
+
+      const result = await conversionService.startConversion(audiobook, mockDb);
+
+      expect(result.jobId).toBeDefined();
+      expect(result.status).toBe('started');
+    });
+
+    test('treats multifile as single when no chapters found', async () => {
+      fs.existsSync.mockReturnValue(true);
+      spawn.mockReturnValue({
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        on: jest.fn()
+      });
+
+      const audiobook = {
+        id: 1,
+        title: 'Test Book',
+        file_path: '/test/book.mp3',
+        duration: 3600,
+        is_multi_file: 1
+      };
+      const mockDb = {
+        all: jest.fn((query, params, cb) => cb(null, [])), // No chapters
+        run: jest.fn((query, params, cb) => cb && cb(null))
+      };
+
+      const result = await conversionService.startConversion(audiobook, mockDb);
+
+      expect(result.jobId).toBeDefined();
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('treating as single file')
+      );
+    });
+  });
+
+  describe('buildFFmpegArgs', () => {
+    test('builds concat args for multifile', async () => {
+      const job = {
+        isMultiFile: true,
+        sourceFiles: [
+          { path: '/test/ch1.mp3' },
+          { path: '/test/ch2.mp3' }
+        ],
+        tempPath: '/test/output.m4b',
+        concatListPath: '/test/concat.txt',
+        ext: '.mp3'
+      };
+
+      const args = await conversionService.buildFFmpegArgs(job);
+
+      expect(args).toContain('-f');
+      expect(args).toContain('concat');
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/test/concat.txt',
+        expect.stringContaining("file '/test/ch1.mp3'")
+      );
+    });
+
+    test('builds copy args for M4A', async () => {
+      const job = {
+        isMultiFile: false,
+        sourceFiles: [{ path: '/test/book.m4a' }],
+        tempPath: '/test/output.m4b',
+        ext: '.m4a'
+      };
+
+      const args = await conversionService.buildFFmpegArgs(job);
+
+      expect(args).toContain('-c');
+      expect(args).toContain('copy');
+    });
+
+    test('builds re-encode args for MP3', async () => {
+      const job = {
+        isMultiFile: false,
+        sourceFiles: [{ path: '/test/book.mp3' }],
+        tempPath: '/test/output.m4b',
+        ext: '.mp3'
+      };
+
+      const args = await conversionService.buildFFmpegArgs(job);
+
+      expect(args).toContain('-c:a');
+      expect(args).toContain('aac');
+    });
+  });
+
+  describe('shutdown', () => {
+    test('kills active processes and cleans up', () => {
+      const mockProcess = { kill: jest.fn() };
+      conversionService.jobs.set('job-1', {
+        id: 'job-1',
+        process: mockProcess,
+        tempPath: '/test/temp.m4b'
+      });
+
+      conversionService.shutdown();
+
+      expect(mockProcess.kill).toHaveBeenCalledWith('SIGTERM');
+    });
+
+    test('handles jobs without process', () => {
+      conversionService.jobs.set('job-1', {
+        id: 'job-1',
+        process: null,
+        tempPath: '/test/temp.m4b'
+      });
+      fs.existsSync.mockReturnValue(true);
+
+      // Should not throw
+      expect(() => conversionService.shutdown()).not.toThrow();
+    });
+  });
+
+  describe('runFFmpegWithProgress', () => {
+    test('resolves on successful conversion', async () => {
+      const mockStdout = { on: jest.fn() };
+      const mockStderr = { on: jest.fn() };
+      let closeCallback;
+
+      spawn.mockReturnValue({
+        stdout: mockStdout,
+        stderr: mockStderr,
+        on: jest.fn((event, cb) => {
+          if (event === 'close') closeCallback = cb;
+        })
+      });
+
+      const job = {
+        id: 'job-1',
+        process: null,
+        progress: 10,
+        message: ''
+      };
+
+      const promise = conversionService.runFFmpegWithProgress(job, ['-i', 'input.mp3']);
+
+      // Simulate successful close
+      closeCallback(0);
+
+      await expect(promise).resolves.toBeUndefined();
+    });
+
+    test('rejects on ffmpeg error', async () => {
+      const mockStdout = { on: jest.fn() };
+      const mockStderr = { on: jest.fn() };
+      let closeCallback;
+
+      spawn.mockReturnValue({
+        stdout: mockStdout,
+        stderr: mockStderr,
+        on: jest.fn((event, cb) => {
+          if (event === 'close') closeCallback = cb;
+        })
+      });
+
+      const job = {
+        id: 'job-1',
+        process: null,
+        progress: 10,
+        message: ''
+      };
+
+      const promise = conversionService.runFFmpegWithProgress(job, ['-i', 'input.mp3']);
+
+      // Simulate failure
+      closeCallback(1);
+
+      await expect(promise).rejects.toThrow('FFmpeg exited with code 1');
+    });
+
+    test('rejects on spawn error', async () => {
+      const mockStdout = { on: jest.fn() };
+      const mockStderr = { on: jest.fn() };
+      let errorCallback;
+
+      spawn.mockReturnValue({
+        stdout: mockStdout,
+        stderr: mockStderr,
+        on: jest.fn((event, cb) => {
+          if (event === 'error') errorCallback = cb;
+        })
+      });
+
+      const job = {
+        id: 'job-1',
+        process: null,
+        progress: 10,
+        message: ''
+      };
+
+      const promise = conversionService.runFFmpegWithProgress(job, ['-i', 'input.mp3']);
+
+      // Simulate spawn error
+      errorCallback(new Error('Spawn failed'));
+
+      await expect(promise).rejects.toThrow('Spawn failed');
+    });
+
+    test('parses duration from stderr', async () => {
+      const mockStdout = { on: jest.fn() };
+      let stderrCallback;
+      let closeCallback;
+
+      spawn.mockReturnValue({
+        stdout: mockStdout,
+        stderr: {
+          on: jest.fn((event, cb) => {
+            if (event === 'data') stderrCallback = cb;
+          })
+        },
+        on: jest.fn((event, cb) => {
+          if (event === 'close') closeCallback = cb;
+        })
+      });
+
+      const job = {
+        id: 'job-1',
+        process: null,
+        progress: 10,
+        message: ''
+      };
+
+      const promise = conversionService.runFFmpegWithProgress(job, ['-i', 'input.mp3']);
+
+      // Simulate duration output
+      stderrCallback(Buffer.from('Duration: 01:30:00.00, start: 0.000000'));
+
+      closeCallback(0);
+
+      await promise;
+      expect(console.log).toHaveBeenCalledWith('Conversion duration: 5400s');
+    });
+
+    test('parses progress from stdout', async () => {
+      let stdoutCallback;
+      let stderrCallback;
+      let closeCallback;
+
+      spawn.mockReturnValue({
+        stdout: {
+          on: jest.fn((event, cb) => {
+            if (event === 'data') stdoutCallback = cb;
+          })
+        },
+        stderr: {
+          on: jest.fn((event, cb) => {
+            if (event === 'data') stderrCallback = cb;
+          })
+        },
+        on: jest.fn((event, cb) => {
+          if (event === 'close') closeCallback = cb;
+        })
+      });
+
+      const job = {
+        id: 'job-1',
+        audiobookId: 1,
+        audiobookTitle: 'Test',
+        process: null,
+        progress: 10,
+        message: '',
+        error: null
+      };
+
+      const promise = conversionService.runFFmpegWithProgress(job, ['-i', 'input.mp3']);
+
+      // Set duration first
+      stderrCallback(Buffer.from('Duration: 01:00:00.00'));
+
+      // Then progress
+      stdoutCallback(Buffer.from('out_time=00:30:00.00'));
+
+      closeCallback(0);
+
+      await promise;
+      // Progress should be updated (50% raw = 10 + 40 = 50%)
+      expect(job.progress).toBe(50);
+    });
+  });
+
+  describe('extractCoverArt', () => {
+    test('resolves true when cover extracted', async () => {
+      let closeCallback;
+
+      spawn.mockReturnValue({
+        on: jest.fn((event, cb) => {
+          if (event === 'close') closeCallback = cb;
+        })
+      });
+
+      fs.existsSync.mockReturnValue(true);
+      fs.statSync.mockReturnValue({ size: 1024 });
+
+      const job = {
+        sourcePath: '/test/book.mp3',
+        tempCoverPath: '/test/cover.jpg'
+      };
+
+      const promise = conversionService.extractCoverArt(job);
+
+      closeCallback(0);
+
+      const result = await promise;
+      expect(result).toBe(true);
+    });
+
+    test('resolves false when no cover', async () => {
+      let closeCallback;
+
+      spawn.mockReturnValue({
+        on: jest.fn((event, cb) => {
+          if (event === 'close') closeCallback = cb;
+        })
+      });
+
+      fs.existsSync.mockReturnValue(false);
+
+      const job = {
+        sourcePath: '/test/book.mp3',
+        tempCoverPath: '/test/cover.jpg'
+      };
+
+      const promise = conversionService.extractCoverArt(job);
+
+      closeCallback(0);
+
+      const result = await promise;
+      expect(result).toBe(false);
+    });
+
+    test('resolves false on error', async () => {
+      let errorCallback;
+
+      spawn.mockReturnValue({
+        on: jest.fn((event, cb) => {
+          if (event === 'error') errorCallback = cb;
+        })
+      });
+
+      const job = {
+        sourcePath: '/test/book.mp3',
+        tempCoverPath: '/test/cover.jpg'
+      };
+
+      const promise = conversionService.extractCoverArt(job);
+
+      errorCallback(new Error('FFmpeg error'));
+
+      const result = await promise;
+      expect(result).toBe(false);
+    });
+
+    test('resolves false on timeout', async () => {
+      spawn.mockReturnValue({
+        kill: jest.fn(),
+        on: jest.fn() // Never calls callbacks
+      });
+
+      const job = {
+        sourcePath: '/test/book.mp3',
+        tempCoverPath: '/test/cover.jpg'
+      };
+
+      const promise = conversionService.extractCoverArt(job);
+
+      // Advance timers past the 30 second timeout
+      jest.advanceTimersByTime(31000);
+
+      const result = await promise;
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('embedCoverArt', () => {
+    test('resolves true when cover embedded', async () => {
+      let closeCallback;
+
+      spawn.mockReturnValue({
+        on: jest.fn((event, cb) => {
+          if (event === 'close') closeCallback = cb;
+        })
+      });
+
+      fs.existsSync.mockReturnValue(true);
+
+      const job = {
+        tempPath: '/test/output.m4b',
+        tempCoverPath: '/test/cover.jpg'
+      };
+
+      const promise = conversionService.embedCoverArt(job);
+
+      closeCallback(0);
+
+      const result = await promise;
+      expect(result).toBe(true);
+      expect(fs.unlinkSync).toHaveBeenCalledWith('/test/cover.jpg');
+    });
+
+    test('resolves false on tone error', async () => {
+      let closeCallback;
+
+      spawn.mockReturnValue({
+        on: jest.fn((event, cb) => {
+          if (event === 'close') closeCallback = cb;
+        })
+      });
+
+      fs.existsSync.mockReturnValue(true);
+
+      const job = {
+        tempPath: '/test/output.m4b',
+        tempCoverPath: '/test/cover.jpg'
+      };
+
+      const promise = conversionService.embedCoverArt(job);
+
+      closeCallback(1); // Non-zero exit
+
+      const result = await promise;
+      expect(result).toBe(false);
+    });
+
+    test('resolves false on spawn error', async () => {
+      let errorCallback;
+
+      spawn.mockReturnValue({
+        on: jest.fn((event, cb) => {
+          if (event === 'error') errorCallback = cb;
+        })
+      });
+
+      const job = {
+        tempPath: '/test/output.m4b',
+        tempCoverPath: '/test/cover.jpg'
+      };
+
+      const promise = conversionService.embedCoverArt(job);
+
+      errorCallback(new Error('Tone error'));
+
+      const result = await promise;
+      expect(result).toBe(false);
+    });
+
+    test('resolves false on timeout', async () => {
+      spawn.mockReturnValue({
+        kill: jest.fn(),
+        on: jest.fn()
+      });
+
+      const job = {
+        tempPath: '/test/output.m4b',
+        tempCoverPath: '/test/cover.jpg'
+      };
+
+      const promise = conversionService.embedCoverArt(job);
+
+      // Advance past 60 second timeout
+      jest.advanceTimersByTime(61000);
+
+      const result = await promise;
+      expect(result).toBe(false);
     });
   });
 });

--- a/tests/unit/extractCovers.test.js
+++ b/tests/unit/extractCovers.test.js
@@ -183,5 +183,39 @@ describe('extractCovers script', () => {
 
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Processing complete'));
     }, 15000); // Increase timeout for this test
+
+    test('logs no cover found for books without cover', async () => {
+      const mockBooks = [
+        { id: 1, file_path: '/audiobooks/book1.m4b' }
+      ];
+
+      db.all.mockImplementation((query, callback) => {
+        callback(null, mockBooks);
+      });
+
+      await processAllAudiobooks();
+
+      // Since we can't mock the dynamic import, extractCoverFromFile returns null
+      // which triggers the "no cover found" log
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('No cover found')
+      );
+    }, 15000);
+
+    test('logs processing complete with correct counts', async () => {
+      const mockBooks = [
+        { id: 1, file_path: '/audiobooks/book1.m4b' },
+        { id: 2, file_path: '/audiobooks/book2.m4b' }
+      ];
+
+      db.all.mockImplementation((query, callback) => {
+        callback(null, mockBooks);
+      });
+
+      await processAllAudiobooks();
+
+      expect(console.log).toHaveBeenCalledWith('Total: 2');
+      expect(console.log).toHaveBeenCalledWith('Processed: 2');
+    }, 15000);
   });
 });


### PR DESCRIPTION
## Summary

- Rewrote `backupService.test.js` to properly mock dependencies and test actual service functions (93.33% coverage, was 0%)
- Rewrote `conversionService.test.js` to properly mock dependencies and test actual service functions (80.47% coverage, was 0%)
- Added additional test cases to `extractCovers.test.js`

The previous test files re-implemented functions locally instead of importing from the actual services, resulting in 0% coverage despite having many tests.

## Coverage improvements

| Service | Before | After |
|---------|--------|-------|
| backupService.js | 0% | 93.33% |
| conversionService.js | 0% | 80.47% |

## Test plan

- [x] All unit tests pass (671 tests)
- [x] All integration tests pass (766 tests)
- [x] Coverage meets 80%+ threshold for both services
- [x] No memory issues with test execution

Addresses #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)