### PR TITLE
Fix slow PWA cover loading and blocked metadata cover images

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -48,7 +48,7 @@ app.use(helmet({
       defaultSrc: ["'self'"],
       scriptSrc: ["'self'"],
       styleSrc: ["'self'", "'unsafe-inline'"],
-      imgSrc: ["'self'", 'data:', 'blob:'],
+      imgSrc: ["'self'", 'data:', 'blob:', 'https://*.media-amazon.com', 'https://*.ssl-images-amazon.com', 'https://covers.openlibrary.org', 'https://books.google.com'],
       mediaSrc: ["'self'", 'blob:'],
       connectSrc: ["'self'", 'ws:', 'wss:', 'https://www.googleapis.com', 'https://openlibrary.org', 'https://api.audible.com', 'https://api.audnex.us'],
       fontSrc: ["'self'"],


### PR DESCRIPTION
## Summary
- **Service worker**: Replace stale-while-revalidate with pure cache-first for covers, increase cache limit 200→1000
- **CSP**: Add external image CDN domains so metadata search results display cover images

## Problem
Two issues:

1. **Slow cover loading**: The `cacheFirstSWR` strategy fires a background `fetch()` for every cached cover image. With ~500 books, opening a grid view triggers 500 unnecessary network requests even when all covers are already cached. Combined with the 200-item cache limit (constantly evicting covers from a 500-book library), this made covers appear very slow.

2. **Metadata covers blocked**: The CSP `img-src` directive only allowed `'self'`, `data:`, `blob:`. Cover images from Audible (Amazon CDN), Google Books, and Open Library in the metadata search results were silently blocked.

## Fix

**Service worker (`sw.js`):**
- New `coverCacheFirst` strategy serves from cache without background revalidation. Covers are immutable (URL includes cache-bust param when cover changes), so SWR is unnecessary.
- Cache limit raised from 200 to 1000 to hold the full library.
- Cache version bumped to `v2` so existing clients get a fresh cache with the new strategy.
- `trimCache` optimized to batch-delete instead of recursive single-delete.

**CSP (`server/index.js`):**
- Added `https://*.media-amazon.com`, `https://*.ssl-images-amazon.com`, `https://covers.openlibrary.org`, `https://books.google.com` to `img-src`.

## Test plan
- [ ] Open library grid — covers should load fast (cached instantly after first load)
- [ ] Hard refresh, then navigate — second page load should be near-instant for covers
- [ ] Edit audiobook metadata → search Audnexus → cover images should display in results
- [ ] Check browser DevTools Network tab — no background cover requests when covers are cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)