### PR TITLE
Fix PWA covers, modal positioning, thumbnail concurrency, CSP domains

### DIFF
--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -4,7 +4,7 @@
 // ---------------------------------------------------------------------------
 // Cache names - bump version to invalidate
 // ---------------------------------------------------------------------------
-const APP_SHELL_CACHE = 'app-shell-v1';
+const APP_SHELL_CACHE = 'app-shell-v2';
 const API_CACHE = 'api-cache-v1';
 const COVER_CACHE = 'cover-cache-v2';
 

--- a/client/src/components/AddToCollectionModal.jsx
+++ b/client/src/components/AddToCollectionModal.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { getCollections, createCollection, addToCollection, removeFromCollection, getCollectionsForBook } from '../api';
 import './AddToCollectionModal.css';
 
@@ -96,7 +97,7 @@ export default function AddToCollectionModal({ isOpen, onClose, audiobookId, aud
 
   if (!isOpen) return null;
 
-  return (
+  return createPortal(
     <div className="modal-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-label="Add to collection">
       <div className="add-to-collection-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
@@ -167,6 +168,7 @@ export default function AddToCollectionModal({ isOpen, onClose, audiobookId, aud
           <button className="btn btn-primary" onClick={onClose}>Done</button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/client/src/components/EditMetadataModal.jsx
+++ b/client/src/components/EditMetadataModal.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { updateAudiobook, embedMetadata, convertToM4B, getChapters, updateChapters, refreshMetadata, fetchChaptersFromAudnexus, searchAudnexus } from '../api';
 import './EditMetadataModal.css';
 
@@ -502,7 +503,7 @@ export default function EditMetadataModal({ isOpen, onClose, audiobook, onSave }
 
   if (!isOpen || !audiobook) return null;
 
-  return (
+  return createPortal(
     <div className="modal-overlay" onClick={handleClose} role="dialog" aria-modal="true" aria-label="Edit metadata">
       <div className="modal edit-metadata-modal" onClick={(e) => e.stopPropagation()}>
         {/* Loading Overlay */}
@@ -1001,6 +1002,7 @@ export default function EditMetadataModal({ isOpen, onClose, audiobook, onSave }
           </form>
         )}
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/server/index.js
+++ b/server/index.js
@@ -48,7 +48,7 @@ app.use(helmet({
       defaultSrc: ["'self'"],
       scriptSrc: ["'self'"],
       styleSrc: ["'self'", "'unsafe-inline'"],
-      imgSrc: ["'self'", 'data:', 'blob:', 'https://*.media-amazon.com', 'https://*.ssl-images-amazon.com', 'https://covers.openlibrary.org', 'https://books.google.com'],
+      imgSrc: ["'self'", 'data:', 'blob:', 'https://*.media-amazon.com', 'https://*.ssl-images-amazon.com', 'https://covers.openlibrary.org', 'https://*.archive.org', 'https://books.google.com', 'https://books.googleusercontent.com'],
       mediaSrc: ["'self'", 'blob:'],
       connectSrc: ["'self'", 'ws:', 'wss:', 'https://www.googleapis.com', 'https://openlibrary.org', 'https://api.audible.com', 'https://api.audnex.us'],
       fontSrc: ["'self'"],


### PR DESCRIPTION
## Summary
- Bump SW app-shell cache → PWA gets fresh CSP allowing external cover images
- Add Google Books + Archive.org image CDN domains to CSP
- Deduplicate concurrent thumbnail generation requests
- Render modals via React portal to fix positioning on desktop

## Problems Fixed

### 1. PWA can't load external cover images (metadata search)
The service worker cached HTML with the old CSP `img-src` that only allowed `'self'`. Even after updating the CSP on the server, the PWA kept serving the stale cached HTML. The regular website works because it fetches fresh HTML.

**Fix:** Bump `APP_SHELL_CACHE` from `v1` to `v2`, forcing the old cache to be evicted.

### 2. Missing CSP domains for Google Books
Google Books thumbnails come from `books.googleusercontent.com`, not `books.google.com`. Open Library may redirect to `*.archive.org`.

**Fix:** Add both domains to `img-src`.

### 3. Thumbnail generation thundering herd
When a grid view loads with 50+ uncached thumbnails, all requests hit the server simultaneously. Without deduplication, sharp tries to generate the same thumbnail multiple times in parallel — file I/O contention and wasted CPU.

**Fix:** In-flight Promise map in `thumbnailService.js` — concurrent requests for the same thumbnail share a single generation.

### 4. Edit modal appears at wrong position on desktop
`EditMetadataModal` and `AddToCollectionModal` rendered inline within `AudiobookDetail`, whose `position: sticky` cover creates a new stacking context. The modal's `position: fixed` was relative to that context instead of the viewport.

**Fix:** `createPortal(modal, document.body)` renders modals at document root.

## Test plan
- [ ] PWA: metadata search shows external cover images (Audible, Google Books, Open Library)
- [ ] PWA: library covers load correctly
- [ ] Desktop website: Edit Metadata modal appears centered as overlay
- [ ] Desktop website: Add to Collection modal appears centered
- [ ] Grid view with many uncached thumbnails loads without server errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)