### PR TITLE
Simplify player bottom docking and bump cache version

### DIFF
--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -18,7 +18,7 @@ self.addEventListener('activate', (event) => {
 });
 
 // Service Worker for Sappho PWA
-const CACHE_NAME = 'sappho-v1.5.0';
+const CACHE_NAME = 'sappho-v1.5.1';
 const urlsToCache = [
   '/',
   '/index.html',

--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -1230,27 +1230,27 @@
 }
 
 @media (max-width: 768px) {
-  /* Compact mobile player bar - force dock to screen bottom */
+  /* Compact mobile player bar - dock to screen bottom */
   .audio-player {
     position: fixed !important;
-    inset: auto 0 0 0 !important;
-    bottom: 0 !important;
     left: 0 !important;
     right: 0 !important;
+    bottom: 0 !important;
     top: auto !important;
+    width: 100% !important;
+    height: 90px !important;
     padding: 0 !important;
     margin: 0 !important;
     border: none !important;
     border-top: 1px solid #2a2a2a !important;
-    border-bottom: none !important;
-    height: 90px !important;
-    min-height: 90px !important;
-    max-height: 90px !important;
     z-index: 1002 !important;
     box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.3) !important;
     overflow: hidden !important;
     transform: none !important;
     -webkit-transform: none !important;
+    /* Try to break out of any safe area constraints */
+    -webkit-box-sizing: border-box !important;
+    box-sizing: border-box !important;
   }
 
   .player-info {


### PR DESCRIPTION
## Summary
- Simplifies player CSS to just bottom: 0 with no safe-area handling
- Bumps service worker cache version to force refresh on devices

## Changes
- AudioPlayer.css: Simple fixed positioning with bottom: 0
- sw.js: Cache version v1.5.0 → v1.5.1

## Test plan
- [ ] Clear PWA cache on iOS and test mini player position
- [ ] Test on Android PWA

**Note**: You may need to close and reopen the PWA for cache to refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)