### PR TITLE
Remove body safe-area padding - let player handle it

### DIFF
--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -18,7 +18,7 @@ self.addEventListener('activate', (event) => {
 });
 
 // Service Worker for Sappho PWA
-const CACHE_NAME = 'sappho-v1.5.2';
+const CACHE_NAME = 'sappho-v1.5.3';
 const urlsToCache = [
   '/',
   '/index.html',

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -77,7 +77,7 @@ html {
     height: 100%;
     min-height: 100%;
     padding: 0;
-    padding-bottom: env(safe-area-inset-bottom, 0);
+    /* No padding-bottom - player handles safe area */
   }
 
   #root {


### PR DESCRIPTION
## Summary
- Remove `padding-bottom: env(safe-area-inset-bottom)` from body on mobile
- Only the player should extend into the safe area
- The body padding was likely creating a visible bar/gap

## Test plan
- [ ] Test iOS PWA - should have no bar at bottom
- [ ] Player should dock to screen edge
- [ ] Content should scroll properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)