### PR TITLE
Fix Android mini player gap caused by safe-area-inset-bottom

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -28,12 +28,23 @@
     }
   }
 
-  /* Add bottom padding when player is present - include safe area since player extends into it */
+  /* Add bottom padding when player is present */
   .app.player-active {
-    padding-bottom: calc(90px + env(safe-area-inset-bottom, 0));
+    padding-bottom: 90px;
   }
 
   .app.player-active .main-content {
-    padding-bottom: calc(90px + env(safe-area-inset-bottom, 0));
+    padding-bottom: 90px;
+  }
+
+  /* iOS only: include safe area since player extends into it */
+  @supports (-webkit-touch-callout: none) {
+    .app.player-active {
+      padding-bottom: calc(90px + env(safe-area-inset-bottom, 0));
+    }
+
+    .app.player-active .main-content {
+      padding-bottom: calc(90px + env(safe-area-inset-bottom, 0));
+    }
   }
 }

--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -1234,7 +1234,6 @@
   /* Compact mobile player bar */
   .audio-player {
     padding: 0 !important;
-    padding-bottom: env(safe-area-inset-bottom, 0) !important;
     z-index: 1002 !important;
     bottom: 0 !important;
     left: 0 !important;
@@ -1249,6 +1248,13 @@
     min-height: 90px !important;
     overflow: hidden !important;
     transform: none !important;
+  }
+
+  /* iOS only: add safe area padding for home indicator */
+  @supports (-webkit-touch-callout: none) {
+    .audio-player {
+      padding-bottom: env(safe-area-inset-bottom, 0) !important;
+    }
   }
 
   .player-info {


### PR DESCRIPTION
## Summary
- Fixes mini player hovering above the gesture bar on Android PWA
- Uses `@supports (-webkit-touch-callout: none)` to only apply safe-area-inset-bottom padding on iOS
- Android devices now have no safe area padding, allowing the player to dock directly to the screen bottom

## Changes
- `AudioPlayer.css`: Moved safe area padding inside iOS-only `@supports` block
- `App.css`: Split player-active padding - base 90px for all, plus safe area only on iOS

## Test plan
- [ ] Test on Android PWA - mini player should dock to bottom without gap
- [ ] Test on iOS PWA - mini player should still respect home indicator safe area

🤖 Generated with [Claude Code](https://claude.com/claude-code)