### PR TITLE
Use dvh for player positioning on iOS

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -1230,13 +1230,17 @@
 }
 
 @media (max-width: 768px) {
-  /* Compact mobile player bar */
+  /* Compact mobile player bar - use dvh for iOS compatibility */
   .audio-player {
     position: fixed !important;
     left: 0 !important;
     right: 0 !important;
-    bottom: 0 !important;
-    top: auto !important;
+    /* Use dvh to position at actual screen bottom, not safe area bottom */
+    bottom: auto !important;
+    top: calc(100dvh - 90px) !important;
+    /* Fallback for browsers without dvh support */
+    top: calc(100vh - 90px) !important;
+    top: calc(100dvh - 90px) !important;
     width: 100% !important;
     height: 90px !important;
     padding: 0 !important;


### PR DESCRIPTION
## Summary
Use `top: calc(100dvh - 90px)` instead of `bottom: 0` to position the player at the actual screen bottom rather than the safe area bottom.

`dvh` (dynamic viewport height) accounts for browser chrome and should work better with iOS PWA safe areas.

## Test plan
- [ ] Test on iOS PWA - player should dock to actual screen bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)