### PR TITLE
Ensure html/body backgrounds extend to screen edges

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -1260,9 +1260,12 @@
     left: 0;
     right: 0;
     top: 100%;
-    height: env(safe-area-inset-bottom, 0);
-    background: #1a1a1a;
+    /* Use 100px to ensure it covers the gap even if env() isn't working */
+    height: 100px;
+    height: env(safe-area-inset-bottom, 100px);
+    background: inherit;
     pointer-events: none;
+    z-index: -1;
   }
 
   /* Ensure all player children receive touches */

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -33,6 +33,13 @@
   -webkit-tap-highlight-color: rgba(20, 184, 166, 0.2);
 }
 
+html {
+  /* Ensure background extends to screen edges */
+  background: var(--bg-primary);
+  min-height: 100%;
+  min-height: 100dvh;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
@@ -46,6 +53,8 @@ body {
   overscroll-behavior-y: contain;
   /* Only apply horizontal safe area padding, not bottom */
   padding: env(safe-area-inset-top) env(safe-area-inset-right) 0 env(safe-area-inset-left);
+  min-height: 100%;
+  min-height: 100dvh;
 }
 
 #root {


### PR DESCRIPTION
## Summary
- Add `min-height: 100dvh` to html and body
- Set html background color to match body
- Update player ::after to inherit background

## Test plan
- [ ] Test on iOS - should have no gap at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)