### PR TITLE
Fix metadata embedding gaps and relax series detection filter

### DIFF
--- a/server/services/fileProcessor.js
+++ b/server/services/fileProcessor.js
@@ -241,9 +241,19 @@ async function extractFileMetadata(filePath) {
       // Only applied to ambiguous tags, not explicit series tags
       const looksLikeGenres = (val) => {
         if (!val) return true;
-        // If it contains multiple commas or semicolons, likely genre list
-        if ((val.match(/,/g) || []).length >= 2) return true;
-        if ((val.match(/;/g) || []).length >= 1) return true;
+        const commaCount = (val.match(/,/g) || []).length;
+        const semicolonCount = (val.match(/;/g) || []).length;
+
+        // Strong signal: many separators suggest a list, not a series name
+        if (commaCount >= 3) return true;
+        if (semicolonCount >= 2) return true;
+
+        // Moderate signal: separators + genre keywords suggest genre list
+        if (commaCount >= 1 || semicolonCount >= 1) {
+          const genreKeywords = /\b(fiction|nonfiction|non-fiction|mystery|thriller|romance|fantasy|horror|sci-fi|science fiction|biography|history|drama|comedy|adventure|literary|suspense|crime|detective|young adult|children|self-help|memoir|poetry|western|dystopian|paranormal)\b/i;
+          if (genreKeywords.test(val)) return true;
+        }
+
         return false;
       };
 


### PR DESCRIPTION
## Summary
- **FLAC cover art embedding** — extend ffmpeg cover embedding to FLAC files (was MP3-only), using `METADATA_BLOCK_PICTURE` via `-disposition:v attached_pic`
- **ISBN/ASIN for all formats** — remove Vorbis-only guard so ISBN/ASIN tags are written for MP3 too (ffmpeg maps unrecognized keys to TXXX frames)
- **Relaxed series detection filter** — raise comma threshold from 2→3, semicolon threshold from 1→2, and only reject when genre keywords are present alongside separators. This prevents legitimate series names like "Rivers of London, Book 1" from being misidentified as genre lists

## Test plan
- [x] All 1549 tests pass (1 flaky socket hang up in unrelated apiKeys test)
- [x] fileProcessor.test.js updated with new `looksLikeGenres` behavior — 90 tests pass
- [x] Lint clean
- [ ] Test embed-metadata on an MP3 with ISBN field set
- [ ] Test embed-metadata on a FLAC with cover art
- [ ] Verify series detection on audiobooks with commas in grouping tags

Closes #262, closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)