### PR TITLE
Prevent iOS elastic overscroll revealing bar

### DIFF
--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -18,7 +18,7 @@ self.addEventListener('activate', (event) => {
 });
 
 // Service Worker for Sappho PWA
-const CACHE_NAME = 'sappho-v1.5.3';
+const CACHE_NAME = 'sappho-v1.5.4';
 const urlsToCache = [
   '/',
   '/index.html',

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -55,6 +55,8 @@ body {
 
 html {
   background: var(--bg-primary);
+  /* Prevent overscroll revealing anything behind */
+  overscroll-behavior: none;
 }
 
 .container {
@@ -65,25 +67,31 @@ html {
 
 @media (max-width: 768px) {
   html {
-    overflow-x: hidden;
-    overflow-y: auto;
+    overflow: hidden;
     height: 100%;
+    /* Prevent elastic bounce */
+    overscroll-behavior: none;
+    position: fixed;
+    width: 100%;
   }
 
   body {
-    overflow-x: hidden;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
+    overflow: hidden;
     height: 100%;
     min-height: 100%;
     padding: 0;
-    /* No padding-bottom - player handles safe area */
+    /* Prevent elastic bounce */
+    overscroll-behavior: none;
+    position: fixed;
+    width: 100%;
   }
 
   #root {
-    min-height: 100%;
+    height: 100%;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
+    /* Only #root scrolls, not html/body */
+    overscroll-behavior-y: contain;
   }
 
   /* Hide scrollbars on mobile */


### PR DESCRIPTION
## Summary
The bar at the bottom can be "dragged" upward - this is iOS elastic overscroll revealing something behind the content.

Fix by:
- Fix html/body in place with `position: fixed` and `overflow: hidden`
- Only #root scrolls with `-webkit-overflow-scrolling: touch`
- Add `overscroll-behavior: none` to prevent elastic bounce

## Test plan
- [ ] Test iOS PWA - dragging should not reveal any bar
- [ ] Scrolling should work normally within the app
- [ ] Player should dock properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)