### PR TITLE
Revert to working player CSS from PR #198

### DIFF
--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -18,7 +18,7 @@ self.addEventListener('activate', (event) => {
 });
 
 // Service Worker for Sappho PWA
-const CACHE_NAME = 'sappho-v1.5.1';
+const CACHE_NAME = 'sappho-v1.5.2';
 const urlsToCache = [
   '/',
   '/index.html',

--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -1230,45 +1230,34 @@
 }
 
 @media (max-width: 768px) {
-  /* Compact mobile player bar - sits at safe area bottom, background extends below */
+  /* Compact mobile player bar - extends into safe area */
   .audio-player {
-    position: fixed !important;
+    padding: 0 !important;
+    padding-bottom: env(safe-area-inset-bottom, 0) !important;
+    z-index: 1002 !important;
+    bottom: 0 !important;
     left: 0 !important;
     right: 0 !important;
-    bottom: 0 !important;
-    top: auto !important;
-    width: 100% !important;
-    height: 90px !important;
-    padding: 0 !important;
-    margin: 0 !important;
-    border: none !important;
+    border-bottom: none !important;
     border-top: 1px solid #2a2a2a !important;
-    z-index: 1001 !important;
+    margin: 0 !important;
     box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.3) !important;
-    overflow: visible !important;
+    position: fixed !important;
+    height: calc(90px + env(safe-area-inset-bottom, 0)) !important;
+    max-height: calc(90px + env(safe-area-inset-bottom, 0)) !important;
+    overflow: hidden !important;
     transform: none !important;
-    -webkit-transform: none !important;
-    box-sizing: border-box !important;
-    pointer-events: auto !important;
-    touch-action: auto !important;
   }
 
-  /* Extend background into safe area (like native apps do) */
-  .audio-player::after {
-    content: '';
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 100%;
-    /* Use 50px to cover the safe area gap */
-    height: 50px;
-    background: #1a1a1a;
-    pointer-events: none;
-  }
-
-  /* Ensure all player children receive touches */
-  .audio-player * {
-    pointer-events: auto !important;
+  /* iOS: ensure player is truly docked to bottom */
+  @supports (-webkit-touch-callout: none) {
+    .audio-player {
+      /* Use padding-bottom for safe area, not margin */
+      padding-bottom: env(safe-area-inset-bottom) !important;
+      /* Ensure no gap at bottom */
+      margin-bottom: 0 !important;
+      bottom: 0 !important;
+    }
   }
 
   .player-info {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -33,13 +33,6 @@
   -webkit-tap-highlight-color: rgba(20, 184, 166, 0.2);
 }
 
-html {
-  /* Ensure background extends to screen edges */
-  background: var(--bg-primary);
-  min-height: 100%;
-  min-height: -webkit-fill-available;
-}
-
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
@@ -51,15 +44,17 @@ body {
   transition: background-color 0.3s, color 0.3s;
   /* Prevent pull-to-refresh on mobile */
   overscroll-behavior-y: contain;
-  /* Only apply horizontal safe area padding, not bottom */
-  padding: env(safe-area-inset-top) env(safe-area-inset-right) 0 env(safe-area-inset-left);
-  min-height: 100%;
-  min-height: -webkit-fill-available;
+  /* Support safe areas on notched devices */
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
 }
 
 #root {
   min-height: 100vh;
   min-height: -webkit-fill-available;
+}
+
+html {
+  background: var(--bg-primary);
 }
 
 .container {
@@ -82,7 +77,7 @@ body {
     height: 100%;
     min-height: 100%;
     padding: 0;
-    /* No padding-bottom here - let fixed elements handle their own safe area */
+    padding-bottom: env(safe-area-inset-bottom, 0);
   }
 
   #root {


### PR DESCRIPTION
## Summary
- Reverts CSS changes made in PRs #199-#218 that caused iOS PWA issues
- Returns to the simpler, proven approach from PR #198
- Player extends into safe area with proper height calculation
- Removes complex pseudo-element and -webkit-fill-available approaches

## Changes
- **AudioPlayer.css**: Use `height: calc(90px + env(safe-area-inset-bottom))` instead of `::after` pseudo-element
- **index.css**: Restore safe area padding on body, remove `-webkit-fill-available` complexity
- **sw.js**: Bump cache version to v1.5.2

## Test plan
- [ ] Test iOS PWA mini player docking
- [ ] Verify no gap at bottom of screen
- [ ] Verify content scrolls properly behind player
- [ ] Test fullscreen player opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)