### PR TITLE
Fix player z-index ordering

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -350,7 +350,7 @@
   right: 0;
   bottom: 0;
   background: rgba(0, 0, 0, 0.95);
-  z-index: 1000;
+  z-index: 10000;
   display: flex;
   flex-direction: column;
   backdrop-filter: blur(10px);
@@ -1243,7 +1243,7 @@
     margin: 0 !important;
     border: none !important;
     border-top: 1px solid #2a2a2a !important;
-    z-index: 9999 !important;
+    z-index: 1001 !important;
     box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.3) !important;
     overflow: visible !important;
     transform: none !important;


### PR DESCRIPTION
## Summary
Fix z-index so fullscreen player appears in front of mini player.

- Mini player: z-index 1001
- Fullscreen player: z-index 10000

🤖 Generated with [Claude Code](https://claude.com/claude-code)