### PR TITLE
Fix admin-only buttons visible to non-admin users

### DIFF
--- a/client/src/components/BatchActionBar.jsx
+++ b/client/src/components/BatchActionBar.jsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import { getCollections, batchMarkFinished, batchClearProgress, batchAddToReadingList, batchAddToCollection, batchDelete } from '../api';
+import { getCollections, batchMarkFinished, batchClearProgress, batchAddToReadingList, batchAddToCollection } from '../api';
 import './BatchActionBar.css';
 
-export default function BatchActionBar({ selectedIds, onActionComplete, onClose, isAdmin }) {
+export default function BatchActionBar({ selectedIds, onActionComplete, onClose }) {
   const [showCollectionPicker, setShowCollectionPicker] = useState(false);
   const [collections, setCollections] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -65,19 +65,6 @@ export default function BatchActionBar({ selectedIds, onActionComplete, onClose,
       onActionComplete('Added to collection');
     } catch (error) {
       alert('Failed to add to collection: ' + (error.response?.data?.error || error.message));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleDelete = async () => {
-    if (!confirm(`DELETE ${count} book${count !== 1 ? 's' : ''}? This cannot be undone!`)) return;
-    setLoading(true);
-    try {
-      await batchDelete(selectedIds, false);
-      onActionComplete('Deleted');
-    } catch (error) {
-      alert('Failed to delete: ' + (error.response?.data?.error || error.message));
     } finally {
       setLoading(false);
     }

--- a/client/src/pages/AllBooks.jsx
+++ b/client/src/pages/AllBooks.jsx
@@ -550,7 +550,6 @@ export default function AllBooks({ onPlay }) {
                 setSelectedIds(new Set());
                 setSelectionMode(false);
               }}
-              isAdmin={isAdmin}
             />
           )}
         </>

--- a/client/src/pages/AudiobookDetail.jsx
+++ b/client/src/pages/AudiobookDetail.jsx
@@ -566,18 +566,22 @@ export default function AudiobookDetail({ onPlay }) {
             )}
             <button className="btn btn-secondary" onClick={handleDownload}>Export</button>
             <DownloadButton audiobook={audiobook} />
-            <button
-              className={`btn btn-refresh ${refreshingMetadata ? 'loading' : ''}`}
-              onClick={handleRefreshMetadata}
-              disabled={refreshingMetadata}
-              title="Re-scan file and update metadata"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={refreshingMetadata ? 'spinning' : ''}>
-                <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
-              </svg>
-              {refreshingMetadata ? 'Refreshing...' : 'Refresh'}
-            </button>
-            <button className="btn btn-danger" onClick={handleDelete}>Delete</button>
+            {isAdmin && (
+              <button
+                className={`btn btn-refresh ${refreshingMetadata ? 'loading' : ''}`}
+                onClick={handleRefreshMetadata}
+                disabled={refreshingMetadata}
+                title="Re-scan file and update metadata"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={refreshingMetadata ? 'spinning' : ''}>
+                  <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
+                </svg>
+                {refreshingMetadata ? 'Refreshing...' : 'Refresh'}
+              </button>
+            )}
+            {isAdmin && (
+              <button className="btn btn-danger" onClick={handleDelete}>Delete</button>
+            )}
           </div>
 
           <div className="detail-metadata">

--- a/client/src/pages/SeriesDetail.jsx
+++ b/client/src/pages/SeriesDetail.jsx
@@ -397,7 +397,6 @@ export default function SeriesDetail({ onPlay }) {
             setSelectedIds(new Set());
             setSelectionMode(false);
           }}
-          isAdmin={isAdmin}
         />
       )}
     </div>

--- a/server/routes/audiobooks.js
+++ b/server/routes/audiobooks.js
@@ -1728,8 +1728,8 @@ function formatOpenLibraryResult(book) {
   };
 }
 
-// Refresh metadata from file
-router.post('/:id/refresh-metadata', authenticateToken, async (req, res) => {
+// Refresh metadata from file (admin only)
+router.post('/:id/refresh-metadata', authenticateToken, requireAdmin, async (req, res) => {
   try {
     const audiobook = await new Promise((resolve, reject) => {
       db.get('SELECT * FROM audiobooks WHERE id = ?', [req.params.id], (err, row) => {


### PR DESCRIPTION
## Summary
- Delete and Refresh Metadata buttons on AudiobookDetail page now only show for admin users
- Backend refresh-metadata endpoint now requires admin authentication
- Cleaned up dead code from BatchActionBar (unused batchDelete import and isAdmin prop)

## Test plan
- [ ] Log in as non-admin user, verify Delete and Refresh Metadata buttons are not visible on audiobook detail page
- [ ] Log in as admin user, verify Delete and Refresh Metadata buttons are visible and work correctly
- [ ] Test batch actions still work correctly for both admin and non-admin users

Fixes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)