### PR TITLE
Remove all safe-area-inset-bottom padding from mini player

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -36,15 +36,4 @@
   .app.player-active .main-content {
     padding-bottom: 90px;
   }
-
-  /* iOS only: include safe area since player extends into it */
-  @supports (-webkit-touch-callout: none) {
-    .app.player-active {
-      padding-bottom: calc(90px + env(safe-area-inset-bottom, 0));
-    }
-
-    .app.player-active .main-content {
-      padding-bottom: calc(90px + env(safe-area-inset-bottom, 0));
-    }
-  }
 }

--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -1250,13 +1250,6 @@
     transform: none !important;
   }
 
-  /* iOS only: add safe area padding for home indicator */
-  @supports (-webkit-touch-callout: none) {
-    .audio-player {
-      padding-bottom: env(safe-area-inset-bottom, 0) !important;
-    }
-  }
-
   .player-info {
     padding: 20px 12px 12px 12px !important;
     margin-bottom: 0 !important;


### PR DESCRIPTION
## Summary
- Removes all safe-area-inset-bottom padding from the mini player on both iOS and Android
- Player now docks directly to the screen bottom without any gap

## Changes
- `AudioPlayer.css`: Removed iOS-only `@supports` block for safe area padding
- `App.css`: Removed iOS-only `@supports` block for player-active padding

## Test plan
- [ ] Test on Android PWA - mini player should dock to bottom
- [ ] Test on iOS PWA - mini player should dock to bottom (may overlap home indicator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)