### PR TITLE
Add conditional marquee animation and fix chapter modal in fullscreen

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -469,6 +469,9 @@
 .fullscreen-title-content {
   display: inline-block;
   white-space: nowrap;
+}
+
+.fullscreen-title.marquee .fullscreen-title-content {
   animation: marquee 45s linear infinite;
 }
 
@@ -946,6 +949,9 @@
   .marquee-content {
     display: inline-block;
     white-space: nowrap;
+  }
+
+  .player-title.marquee .marquee-content {
     animation: marquee 20s linear infinite;
   }
 
@@ -1306,6 +1312,9 @@
   .marquee-content {
     display: inline-block;
     white-space: nowrap;
+  }
+
+  .player-title.marquee .marquee-content {
     animation: marquee 20s linear infinite;
   }
 


### PR DESCRIPTION
## Summary
- Only animate marquee when title overflows container (short titles stay static)
- Detect overflow by measuring title width vs container width
- Move chapter modal outside audio-player div so it works in fullscreen mode
- Fix overflow detection timing for fullscreen player

## Test plan
- [ ] Short titles should not scroll in mini player
- [ ] Short titles should not scroll in fullscreen player
- [ ] Long titles should scroll with marquee animation
- [ ] Chapter button in fullscreen should open chapter list

🤖 Generated with [Claude Code](https://claude.com/claude-code)