### PR TITLE
Use object-fit: contain for cover images

### DIFF
--- a/client/src/pages/AllBooks.css
+++ b/client/src/pages/AllBooks.css
@@ -140,6 +140,7 @@
   width: 100%;
   height: 100%;
   position: relative;
+  background: #1a1a1a;
 }
 
 .audiobook-cover img {
@@ -148,7 +149,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
 }
 
 .audiobook-cover-placeholder {

--- a/client/src/pages/AudiobookDetail.css
+++ b/client/src/pages/AudiobookDetail.css
@@ -78,6 +78,7 @@
   aspect-ratio: 1;
   border-radius: 12px;
   overflow: hidden;
+  background: #1a1a1a;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
   transition: transform 0.3s ease;
   cursor: pointer;
@@ -127,7 +128,7 @@
 .detail-cover img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
 }
 
 .cover-placeholder {

--- a/client/src/pages/AuthorDetail.css
+++ b/client/src/pages/AuthorDetail.css
@@ -188,7 +188,7 @@
 .book-card-cover img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
   transition: transform 0.4s ease;
 }
 

--- a/client/src/pages/CollectionDetail.css
+++ b/client/src/pages/CollectionDetail.css
@@ -333,7 +333,7 @@
 .collection-detail-page .book-cover img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
 }
 
 .collection-detail-page .book-cover .progress-bar-overlay {

--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -113,7 +113,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
 }
 
 .audiobook-cover-placeholder {

--- a/client/src/pages/Library.css
+++ b/client/src/pages/Library.css
@@ -742,7 +742,7 @@
 .book-cover img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
 }
 
 .book-info {
@@ -1451,7 +1451,7 @@
   }
 
   .audiobook-cover img {
-    object-fit: cover !important;
+    object-fit: contain !important;
   }
 
   .play-overlay,

--- a/client/src/pages/SeriesDetail.css
+++ b/client/src/pages/SeriesDetail.css
@@ -101,7 +101,7 @@
 .series-books-grid .audiobook-cover img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
 }
 
 .series-books-grid .audiobook-cover-placeholder {


### PR DESCRIPTION
## Summary
- Switch from `object-fit: cover` to `contain` across all cover image views
- Non-square covers now display in full with dark letterboxing instead of being cropped
- Applied to AllBooks, Home, SeriesDetail, CollectionDetail, AuthorDetail, AudiobookDetail, Library

## Test plan
- [ ] Verify square covers still display correctly (no letterboxing needed)
- [ ] Verify tall/rectangular covers show in full without cropping
- [ ] Verify letterbox background is dark and consistent across pages
- [ ] Check detail page cover display
- [ ] Check mobile views

🤖 Generated with [Claude Code](https://claude.com/claude-code)