### PR TITLE
Force mini player to dock to screen bottom

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -379,8 +379,7 @@
 .fullscreen-content {
   width: 100%;
   max-width: 600px;
-  padding: 3rem 2rem 2rem 2rem;
-  padding-bottom: calc(7rem + env(safe-area-inset-bottom, 0));
+  padding: 3rem 2rem 7rem 2rem;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1231,23 +1230,27 @@
 }
 
 @media (max-width: 768px) {
-  /* Compact mobile player bar */
+  /* Compact mobile player bar - force dock to screen bottom */
   .audio-player {
-    padding: 0 !important;
-    z-index: 1002 !important;
+    position: fixed !important;
+    inset: auto 0 0 0 !important;
     bottom: 0 !important;
     left: 0 !important;
     right: 0 !important;
-    border-bottom: none !important;
-    border-top: 1px solid #2a2a2a !important;
+    top: auto !important;
+    padding: 0 !important;
     margin: 0 !important;
-    box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.3) !important;
-    position: fixed !important;
-    height: auto !important;
-    max-height: none !important;
+    border: none !important;
+    border-top: 1px solid #2a2a2a !important;
+    border-bottom: none !important;
+    height: 90px !important;
     min-height: 90px !important;
+    max-height: 90px !important;
+    z-index: 1002 !important;
+    box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.3) !important;
     overflow: hidden !important;
     transform: none !important;
+    -webkit-transform: none !important;
   }
 
   .player-info {
@@ -1610,8 +1613,7 @@
   }
 
   .fullscreen-content {
-    padding: 5rem 1rem 1rem 1rem;
-    padding-bottom: calc(7rem + env(safe-area-inset-bottom, 0));
+    padding: 5rem 1rem 7rem 1rem;
   }
 
   .fullscreen-cover {
@@ -2032,7 +2034,6 @@
   justify-content: space-around;
   align-items: center;
   padding: 1rem 2rem;
-  padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0));
   background: rgba(0, 0, 0, 0.8);
   border-top: 1px solid rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);


### PR DESCRIPTION
## Summary
- Forces mini player to dock directly to screen bottom on iOS and Android
- Uses `inset: auto 0 0 0` for more explicit positioning
- Sets fixed height: 90px instead of auto/min-height
- Removes all safe-area-inset-bottom from fullscreen elements

## Changes
- Mini player: explicit positioning with inset, fixed height, no transforms
- Fullscreen content: removed safe-area-inset-bottom padding
- Fullscreen bottom bar: removed safe-area-inset-bottom padding

## Test plan
- [ ] Test mini player on Android PWA - should dock to very bottom
- [ ] Test mini player on iOS PWA - should dock to very bottom  
- [ ] Test fullscreen player bottom bar - should be at screen bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)