### PR TITLE
Fix PWA playback delay after hard close

### DIFF
--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -18,7 +18,7 @@ self.addEventListener('activate', (event) => {
 });
 
 // Service Worker for Sappho PWA
-const CACHE_NAME = 'sappho-v1.5.46';
+const CACHE_NAME = 'sappho-v1.5.47';
 const urlsToCache = [
   '/',
   '/index.html',
@@ -69,6 +69,13 @@ self.addEventListener('fetch', (event) => {
 
   // Skip cross-origin requests
   if (!event.request.url.startsWith(self.location.origin)) {
+    return;
+  }
+
+  // IMPORTANT: Never cache API requests - they contain auth tokens and dynamic data
+  // This includes streams, progress updates, and all authenticated endpoints
+  if (event.request.url.includes('/api/')) {
+    event.respondWith(fetch(event.request));
     return;
   }
 


### PR DESCRIPTION
## Summary
- Service worker was caching all same-origin requests including API endpoints
- This caused stale auth tokens and progress data to be served after users hard-closed and reopened the PWA
- Added explicit bypass for `/api/` routes to ensure fresh data on every API request

## Problem
Users reported having to wait several minutes for playback to work after hard-closing and reopening the app. The service worker cache was serving stale API responses.

## Solution
Added a check in the fetch event handler to skip caching for any request to `/api/` endpoints, ensuring authentication and progress data is always fresh from the server.

## Test plan
- [ ] Hard close PWA on iOS/Android
- [ ] Reopen app
- [ ] Verify playback works immediately without delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)