### PR TITLE
Fix rate limiting blocking cover images and API responses

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -89,7 +89,7 @@ app.use(pinoHttp({
 // SECURITY: Global API rate limiter (baseline for all endpoints)
 const globalApiLimiter = rateLimit({
   windowMs: 60 * 1000,
-  max: 200,
+  max: 1000,
   message: { error: 'Too many requests. Please slow down.' },
   standardHeaders: true,
   legacyHeaders: false,

--- a/server/routes/audiobooks/index.js
+++ b/server/routes/audiobooks/index.js
@@ -6,16 +6,6 @@
  */
 
 const express = require('express');
-const rateLimit = require('express-rate-limit');
-
-// SECURITY: General API rate limiter for authenticated audiobook endpoints
-const apiLimiter = rateLimit({
-  windowMs: 60 * 1000, // 1 minute
-  max: 120, // 120 requests per minute per IP
-  message: { error: 'Too many requests. Please slow down.' },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
 
 // Route modules
 const crud = require('./crud');
@@ -81,10 +71,6 @@ function createAudiobooksRouter(deps = {}) {
     GENRE_MAPPINGS,
     DEFAULT_GENRE_METADATA,
   };
-
-  // SECURITY: Apply general rate limiter to all audiobook routes.
-  // Individual modules may apply stricter per-route limiters on top of this.
-  router.use(apiLimiter);
 
   // Register route modules — order matters!
   // Specific path prefixes (/meta/*, /batch/*, /jobs/*) must come before


### PR DESCRIPTION
## Summary
- The per-router audiobooks rate limiter (120 req/min) was too aggressive — a page load with 400+ books fires hundreds of cover image requests instantly, hitting the limit and causing broken covers and missing titles on the home screen
- Removed the redundant per-router audiobooks rate limiter (global limiter is sufficient)
- Raised global API rate limit from 200 to 1000 req/min to accommodate large libraries
- Sensitive endpoints (auth, uploads, maintenance) retain their own stricter per-route limiters

## Test plan
- [ ] Deploy and verify all covers load on home screen
- [ ] Verify book titles appear alongside covers
- [ ] Verify no 429 errors in container logs during normal browsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)