### PR TITLE
Use transform to shift player, increase z-index

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -1230,13 +1230,12 @@
 }
 
 @media (max-width: 768px) {
-  /* Compact mobile player bar - shift down into safe area */
+  /* Compact mobile player bar - use transform to shift into safe area */
   .audio-player {
     position: fixed !important;
     left: 0 !important;
     right: 0 !important;
-    /* Negative bottom shifts player DOWN into safe area */
-    bottom: calc(-1 * env(safe-area-inset-bottom, 0)) !important;
+    bottom: 0 !important;
     top: auto !important;
     width: 100% !important;
     height: 90px !important;
@@ -1244,11 +1243,12 @@
     margin: 0 !important;
     border: none !important;
     border-top: 1px solid #2a2a2a !important;
-    z-index: 1002 !important;
+    z-index: 9999 !important;
     box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.3) !important;
     overflow: hidden !important;
-    transform: none !important;
-    -webkit-transform: none !important;
+    /* Transform shifts player DOWN into safe area */
+    transform: translateY(env(safe-area-inset-bottom, 0)) !important;
+    -webkit-transform: translateY(env(safe-area-inset-bottom, 0)) !important;
     box-sizing: border-box !important;
   }
 


### PR DESCRIPTION
## Summary
- Uses transform: translateY() to shift player down instead of negative bottom
- Increases z-index to 9999 in case something is covering the player

## Test plan
- [ ] Test on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)