### PR TITLE
Fix iOS PWA mini player safe area

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -28,12 +28,12 @@
     }
   }
 
-  /* Add bottom padding when player is present - no safe area here, player handles it */
+  /* Add bottom padding when player is present - include safe area since player extends into it */
   .app.player-active {
-    padding-bottom: 90px;
+    padding-bottom: calc(90px + env(safe-area-inset-bottom, 0));
   }
 
   .app.player-active .main-content {
-    padding-bottom: 90px;
+    padding-bottom: calc(90px + env(safe-area-inset-bottom, 0));
   }
 }

--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -1234,6 +1234,7 @@
   /* Compact mobile player bar */
   .audio-player {
     padding: 0 !important;
+    padding-bottom: env(safe-area-inset-bottom, 0) !important;
     z-index: 1002 !important;
     bottom: 0 !important;
     left: 0 !important;
@@ -1243,21 +1244,11 @@
     margin: 0 !important;
     box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.3) !important;
     position: fixed !important;
-    height: 90px !important;
-    max-height: 90px !important;
+    height: auto !important;
+    max-height: none !important;
+    min-height: 90px !important;
     overflow: hidden !important;
     transform: none !important;
-    /* iOS safe area handled by padding inside, not on container */
-  }
-
-  /* iOS: ensure player is truly docked to bottom with no gap */
-  @supports (-webkit-touch-callout: none) {
-    .audio-player {
-      /* No padding-bottom on container - it goes on content inside */
-      padding-bottom: 0 !important;
-      margin-bottom: 0 !important;
-      bottom: 0 !important;
-    }
   }
 
   .player-info {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -44,8 +44,8 @@ body {
   transition: background-color 0.3s, color 0.3s;
   /* Prevent pull-to-refresh on mobile */
   overscroll-behavior-y: contain;
-  /* Support safe areas on notched devices */
-  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+  /* Only apply horizontal safe area padding, not bottom */
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) 0 env(safe-area-inset-left);
 }
 
 #root {


### PR DESCRIPTION
## Summary
- Remove bottom safe area padding from body
- Player extends into safe area with internal padding
- Player background fills to screen edge on iOS

## Test plan
- [ ] iOS PWA: Mini player should dock to very bottom with no gap
- [ ] Player content should still be above home indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)