### PR TITLE
Fix iOS player layout and move collections/reading list to browse

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -380,7 +380,7 @@
   width: 100%;
   max-width: 600px;
   padding: 3rem 2rem 2rem 2rem;
-  padding-bottom: calc(6rem + env(safe-area-inset-bottom, 0));
+  padding-bottom: calc(7rem + env(safe-area-inset-bottom, 0));
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1234,7 +1234,6 @@
   /* Compact mobile player bar */
   .audio-player {
     padding: 0 !important;
-    padding-bottom: env(safe-area-inset-bottom, 0) !important;
     z-index: 1002 !important;
     bottom: 0 !important;
     left: 0 !important;
@@ -1244,18 +1243,18 @@
     margin: 0 !important;
     box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.3) !important;
     position: fixed !important;
-    height: calc(90px + env(safe-area-inset-bottom, 0)) !important;
-    max-height: calc(90px + env(safe-area-inset-bottom, 0)) !important;
+    height: 90px !important;
+    max-height: 90px !important;
     overflow: hidden !important;
     transform: none !important;
+    /* iOS safe area handled by padding inside, not on container */
   }
 
-  /* iOS: ensure player is truly docked to bottom */
+  /* iOS: ensure player is truly docked to bottom with no gap */
   @supports (-webkit-touch-callout: none) {
     .audio-player {
-      /* Use padding-bottom for safe area, not margin */
-      padding-bottom: env(safe-area-inset-bottom) !important;
-      /* Ensure no gap at bottom */
+      /* No padding-bottom on container - it goes on content inside */
+      padding-bottom: 0 !important;
       margin-bottom: 0 !important;
       bottom: 0 !important;
     }
@@ -1622,7 +1621,7 @@
 
   .fullscreen-content {
     padding: 5rem 1rem 1rem 1rem;
-    padding-bottom: calc(6rem + env(safe-area-inset-bottom, 0));
+    padding-bottom: calc(7rem + env(safe-area-inset-bottom, 0));
   }
 
   .fullscreen-cover {

--- a/client/src/pages/Library.css
+++ b/client/src/pages/Library.css
@@ -228,6 +228,18 @@
   color: #fff;
 }
 
+.category-icon-wrapper.reading-list {
+  background: linear-gradient(135deg, #f59e0b 0%, #fbbf24 100%);
+  box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
+  color: #fff;
+}
+
+.category-icon-wrapper.collections {
+  background: linear-gradient(135deg, #8b5cf6 0%, #a855f7 100%);
+  box-shadow: 0 4px 15px rgba(139, 92, 246, 0.3);
+  color: #fff;
+}
+
 .category-icon-wrapper.favorites {
   background: linear-gradient(135deg, #facc15 0%, #f59e0b 100%);
   box-shadow: 0 4px 15px rgba(250, 204, 21, 0.3);

--- a/client/src/pages/Library.jsx
+++ b/client/src/pages/Library.jsx
@@ -234,8 +234,6 @@ export default function Library({ onPlay }) {
 
   const tabs = [
     { id: 'browse', label: 'Browse', count: stats.totalBooks },
-    { id: 'reading-list', label: 'Reading List', count: stats.totalFavorites },
-    { id: 'collections', label: 'Collections', count: stats.totalCollections },
   ];
 
   if (isAdmin) {
@@ -426,6 +424,74 @@ export default function Library({ onPlay }) {
                 <div className="category-text">
                   <h3>Genres</h3>
                   <p>Browse by category</p>
+                </div>
+                <div className="category-arrow">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M5 12h14M12 5l7 7-7 7" />
+                  </svg>
+                </div>
+              </div>
+            </div>
+
+            {/* Reading List Card */}
+            <div
+              className="category-card"
+              onClick={() => { setActiveTab('reading-list'); loadFavorites(); }}
+            >
+              <div className="category-card-bg">
+                <svg viewBox="0 0 200 200" className="category-bg-pattern">
+                  <defs>
+                    <linearGradient id="grad-reading" x1="0%" y1="0%" x2="100%" y2="100%">
+                      <stop offset="0%" stopColor="#f59e0b" stopOpacity="0.3" />
+                      <stop offset="100%" stopColor="#fbbf24" stopOpacity="0.1" />
+                    </linearGradient>
+                  </defs>
+                  <circle cx="160" cy="40" r="70" fill="url(#grad-reading)" />
+                </svg>
+              </div>
+              <div className="category-card-content">
+                <div className="category-icon-wrapper reading-list">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                    <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+                  </svg>
+                </div>
+                <div className="category-text">
+                  <h3>Reading List</h3>
+                  <p>{stats.totalFavorites} saved</p>
+                </div>
+                <div className="category-arrow">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M5 12h14M12 5l7 7-7 7" />
+                  </svg>
+                </div>
+              </div>
+            </div>
+
+            {/* Collections Card */}
+            <div
+              className="category-card"
+              onClick={() => { setActiveTab('collections'); loadCollections(); }}
+            >
+              <div className="category-card-bg">
+                <svg viewBox="0 0 200 200" className="category-bg-pattern">
+                  <defs>
+                    <linearGradient id="grad-collections" x1="0%" y1="0%" x2="100%" y2="100%">
+                      <stop offset="0%" stopColor="#8b5cf6" stopOpacity="0.3" />
+                      <stop offset="100%" stopColor="#a855f7" stopOpacity="0.1" />
+                    </linearGradient>
+                  </defs>
+                  <circle cx="150" cy="50" r="65" fill="url(#grad-collections)" />
+                </svg>
+              </div>
+              <div className="category-card-content">
+                <div className="category-icon-wrapper collections">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                    <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+                  </svg>
+                </div>
+                <div className="category-text">
+                  <h3>Collections</h3>
+                  <p>{stats.totalCollections} collections</p>
                 </div>
                 <div className="category-arrow">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">


### PR DESCRIPTION
## Summary
- Fix iOS mini player gap at bottom by removing extra safe area padding
- Fix fullscreen bottom bar overlapping seek thumb (increased content padding)
- Move Collections and Reading List from tabs to category cards in Browse section

## Test plan
- [ ] iOS: Mini player should snap to bottom with no gap
- [ ] iOS: Fullscreen bottom bar should not overlap the seek thumb
- [ ] Library Browse tab now shows Collections and Reading List as cards
- [ ] Clicking the cards switches to their respective views

🤖 Generated with [Claude Code](https://claude.com/claude-code)