### PR TITLE
Request sized cover thumbnails to fix slow PWA loading

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -121,9 +121,12 @@ export const getDownloadUrl = (id) => {
   return `${API_BASE}/audiobooks/${id}/download?token=${encodeURIComponent(token)}`;
 };
 
-export const getCoverUrl = (id, cacheBust = null) => {
+export const getCoverUrl = (id, cacheBust = null, width = null) => {
   const token = localStorage.getItem('token');
   let url = `${API_BASE}/audiobooks/${id}/cover?token=${encodeURIComponent(token)}`;
+  if (width) {
+    url += `&width=${width}`;
+  }
   if (cacheBust) {
     url += `&t=${encodeURIComponent(cacheBust)}`;
   }

--- a/client/src/components/AudioPlayer.jsx
+++ b/client/src/components/AudioPlayer.jsx
@@ -261,7 +261,7 @@ const AudioPlayer = forwardRef(({ audiobook, progress, onClose }, ref) => {
         artist: audiobook.author || 'Unknown Author',
         album: audiobook.series || 'Audiobook',
         artwork: audiobook.cover_image ? [
-          { src: getCoverUrl(audiobook.id), sizes: '512x512', type: 'image/jpeg' }
+          { src: getCoverUrl(audiobook.id, null, 600), sizes: '512x512', type: 'image/jpeg' }
         ] : []
       });
 
@@ -1156,7 +1156,7 @@ const AudioPlayer = forwardRef(({ audiobook, progress, onClose }, ref) => {
       <div className="player-info">
         {audiobook.cover_image && (
           <img
-            src={getCoverUrl(audiobook.id)}
+            src={getCoverUrl(audiobook.id, null, 120)}
             alt={`${audiobook.title} by ${audiobook.author || 'Unknown Author'}`}
             className="player-cover"
             onClick={(e) => {

--- a/client/src/components/SearchModal.jsx
+++ b/client/src/components/SearchModal.jsx
@@ -181,7 +181,7 @@ export default function SearchModal({ isOpen, onClose }) {
                     >
                       {book.cover_image && (
                         <img
-                          src={getCoverUrl(book.id)}
+                          src={getCoverUrl(book.id, null, 120)}
                           alt={book.title}
                           className="search-result-cover"
                           loading="lazy"

--- a/client/src/components/player/FullscreenPlayer.jsx
+++ b/client/src/components/player/FullscreenPlayer.jsx
@@ -190,7 +190,7 @@ export default function FullscreenPlayer({
 
           <div className="fullscreen-cover">
             {audiobook.cover_image ? (
-              <img src={getCoverUrl(audiobook.id)} alt={`${audiobook.title} by ${audiobook.author || 'Unknown Author'}`} />
+              <img src={getCoverUrl(audiobook.id, null, 600)} alt={`${audiobook.title} by ${audiobook.author || 'Unknown Author'}`} />
             ) : (
               <div className="fullscreen-cover-placeholder">{audiobook.title}</div>
             )}

--- a/client/src/pages/AllBooks.jsx
+++ b/client/src/pages/AllBooks.jsx
@@ -423,7 +423,7 @@ export default function AllBooks({ onPlay }) {
         <div className="audiobook-cover">
           {book.cover_image ? (
             <img
-              src={getCoverUrl(book.id)}
+              src={getCoverUrl(book.id, null, 300)}
               alt={book.title}
               loading="lazy"
               onError={(e) => {

--- a/client/src/pages/AudiobookDetail.jsx
+++ b/client/src/pages/AudiobookDetail.jsx
@@ -321,7 +321,7 @@ export default function AudiobookDetail({ onPlay }) {
           <div className="detail-cover" onClick={handlePlay}>
             {audiobook.cover_image ? (
               <img
-                src={getCoverUrl(audiobook.id, audiobook.updated_at)}
+                src={getCoverUrl(audiobook.id, audiobook.updated_at, 600)}
                 alt={audiobook.title}
                 onError={(e) => e.target.src = '/placeholder-cover.png'}
               />

--- a/client/src/pages/AuthorDetail.jsx
+++ b/client/src/pages/AuthorDetail.jsx
@@ -169,7 +169,7 @@ export default function AuthorDetail({ onPlay }) {
                 <div className="book-card-cover">
                   {book.cover_image ? (
                     <img
-                      src={getCoverUrl(book.id, book.updated_at)}
+                      src={getCoverUrl(book.id, book.updated_at, 300)}
                       alt={book.title}
                       loading="lazy"
                       onError={(e) => {

--- a/client/src/pages/AuthorsList.jsx
+++ b/client/src/pages/AuthorsList.jsx
@@ -96,7 +96,7 @@ export default function AuthorsList() {
                     {author.cover_ids.slice(0, 4).map((coverId, index) => (
                       <div key={index} className="cover-item">
                         <img
-                          src={getCoverUrl(coverId)}
+                          src={getCoverUrl(coverId, null, 120)}
                           alt={`Book by ${author.author}`}
                           loading="lazy"
                           onError={(e) => e.target.style.display = 'none'}

--- a/client/src/pages/CollectionDetail.jsx
+++ b/client/src/pages/CollectionDetail.jsx
@@ -214,7 +214,7 @@ export default function CollectionDetail() {
               <div className="drag-handle">⋮⋮</div>
               <div className="book-cover" onClick={() => navigate(`/audiobook/${book.id}`)}>
                 <img
-                  src={getCoverUrl(book.id)}
+                  src={getCoverUrl(book.id, null, 300)}
                   alt={book.title}
                   loading="lazy"
                   onError={(e) => e.target.src = '/placeholder-cover.png'}

--- a/client/src/pages/Collections.jsx
+++ b/client/src/pages/Collections.jsx
@@ -36,7 +36,7 @@ function RotatingCover({ bookIds, collectionName }) {
   return (
     <div className="cover-single">
       <img
-        src={getCoverUrl(bookIds[currentIndex])}
+        src={getCoverUrl(bookIds[currentIndex], null, 300)}
         alt={collectionName}
         loading="lazy"
         onError={() => setImageError(true)}

--- a/client/src/pages/GenresList.jsx
+++ b/client/src/pages/GenresList.jsx
@@ -86,7 +86,7 @@ export default function GenresList() {
                       {genreData.cover_ids.slice(0, 4).map((coverId, index) => (
                         <div key={index} className="cover-thumbnail">
                           <img
-                            src={getCoverUrl(coverId)}
+                            src={getCoverUrl(coverId, null, 120)}
                             alt={`${genreData.genre} cover ${index + 1}`}
                             loading="lazy"
                             onError={(e) => e.target.style.display = 'none'}

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -111,7 +111,7 @@ export default function Home({ onPlay }) {
       )}
       <div className="audiobook-cover" onClick={() => navigate(`/audiobook/${book.id}`)}>
         {book.cover_image ? (
-          <img src={getCoverUrl(book.id)} alt={book.title} loading="lazy" onError={(e) => e.target.style.display = 'none'} />
+          <img src={getCoverUrl(book.id, null, 300)} alt={book.title} loading="lazy" onError={(e) => e.target.style.display = 'none'} />
         ) : (
           <div className="audiobook-cover-placeholder">
             <h3>{book.title}</h3>

--- a/client/src/pages/Library.jsx
+++ b/client/src/pages/Library.jsx
@@ -38,7 +38,7 @@ function RotatingCover({ bookIds, collectionName }) {
   return (
     <div className="cover-single">
       <img
-        src={getCoverUrl(bookIds[currentIndex])}
+        src={getCoverUrl(bookIds[currentIndex], null, 300)}
         alt={collectionName}
         loading="lazy"
         onError={() => setImageError(true)}
@@ -538,7 +538,7 @@ export default function Library({ onPlay }) {
                   >
                     <div className="book-cover">
                       <img
-                        src={getCoverUrl(book.id)}
+                        src={getCoverUrl(book.id, null, 300)}
                         alt={book.title}
                         loading="lazy"
                         onError={(e) => {

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -334,7 +334,7 @@ export default function Profile() {
                 onClick={() => navigate(`/audiobook/${book.id}`)}
               >
                 {book.cover_image ? (
-                  <img src={getCoverUrl(book.id)} alt={`${book.title || 'Audiobook'} by ${book.author || 'Unknown Author'}`} className="recent-book-cover" loading="lazy" />
+                  <img src={getCoverUrl(book.id, null, 120)} alt={`${book.title || 'Audiobook'} by ${book.author || 'Unknown Author'}`} className="recent-book-cover" loading="lazy" />
                 ) : (
                   <div className="recent-book-placeholder">{book.title?.charAt(0)}</div>
                 )}

--- a/client/src/pages/SeriesDetail.jsx
+++ b/client/src/pages/SeriesDetail.jsx
@@ -182,7 +182,7 @@ export default function SeriesDetail({ onPlay }) {
         )}
         <div className="audiobook-cover" onClick={handleCardClick}>
           {book.cover_image ? (
-            <img src={getCoverUrl(book.id)} alt={book.title} loading="lazy" onError={(e) => e.target.style.display = 'none'} />
+            <img src={getCoverUrl(book.id, null, 300)} alt={book.title} loading="lazy" onError={(e) => e.target.style.display = 'none'} />
           ) : (
             <div className="audiobook-cover-placeholder">
               <h3>{book.title}</h3>

--- a/client/src/pages/SeriesList.jsx
+++ b/client/src/pages/SeriesList.jsx
@@ -68,7 +68,7 @@ export default function SeriesList() {
                     {series.cover_ids.slice(0, 4).map((coverId, index) => (
                       <div key={index} className="cover-thumbnail">
                         <img
-                          src={getCoverUrl(coverId)}
+                          src={getCoverUrl(coverId, null, 120)}
                           alt={`${series.series} cover ${index + 1}`}
                           loading="lazy"
                           onError={(e) => e.target.src = '/placeholder-cover.png'}


### PR DESCRIPTION
## Summary
- All `getCoverUrl()` calls now pass a `width` parameter matching their display context
- Grid/card views use 300px thumbnails, small thumbnails use 120px, detail views use 600px
- Previously every cover loaded at full resolution (100-500KB each), now thumbnails are 5-30KB — ~90% bandwidth reduction

## Details
The server already supported `?width=120|300|600` via `thumbnailService.js`, but the frontend never used it. With ~500 books, grid views were downloading 50-250MB of cover images. This change requests appropriately-sized thumbnails:

| Context | Width | Files |
|---------|-------|-------|
| Grid/card views | 300px | Home, AllBooks, Library, SeriesDetail, AuthorDetail, Collections, CollectionDetail |
| Small thumbnails | 120px | Profile, SearchModal, SeriesList, GenresList, AuthorsList, mini player |
| Detail/fullscreen | 600px | AudiobookDetail, FullscreenPlayer, media session artwork |

## Test plan
- [ ] Verify covers load on Home page (should be noticeably faster)
- [ ] Check grid views render correctly at 300px
- [ ] Verify detail page still shows high-quality cover
- [ ] Check mini player cover is crisp at 120px
- [ ] Confirm fullscreen player cover looks good at 600px

🤖 Generated with [Claude Code](https://claude.com/claude-code)