### PR TITLE
Fix chapter mode progress bar seeking to wrong position

### DIFF
--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -18,7 +18,7 @@ self.addEventListener('activate', (event) => {
 });
 
 // Service Worker for Sappho PWA
-const CACHE_NAME = 'sappho-v1.5.45';
+const CACHE_NAME = 'sappho-v1.5.46';
 const urlsToCache = [
   '/',
   '/index.html',

--- a/client/src/components/AudioPlayer.jsx
+++ b/client/src/components/AudioPlayer.jsx
@@ -717,6 +717,19 @@ const AudioPlayer = forwardRef(({ audiobook, progress, onClose }, ref) => {
     const rect = barRef.current.getBoundingClientRect();
     const x = clientX - rect.left;
     const percentage = Math.max(0, Math.min(1, x / rect.width));
+
+    // In chapter mode, seek within the current chapter's time range
+    if (progressDisplayMode === 'chapter' && chapters.length > 0) {
+      const chapter = chapters[currentChapter];
+      const nextChapter = chapters[currentChapter + 1];
+      const chapterStart = chapter?.start_time || 0;
+      const chapterEnd = nextChapter ? nextChapter.start_time : duration;
+      const chapterDuration = chapterEnd - chapterStart;
+      const seekTime = chapterStart + (percentage * chapterDuration);
+      return { time: seekTime, percent: percentage * 100 };
+    }
+
+    // Default: seek within full book duration
     return { time: percentage * duration, percent: percentage * 100 };
   };
 


### PR DESCRIPTION
## Summary
- Fix progress bar seeking in chapter display mode calculating position as percentage of full book instead of chapter duration
- Seeking now stays within the current chapter when in chapter mode

## Test plan
- [ ] Enable chapter progress display mode in profile settings
- [ ] Play an audiobook with chapters
- [ ] Drag to seek on the progress bar
- [ ] Verify seeking stays within the current chapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)