### PR TITLE
Extend player background into safe area with pseudo-element

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -1230,17 +1230,13 @@
 }
 
 @media (max-width: 768px) {
-  /* Compact mobile player bar - use dvh for iOS compatibility */
+  /* Compact mobile player bar - sits at safe area bottom, background extends below */
   .audio-player {
     position: fixed !important;
     left: 0 !important;
     right: 0 !important;
-    /* Use dvh to position at actual screen bottom, not safe area bottom */
-    bottom: auto !important;
-    top: calc(100dvh - 90px) !important;
-    /* Fallback for browsers without dvh support */
-    top: calc(100vh - 90px) !important;
-    top: calc(100dvh - 90px) !important;
+    bottom: 0 !important;
+    top: auto !important;
     width: 100% !important;
     height: 90px !important;
     padding: 0 !important;
@@ -1255,6 +1251,18 @@
     box-sizing: border-box !important;
     pointer-events: auto !important;
     touch-action: auto !important;
+  }
+
+  /* Extend background into safe area (like native apps do) */
+  .audio-player::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 100%;
+    height: env(safe-area-inset-bottom, 0);
+    background: #1a1a1a;
+    pointer-events: none;
   }
 
   /* Ensure all player children receive touches */


### PR DESCRIPTION
## Summary
Uses the same pattern as native iOS apps:
- Player content stays at safe area bottom (interactive)
- `::after` pseudo-element extends background into home indicator area (visual fill)

```css
.audio-player::after {
  content: '';
  position: absolute;
  top: 100%;
  height: env(safe-area-inset-bottom, 0);
  background: #1a1a1a;
}
```

## Test plan
- [ ] Test on iOS - background should extend to screen edge, no gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)