### PR TITLE
Fix iOS mini player docking and library navigation

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -73,7 +73,7 @@ body {
     height: 100%;
     min-height: 100%;
     padding: 0;
-    padding-bottom: env(safe-area-inset-bottom, 0);
+    /* No padding-bottom here - let fixed elements handle their own safe area */
   }
 
   #root {

--- a/client/src/pages/Library.css
+++ b/client/src/pages/Library.css
@@ -748,6 +748,58 @@
   margin-bottom: 1.5rem;
 }
 
+/* Section Header with Back Button */
+.section-header-with-back {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #374151;
+}
+
+.section-header-with-back h2 {
+  flex: 1;
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.back-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: rgba(55, 65, 81, 0.5);
+  border: 1px solid #4b5563;
+  border-radius: 8px;
+  color: #9ca3af;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.back-btn:hover {
+  background: rgba(75, 85, 99, 0.5);
+  color: #fff;
+}
+
+.back-btn:active {
+  transform: scale(0.98);
+}
+
+.back-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.btn-new-collection {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+}
+
 .collections-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));

--- a/client/src/pages/Library.jsx
+++ b/client/src/pages/Library.jsx
@@ -290,6 +290,74 @@ export default function Library({ onPlay }) {
         {/* Browse Tab */}
         {activeTab === 'browse' && (
           <div className="library-categories">
+            {/* Reading List Card */}
+            <div
+              className="category-card"
+              onClick={() => { setActiveTab('reading-list'); loadFavorites(); }}
+            >
+              <div className="category-card-bg">
+                <svg viewBox="0 0 200 200" className="category-bg-pattern">
+                  <defs>
+                    <linearGradient id="grad-reading-top" x1="0%" y1="0%" x2="100%" y2="100%">
+                      <stop offset="0%" stopColor="#f59e0b" stopOpacity="0.3" />
+                      <stop offset="100%" stopColor="#fbbf24" stopOpacity="0.1" />
+                    </linearGradient>
+                  </defs>
+                  <circle cx="160" cy="40" r="70" fill="url(#grad-reading-top)" />
+                </svg>
+              </div>
+              <div className="category-card-content">
+                <div className="category-icon-wrapper reading-list">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                    <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+                  </svg>
+                </div>
+                <div className="category-text">
+                  <h3>Reading List</h3>
+                  <p>{stats.totalFavorites} saved</p>
+                </div>
+                <div className="category-arrow">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M5 12h14M12 5l7 7-7 7" />
+                  </svg>
+                </div>
+              </div>
+            </div>
+
+            {/* Collections Card */}
+            <div
+              className="category-card"
+              onClick={() => { setActiveTab('collections'); loadCollections(); }}
+            >
+              <div className="category-card-bg">
+                <svg viewBox="0 0 200 200" className="category-bg-pattern">
+                  <defs>
+                    <linearGradient id="grad-collections-top" x1="0%" y1="0%" x2="100%" y2="100%">
+                      <stop offset="0%" stopColor="#8b5cf6" stopOpacity="0.3" />
+                      <stop offset="100%" stopColor="#a855f7" stopOpacity="0.1" />
+                    </linearGradient>
+                  </defs>
+                  <circle cx="150" cy="50" r="65" fill="url(#grad-collections-top)" />
+                </svg>
+              </div>
+              <div className="category-card-content">
+                <div className="category-icon-wrapper collections">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                    <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+                  </svg>
+                </div>
+                <div className="category-text">
+                  <h3>Collections</h3>
+                  <p>{stats.totalCollections} collections</p>
+                </div>
+                <div className="category-arrow">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M5 12h14M12 5l7 7-7 7" />
+                  </svg>
+                </div>
+              </div>
+            </div>
+
             {/* All Books - Featured Card */}
             <div
               className="category-card featured"
@@ -433,79 +501,21 @@ export default function Library({ onPlay }) {
               </div>
             </div>
 
-            {/* Reading List Card */}
-            <div
-              className="category-card"
-              onClick={() => { setActiveTab('reading-list'); loadFavorites(); }}
-            >
-              <div className="category-card-bg">
-                <svg viewBox="0 0 200 200" className="category-bg-pattern">
-                  <defs>
-                    <linearGradient id="grad-reading" x1="0%" y1="0%" x2="100%" y2="100%">
-                      <stop offset="0%" stopColor="#f59e0b" stopOpacity="0.3" />
-                      <stop offset="100%" stopColor="#fbbf24" stopOpacity="0.1" />
-                    </linearGradient>
-                  </defs>
-                  <circle cx="160" cy="40" r="70" fill="url(#grad-reading)" />
-                </svg>
-              </div>
-              <div className="category-card-content">
-                <div className="category-icon-wrapper reading-list">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-                    <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
-                  </svg>
-                </div>
-                <div className="category-text">
-                  <h3>Reading List</h3>
-                  <p>{stats.totalFavorites} saved</p>
-                </div>
-                <div className="category-arrow">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <path d="M5 12h14M12 5l7 7-7 7" />
-                  </svg>
-                </div>
-              </div>
-            </div>
-
-            {/* Collections Card */}
-            <div
-              className="category-card"
-              onClick={() => { setActiveTab('collections'); loadCollections(); }}
-            >
-              <div className="category-card-bg">
-                <svg viewBox="0 0 200 200" className="category-bg-pattern">
-                  <defs>
-                    <linearGradient id="grad-collections" x1="0%" y1="0%" x2="100%" y2="100%">
-                      <stop offset="0%" stopColor="#8b5cf6" stopOpacity="0.3" />
-                      <stop offset="100%" stopColor="#a855f7" stopOpacity="0.1" />
-                    </linearGradient>
-                  </defs>
-                  <circle cx="150" cy="50" r="65" fill="url(#grad-collections)" />
-                </svg>
-              </div>
-              <div className="category-card-content">
-                <div className="category-icon-wrapper collections">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-                    <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
-                  </svg>
-                </div>
-                <div className="category-text">
-                  <h3>Collections</h3>
-                  <p>{stats.totalCollections} collections</p>
-                </div>
-                <div className="category-arrow">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <path d="M5 12h14M12 5l7 7-7 7" />
-                  </svg>
-                </div>
-              </div>
-            </div>
           </div>
         )}
 
         {/* Reading List Tab */}
         {activeTab === 'reading-list' && (
           <div className="reading-list-content">
+            <div className="section-header-with-back">
+              <button className="back-btn" onClick={() => setActiveTab('browse')}>
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M19 12H5M12 19l-7-7 7-7" />
+                </svg>
+                Library
+              </button>
+              <h2>Reading List</h2>
+            </div>
             {loadingFavorites ? (
               <div className="loading">Loading your reading list...</div>
             ) : favorites.length === 0 ? (
@@ -548,9 +558,16 @@ export default function Library({ onPlay }) {
         {/* Collections Tab */}
         {activeTab === 'collections' && (
           <div className="collections-content">
-            <div className="collections-header-inline">
-              <button className="btn btn-primary" onClick={() => setShowCreateModal(true)}>
-                + New Collection
+            <div className="section-header-with-back">
+              <button className="back-btn" onClick={() => setActiveTab('browse')}>
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M19 12H5M12 19l-7-7 7-7" />
+                </svg>
+                Library
+              </button>
+              <h2>Collections</h2>
+              <button className="btn btn-primary btn-new-collection" onClick={() => setShowCreateModal(true)}>
+                + New
               </button>
             </div>
 


### PR DESCRIPTION
## Summary
- Remove body padding-bottom that was pushing mini player up on iOS
- Move Reading List and Collections cards to top of Browse section
- Add back navigation headers to Reading List and Collections views

## Test plan
- [ ] iOS: Mini player should dock to bottom with no gap
- [ ] Library: Reading List and Collections cards appear first
- [ ] Library: Back button in Reading List/Collections returns to Browse

🤖 Generated with [Claude Code](https://claude.com/claude-code)