### PR TITLE
Fix rate limiting and metadata extraction bugs

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,10 @@ const { startScheduledBackups } = require('./services/backupService');
 const app = express();
 const PORT = process.env.PORT || 3001;
 
+// Trust proxy headers (X-Forwarded-For) so rate limiting uses real client IPs
+// Required when running behind Docker/nginx/reverse proxy
+app.set('trust proxy', 1);
+
 // SECURITY: Configure allowed origins for CORS
 const allowedOrigins = process.env.CORS_ORIGINS
   ? process.env.CORS_ORIGINS.split(',').map(o => o.trim())


### PR DESCRIPTION
## Summary
- Fix rate limit errors caused by missing `trust proxy` setting — all requests behind Docker/nginx shared the same rate limit bucket since Express saw them all from the Docker gateway IP
- Fix metadata extraction and upload processing bugs (from prior commit)

## Test plan
- [ ] Verify no more rate limit errors during normal usage
- [ ] Verify metadata extraction works correctly on upload
- [ ] Verify rate limiting still works per-user (not globally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)