### PR TITLE
Fix metadata extraction and upload processing bugs

### DIFF
--- a/server/routes/audiobooks.js
+++ b/server/routes/audiobooks.js
@@ -1804,13 +1804,16 @@ router.post('/:id/refresh-metadata', authenticateToken, requireAdmin, async (req
 
     const hasChapters = chapters && chapters.length > 1;
 
-    // Update database with new metadata
+    // Update database with new metadata (including extended fields)
     await new Promise((resolve, reject) => {
       db.run(
         `UPDATE audiobooks
          SET title = ?, author = ?, narrator = ?, description = ?, genre = ?,
              series = ?, series_position = ?, published_year = ?, cover_image = ?,
-             duration = ?, is_multi_file = ?, updated_at = CURRENT_TIMESTAMP
+             duration = ?, is_multi_file = ?, isbn = ?,
+             tags = ?, publisher = ?, copyright_year = ?, asin = ?,
+             language = ?, rating = ?, abridged = ?, subtitle = ?,
+             updated_at = CURRENT_TIMESTAMP
          WHERE id = ?`,
         [
           metadata.title,
@@ -1824,6 +1827,15 @@ router.post('/:id/refresh-metadata', authenticateToken, requireAdmin, async (req
           metadata.cover_image,
           metadata.duration,
           hasChapters ? 1 : 0,
+          metadata.isbn,
+          metadata.tags,
+          metadata.publisher,
+          metadata.copyright_year,
+          metadata.asin,
+          metadata.language,
+          metadata.rating,
+          metadata.abridged ? 1 : 0,
+          metadata.subtitle,
           req.params.id
         ],
         (err) => {


### PR DESCRIPTION
## Summary
- Include extended metadata fields (ISBN, tags, publisher, ASIN, language, rating, abridged, subtitle) in refresh-metadata and upload DB operations
- Filter empty manual metadata values to avoid overriding extracted file data during upload
- Extract and save chapters from M4B/M4A files during upload via ffprobe
- Split series tag detection so movement tags skip genre filtering while other tags still filter
- Fix ISRC incorrectly used as ISBN fallback; add language fallback instead
- Use SHA-256 hash for cover art filenames to avoid path collisions
- Use shared `sanitizeName` for file organization consistency

## Test plan
- [ ] Upload an M4B file with embedded chapters and verify chapters are extracted
- [ ] Upload a file with rich metadata and verify all extended fields are saved
- [ ] Upload with manual metadata overrides and verify empty fields don't wipe extracted data
- [ ] Refresh metadata on an existing audiobook and verify extended fields update
- [ ] Verify cover art filenames are unique across different audiobooks with same name

🤖 Generated with [Claude Code](https://claude.com/claude-code)