### PR TITLE
Fix iOS safe area: extend player into safe area per Apple guidelines

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -28,12 +28,12 @@
     }
   }
 
-  /* Add bottom padding when player is present */
+  /* Add bottom padding when player is present - matches player height including safe area */
   .app.player-active {
-    padding-bottom: 90px;
+    padding-bottom: calc(90px + env(safe-area-inset-bottom, 0));
   }
 
   .app.player-active .main-content {
-    padding-bottom: 90px;
+    padding-bottom: calc(90px + env(safe-area-inset-bottom, 0));
   }
 }

--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -1230,7 +1230,7 @@
 }
 
 @media (max-width: 768px) {
-  /* Compact mobile player bar - dock to screen bottom */
+  /* Compact mobile player bar - extends into safe area so background touches screen edge */
   .audio-player {
     position: fixed !important;
     left: 0 !important;
@@ -1238,8 +1238,10 @@
     bottom: 0 !important;
     top: auto !important;
     width: 100% !important;
-    height: 90px !important;
-    padding: 0 !important;
+    /* Extend height INTO safe area - background will cover home indicator */
+    height: calc(90px + env(safe-area-inset-bottom, 0)) !important;
+    /* Padding keeps content above home indicator */
+    padding: 0 0 env(safe-area-inset-bottom, 0) 0 !important;
     margin: 0 !important;
     border: none !important;
     border-top: 1px solid #2a2a2a !important;
@@ -1248,8 +1250,6 @@
     overflow: hidden !important;
     transform: none !important;
     -webkit-transform: none !important;
-    /* Try to break out of any safe area constraints */
-    -webkit-box-sizing: border-box !important;
     box-sizing: border-box !important;
   }
 
@@ -2024,7 +2024,7 @@
   font-size: 0.875rem;
 }
 
-/* Fullscreen Bottom Bar */
+/* Fullscreen Bottom Bar - extends into safe area */
 .fullscreen-bottom-bar {
   position: fixed;
   bottom: 0;
@@ -2033,7 +2033,8 @@
   display: flex;
   justify-content: space-around;
   align-items: center;
-  padding: 1rem 2rem;
+  /* Extend into safe area - content padding keeps buttons above home indicator */
+  padding: 1rem 2rem calc(1rem + env(safe-area-inset-bottom, 0)) 2rem;
   background: rgba(0, 0, 0, 0.8);
   border-top: 1px solid rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);


### PR DESCRIPTION
## Summary
Per [Apple's PWA documentation](https://developer.apple.com/forums/thread/110854) and [CSS-Tricks](https://css-tricks.com/the-notch-and-css/), the correct approach for fixed bottom elements is to **extend INTO the safe area**, not avoid it.

## The Fix
```css
.audio-player {
  /* Extend height INTO safe area - background covers home indicator */
  height: calc(90px + env(safe-area-inset-bottom, 0));
  /* Padding keeps content above home indicator */
  padding-bottom: env(safe-area-inset-bottom, 0);
}
```

This way:
- Player **background** extends to the screen edge (no gap)
- Player **content** (buttons, controls) stays in the 90px area above the home indicator

## Changes
- AudioPlayer.css: Mini player extends into safe area
- AudioPlayer.css: Fullscreen bottom bar extends into safe area  
- App.css: Content padding matches player height including safe area

## Test plan
- [ ] iOS PWA: Player background should touch screen bottom, buttons above home indicator
- [ ] Android: Should work the same (safe-area-inset-bottom is 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)