### PR TITLE
Fix iOS mini player safe area and responsive stats bar

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -28,12 +28,12 @@
     }
   }
 
-  /* Add bottom padding when player is present */
+  /* Add bottom padding when player is present - no safe area here, player handles it */
   .app.player-active {
-    padding-bottom: calc(70px + env(safe-area-inset-bottom, 0));
+    padding-bottom: 90px;
   }
 
   .app.player-active .main-content {
-    padding-bottom: calc(70px + env(safe-area-inset-bottom, 0));
+    padding-bottom: 90px;
   }
 }

--- a/client/src/pages/Library.css
+++ b/client/src/pages/Library.css
@@ -45,6 +45,7 @@
   border-radius: 16px;
   margin-bottom: 2rem;
   backdrop-filter: blur(10px);
+  flex-wrap: nowrap;
 }
 
 .stat-item {
@@ -52,26 +53,49 @@
   flex-direction: column;
   align-items: center;
   gap: 0.25rem;
+  flex-shrink: 0;
 }
 
 .stat-value {
-  font-size: 1.5rem;
+  font-size: clamp(1rem, 4vw, 1.5rem);
   font-weight: 700;
   color: #fff;
   line-height: 1;
+  white-space: nowrap;
 }
 
 .stat-label {
-  font-size: 0.75rem;
+  font-size: clamp(0.6rem, 2.5vw, 0.75rem);
   color: #9ca3af;
   text-transform: uppercase;
   letter-spacing: 0.5px;
+  white-space: nowrap;
 }
 
 .stat-divider {
   width: 1px;
   height: 32px;
   background: linear-gradient(180deg, transparent 0%, #374151 50%, transparent 100%);
+  flex-shrink: 0;
+}
+
+@media (max-width: 400px) {
+  .library-stats-bar {
+    gap: 0.75rem;
+    padding: 1rem 0.75rem;
+  }
+
+  .stat-value {
+    font-size: 0.9rem;
+  }
+
+  .stat-label {
+    font-size: 0.55rem;
+  }
+
+  .stat-divider {
+    height: 24px;
+  }
 }
 
 /* Tab Bar */


### PR DESCRIPTION
## Summary
- Remove safe-area-inset-bottom from app container padding (player handles its own safe area)
- Make library stats bar responsive with clamp() font sizes
- Prevent stats from wrapping to next line

## Test plan
- [ ] iOS: Mini player docks to bottom with no gap
- [ ] Library stats bar doesn't wrap on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)