### PR TITLE
Fix duplicate audiobooks after metadata edits

### DIFF
--- a/server/services/fileOrganizer.js
+++ b/server/services/fileOrganizer.js
@@ -135,11 +135,20 @@ function moveFile(source, destination) {
         throw new Error('File size mismatch after copy');
       }
 
-      fs.unlinkSync(source);
+      try {
+        fs.unlinkSync(source);
+      } catch (deleteErr) {
+        // Source couldn't be deleted - remove the copy to avoid duplicates
+        console.error(`Failed to delete source ${source}: ${deleteErr.message}, removing copy`);
+        fs.unlinkSync(destination);
+        return false;
+      }
       console.log(`Moved file (copy+delete): ${path.basename(source)}`);
       return true;
     } catch (copyErr) {
       console.error(`Failed to move file ${source}:`, copyErr.message);
+      // Clean up destination if it was created
+      try { if (fs.existsSync(destination)) fs.unlinkSync(destination); } catch (_e) { /* ignore */ }
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- Fix `content_hash` not being updated when metadata is edited via PUT, refresh-metadata, or force rescan — stale hashes caused the library scanner's duplicate detection to miss matches, creating duplicate entries
- Fix `moveFile` leaking destination files when source deletion fails in the copy+delete fallback path, leaving both copies on disk for the scanner to pick up

## Test plan
- [ ] Edit a book's title/author, verify no duplicate appears after next library scan
- [ ] Use "Save and Embed" on an edited book, verify no duplicate
- [ ] Run metadata refresh from maintenance, verify no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)