### PR TITLE
Improve progress bar scrubbing with seek preview tooltip

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -1422,6 +1422,36 @@
     z-index: 2;
   }
 
+  /* Mobile seek preview tooltip - use fixed positioning to escape overflow:hidden */
+  .seek-preview-tooltip {
+    position: fixed;
+    bottom: calc(90px + env(safe-area-inset-bottom, 0) + 24px);
+    left: calc(var(--preview-percent, 0%) * (100vw - 24px) / 100% + 12px);
+    padding: 10px 16px;
+    font-size: 18px;
+    border-radius: 10px;
+    margin-bottom: 0;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.5);
+    z-index: 9999;
+  }
+
+  .seek-preview-tooltip::after {
+    display: none;
+  }
+
+  .player-progress.seeking .progress-thumb {
+    transform: translate(-50%, -50%) scale(1.5);
+    width: 16px;
+    height: 16px;
+  }
+
+  /* Mobile fullscreen seek tooltip */
+  .fullscreen-seek-tooltip {
+    padding: 12px 20px;
+    font-size: 20px;
+    border-radius: 12px;
+  }
+
   .time-display {
     display: none;
   }
@@ -1845,4 +1875,172 @@
 .chapter-modal-time {
   color: #9ca3af;
   font-size: 0.875rem;
+}
+
+/* Seek Preview Tooltip Styles - uses fixed positioning for visibility */
+.seek-preview-tooltip {
+  position: fixed;
+  bottom: 130px;
+  left: calc(var(--preview-percent, 0%) * (100vw - 40px) / 100% + 20px);
+  transform: translateX(-50%);
+  background: rgba(59, 130, 246, 0.95);
+  color: #fff;
+  padding: 8px 14px;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 9999;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  animation: tooltipFadeIn 0.15s ease-out;
+}
+
+.seek-preview-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: rgba(59, 130, 246, 0.95);
+}
+
+.fullscreen-seek-tooltip {
+  position: absolute;
+  bottom: calc(100% + 16px);
+  left: calc(var(--preview-percent, 0%));
+  transform: translateX(-50%);
+  background: rgba(59, 130, 246, 0.95);
+  color: #fff;
+  padding: 10px 18px;
+  border-radius: 10px;
+  font-size: 18px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 100;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  animation: tooltipFadeIn 0.15s ease-out;
+}
+
+.fullscreen-seek-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 8px solid transparent;
+  border-top-color: rgba(59, 130, 246, 0.95);
+}
+
+@keyframes tooltipFadeIn {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+/* Seeking state styles */
+.player-progress.seeking .progress-thumb {
+  transform: translate(-50%, -50%) scale(1.3);
+  box-shadow: 0 0 12px rgba(59, 130, 246, 0.6);
+}
+
+/* Disable transitions during seeking for immediate response */
+.player-progress.seeking::after {
+  transition: none !important;
+}
+
+.player-progress.seeking .progress-thumb {
+  transition: none !important;
+}
+
+.fullscreen-progress.seeking .fullscreen-slider::-webkit-slider-thumb {
+  transform: scale(1.2);
+  box-shadow: 0 0 16px rgba(59, 130, 246, 0.6);
+  transition: none !important;
+}
+
+.fullscreen-progress.seeking .fullscreen-slider::-moz-range-thumb {
+  transform: scale(1.2);
+  box-shadow: 0 0 16px rgba(59, 130, 246, 0.6);
+  transition: none !important;
+}
+
+/* Disable track transitions during seeking */
+.fullscreen-progress.seeking .fullscreen-slider::-webkit-slider-runnable-track {
+  transition: none !important;
+}
+
+.fullscreen-progress.seeking .fullscreen-slider::-moz-range-track {
+  transition: none !important;
+}
+
+/* Make fullscreen-progress position relative for tooltip positioning */
+.fullscreen-progress {
+  position: relative;
+}
+
+/* Fullscreen title marquee for long titles */
+.fullscreen-title-wrapper {
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.fullscreen-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #fff;
+  margin: 0 0 0.5rem 0;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.fullscreen-title-text {
+  display: inline-block;
+  white-space: nowrap;
+  animation: fullscreenMarquee 15s linear infinite;
+}
+
+.fullscreen-title-spacer {
+  padding: 0 1rem;
+  opacity: 0.5;
+}
+
+@keyframes fullscreenMarquee {
+  0% {
+    transform: translateX(0%);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}
+
+/* On mobile, make title smaller */
+@media (max-width: 768px) {
+  .fullscreen-title {
+    font-size: 1.4rem;
+  }
+}
+
+/* Smoother slider transitions */
+.fullscreen-slider {
+  touch-action: none;
+}
+
+.fullscreen-slider::-webkit-slider-thumb {
+  transition: transform 0.1s ease-out, box-shadow 0.1s ease-out;
+}
+
+.fullscreen-slider::-moz-range-thumb {
+  transition: transform 0.1s ease-out, box-shadow 0.1s ease-out;
 }


### PR DESCRIPTION
## Summary
- Add seek preview tooltip that shows target time while scrubbing progress bars
- Delay actual seek until finger/mouse is lifted (matches Android app behavior)
- Fix "catching" sensation when changing scrub directions by preventing timeupdate re-renders during drag and disabling CSS transitions
- Add marquee animation for long titles in fullscreen player

## Test plan
- [ ] Test mini player progress bar scrubbing - should show tooltip and only seek on release
- [ ] Test fullscreen player slider scrubbing - should show tooltip and only seek on release
- [ ] Verify no "catching" when rapidly changing scrub directions
- [ ] Verify long titles in fullscreen player scroll with marquee animation
- [ ] Test on both desktop and mobile/PWA

🤖 Generated with [Claude Code](https://claude.com/claude-code)