### PR TITLE
Shift player down into safe area with negative bottom

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -28,12 +28,12 @@
     }
   }
 
-  /* Add bottom padding when player is present - matches player height including safe area */
+  /* Add bottom padding when player is present */
   .app.player-active {
-    padding-bottom: calc(90px + env(safe-area-inset-bottom, 0));
+    padding-bottom: 90px;
   }
 
   .app.player-active .main-content {
-    padding-bottom: calc(90px + env(safe-area-inset-bottom, 0));
+    padding-bottom: 90px;
   }
 }

--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -1230,16 +1230,16 @@
 }
 
 @media (max-width: 768px) {
-  /* Compact mobile player bar - extends into safe area so background touches screen edge */
+  /* Compact mobile player bar - shift down into safe area */
   .audio-player {
     position: fixed !important;
     left: 0 !important;
     right: 0 !important;
-    bottom: 0 !important;
+    /* Negative bottom shifts player DOWN into safe area */
+    bottom: calc(-1 * env(safe-area-inset-bottom, 0)) !important;
     top: auto !important;
     width: 100% !important;
-    /* Extend height INTO safe area - background will cover home indicator */
-    height: calc(90px + env(safe-area-inset-bottom, 0)) !important;
+    height: 90px !important;
     padding: 0 !important;
     margin: 0 !important;
     border: none !important;


### PR DESCRIPTION
## Summary
Uses negative bottom value to shift player DOWN into safe area instead of extending height.

```css
bottom: calc(-1 * env(safe-area-inset-bottom, 0))
```

## Test plan
- [ ] Test on iOS - player should shift down to screen edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)