### PR TITLE
Revert profile stats to vertical layout

### DIFF
--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -18,7 +18,7 @@ self.addEventListener('activate', (event) => {
 });
 
 // Service Worker for Sappho PWA
-const CACHE_NAME = 'sappho-v1.5.42';
+const CACHE_NAME = 'sappho-v1.5.43';
 const urlsToCache = [
   '/',
   '/index.html',

--- a/client/src/pages/Profile.css
+++ b/client/src/pages/Profile.css
@@ -157,9 +157,9 @@
 
 .stat-item {
   display: flex;
-  flex-direction: row;
-  align-items: baseline;
-  gap: 0.35rem;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .stat-number {


### PR DESCRIPTION
## Summary
- Keep stat labels below numbers instead of inline

## Test plan
- [ ] Check profile page stats display vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)