### PR TITLE
Extract duplicated database query patterns into shared helpers

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -278,7 +278,7 @@ async function authenticateApiKey(apiKey, req, res, next) {
 // Middleware to check admin privileges
 function requireAdmin(req, res, next) {
   if (!req.user || !req.user.is_admin) {
-    return res.status(403).json({ error: 'Admin privileges required' });
+    return res.status(403).json({ error: 'Admin access required' });
   }
   next();
 }

--- a/server/routes/audiobooks/progress.js
+++ b/server/routes/audiobooks/progress.js
@@ -4,9 +4,11 @@
  */
 const { getOrCreateSessionId, clearSessionId, getClientIP, activeSessionIds } = require('./helpers');
 const { createDbHelpers } = require('../../utils/db');
+const { createQueryHelpers } = require('../../utils/queryHelpers');
 
 function register(router, { db, authenticateToken }) {
   const { dbGet, dbRun } = createDbHelpers(db);
+  const { getAudiobookById } = createQueryHelpers(db);
 
   /**
    * Queue the next book in a series when the current book is finished.
@@ -108,7 +110,7 @@ function register(router, { db, authenticateToken }) {
       const sessionId = getOrCreateSessionId(userId, audiobookId);
 
       // Get audiobook details for session tracking
-      const audiobook = await dbGet('SELECT * FROM audiobooks WHERE id = ?', [audiobookId]);
+      const audiobook = await getAudiobookById(audiobookId);
       if (audiobook) {
         const actualState = completed ? 'stopped' : state;
 

--- a/server/routes/audiobooks/stream.js
+++ b/server/routes/audiobooks/stream.js
@@ -10,9 +10,11 @@ const path = require('path');
 const { getAudioMimeType } = require('./helpers');
 const { isValidWidth, getOrGenerateThumbnail } = require('../../services/thumbnailService');
 const { createDbHelpers } = require('../../utils/db');
+const { createQueryHelpers } = require('../../utils/queryHelpers');
 
 function register(router, { db, authenticateToken, authenticateMediaToken, requireAdmin }) {
   const { dbGet } = createDbHelpers(db);
+  const { getAudiobookById } = createQueryHelpers(db);
 
   // Get all files in the audiobook's directory
   router.get('/:id/directory-files', authenticateToken, async (req, res) => {
@@ -62,7 +64,7 @@ function register(router, { db, authenticateToken, authenticateMediaToken, requi
     }
 
     try {
-      const audiobook = await dbGet('SELECT * FROM audiobooks WHERE id = ?', [req.params.id]);
+      const audiobook = await getAudiobookById(req.params.id);
       if (!audiobook) {
         return res.status(404).json({ error: 'Audiobook not found' });
       }
@@ -94,7 +96,7 @@ function register(router, { db, authenticateToken, authenticateMediaToken, requi
   // Stream audiobook (uses authenticateMediaToken to allow query string tokens for <audio> tags)
   router.get('/:id/stream', authenticateMediaToken, async (req, res) => {
     try {
-      const audiobook = await dbGet('SELECT * FROM audiobooks WHERE id = ?', [req.params.id]);
+      const audiobook = await getAudiobookById(req.params.id);
       if (!audiobook) {
         return res.status(404).json({ error: 'Audiobook not found' });
       }
@@ -176,7 +178,7 @@ function register(router, { db, authenticateToken, authenticateMediaToken, requi
   // Download audiobook
   router.get('/:id/download', authenticateToken, async (req, res) => {
     try {
-      const audiobook = await dbGet('SELECT * FROM audiobooks WHERE id = ?', [req.params.id]);
+      const audiobook = await getAudiobookById(req.params.id);
       if (!audiobook) {
         return res.status(404).json({ error: 'Audiobook not found' });
       }

--- a/server/routes/backup.js
+++ b/server/routes/backup.js
@@ -60,16 +60,12 @@ function createBackupRouter(deps = {}) {
   // Resolve dependencies (use provided or defaults)
   const auth = deps.auth || defaultDependencies.auth();
   const backupService = deps.backupService || defaultDependencies.backupService();
-  const { authenticateToken } = auth;
+  const { authenticateToken, requireAdmin } = auth;
 
   /**
    * GET /api/backup - List all backups
    */
-  router.get('/', backupLimiter, authenticateToken, (req, res) => {
-  if (!req.user.is_admin) {
-    return res.status(403).json({ error: 'Admin access required' });
-  }
-
+  router.get('/', backupLimiter, authenticateToken, requireAdmin, (req, res) => {
   try {
     const backups = backupService.listBackups();
     const status = backupService.getStatus();
@@ -87,11 +83,7 @@ function createBackupRouter(deps = {}) {
 /**
  * POST /api/backup - Create a new backup
  */
-router.post('/', backupWriteLimiter, authenticateToken, async (req, res) => {
-  if (!req.user.is_admin) {
-    return res.status(403).json({ error: 'Admin access required' });
-  }
-
+router.post('/', backupWriteLimiter, authenticateToken, requireAdmin, async (req, res) => {
   const { includeCovers = true } = req.body;
 
   try {
@@ -107,11 +99,7 @@ router.post('/', backupWriteLimiter, authenticateToken, async (req, res) => {
 /**
  * GET /api/backup/:filename - Download a backup
  */
-router.get('/:filename', backupLimiter, authenticateToken, (req, res) => {
-  if (!req.user.is_admin) {
-    return res.status(403).json({ error: 'Admin access required' });
-  }
-
+router.get('/:filename', backupLimiter, authenticateToken, requireAdmin, (req, res) => {
   try {
     const backupPath = backupService.getBackupPath(req.params.filename);
     res.download(backupPath, req.params.filename);
@@ -124,11 +112,7 @@ router.get('/:filename', backupLimiter, authenticateToken, (req, res) => {
 /**
  * DELETE /api/backup/:filename - Delete a backup
  */
-router.delete('/:filename', backupWriteLimiter, authenticateToken, (req, res) => {
-  if (!req.user.is_admin) {
-    return res.status(403).json({ error: 'Admin access required' });
-  }
-
+router.delete('/:filename', backupWriteLimiter, authenticateToken, requireAdmin, (req, res) => {
   try {
     const result = backupService.deleteBackup(req.params.filename);
     res.json(result);
@@ -141,11 +125,7 @@ router.delete('/:filename', backupWriteLimiter, authenticateToken, (req, res) =>
 /**
  * POST /api/backup/restore/:filename - Restore from an existing backup
  */
-router.post('/restore/:filename', backupWriteLimiter, authenticateToken, async (req, res) => {
-  if (!req.user.is_admin) {
-    return res.status(403).json({ error: 'Admin access required' });
-  }
-
+router.post('/restore/:filename', backupWriteLimiter, authenticateToken, requireAdmin, async (req, res) => {
   const { restoreDatabase = true, restoreCovers = true } = req.body;
 
   try {
@@ -171,11 +151,7 @@ router.post('/restore/:filename', backupWriteLimiter, authenticateToken, async (
 /**
  * POST /api/backup/upload - Upload and restore from a backup file
  */
-router.post('/upload', backupWriteLimiter, authenticateToken, upload.single('backup'), async (req, res) => {
-  if (!req.user.is_admin) {
-    return res.status(403).json({ error: 'Admin access required' });
-  }
-
+router.post('/upload', backupWriteLimiter, authenticateToken, requireAdmin, upload.single('backup'), async (req, res) => {
   if (!req.file) {
     return res.status(400).json({ error: 'No backup file uploaded' });
   }
@@ -212,11 +188,7 @@ router.post('/upload', backupWriteLimiter, authenticateToken, upload.single('bac
 /**
  * POST /api/backup/retention - Apply retention policy
  */
-router.post('/retention', backupWriteLimiter, authenticateToken, (req, res) => {
-  if (!req.user.is_admin) {
-    return res.status(403).json({ error: 'Admin access required' });
-  }
-
+router.post('/retention', backupWriteLimiter, authenticateToken, requireAdmin, (req, res) => {
   const { keepCount = 7 } = req.body;
 
   try {

--- a/server/routes/maintenance/index.js
+++ b/server/routes/maintenance/index.js
@@ -45,7 +45,7 @@ function createMaintenanceRouter(deps = {}) {
   const libraryScanner = deps.libraryScanner || defaultDependencies.libraryScanner();
   const fileOrganizer = deps.fileOrganizer || defaultDependencies.fileOrganizer();
 
-  const { authenticateToken } = auth;
+  const { authenticateToken, requireAdmin } = auth;
   const { extractFileMetadata } = fileProcessor;
   const { scanLibrary, lockScanning, unlockScanning, isScanningLocked, getJobStatus } = libraryScanner;
   const { organizeLibrary, getOrganizationPreview, organizeAudiobook } = fileOrganizer;
@@ -54,6 +54,7 @@ function createMaintenanceRouter(deps = {}) {
   const sharedDeps = {
     db,
     authenticateToken,
+    requireAdmin,
     extractFileMetadata,
     scanLibrary,
     lockScanning,

--- a/server/routes/maintenance/library.js
+++ b/server/routes/maintenance/library.js
@@ -7,15 +7,11 @@ const path = require('path');
 const { maintenanceWriteLimiter, getForceRescanInProgress, setForceRescanInProgress } = require('./helpers');
 const { createDbHelpers } = require('../../utils/db');
 
-function register(router, { db, authenticateToken, extractFileMetadata, scanLibrary, lockScanning, unlockScanning, isScanningLocked }) {
+function register(router, { db, authenticateToken, requireAdmin, extractFileMetadata, scanLibrary, lockScanning, unlockScanning, isScanningLocked }) {
   const { dbGet, dbAll, dbRun, dbTransaction } = createDbHelpers(db);
 
   // Consolidate multi-file audiobooks
-  router.post('/consolidate-multifile', maintenanceWriteLimiter, authenticateToken, async (req, res) => {
-    if (!req.user.is_admin) {
-      return res.status(403).json({ error: 'Admin access required' });
-    }
-
+  router.post('/consolidate-multifile', maintenanceWriteLimiter, authenticateToken, requireAdmin, async (req, res) => {
     try {
       console.log('Starting multi-file audiobook consolidation...');
 
@@ -120,11 +116,7 @@ function register(router, { db, authenticateToken, extractFileMetadata, scanLibr
   });
 
   // Clear all audiobooks from database
-  router.post('/clear-library', maintenanceWriteLimiter, authenticateToken, async (req, res) => {
-    if (!req.user.is_admin) {
-      return res.status(403).json({ error: 'Admin access required' });
-    }
-
+  router.post('/clear-library', maintenanceWriteLimiter, authenticateToken, requireAdmin, async (req, res) => {
     try {
       console.log('Clearing library database...');
 
@@ -144,11 +136,7 @@ function register(router, { db, authenticateToken, extractFileMetadata, scanLibr
   });
 
   // Trigger immediate library scan (imports new files only)
-  router.post('/scan-library', maintenanceWriteLimiter, authenticateToken, async (req, res) => {
-    if (!req.user.is_admin) {
-      return res.status(403).json({ error: 'Admin access required' });
-    }
-
+  router.post('/scan-library', maintenanceWriteLimiter, authenticateToken, requireAdmin, async (req, res) => {
     const refreshMetadata = req.body.refreshMetadata === true;
 
     try {
@@ -248,11 +236,7 @@ function register(router, { db, authenticateToken, extractFileMetadata, scanLibr
   });
 
   // Run database migrations
-  router.post('/migrate', maintenanceWriteLimiter, authenticateToken, async (req, res) => {
-    if (!req.user.is_admin) {
-      return res.status(403).json({ error: 'Admin access required' });
-    }
-
+  router.post('/migrate', maintenanceWriteLimiter, authenticateToken, requireAdmin, async (req, res) => {
     try {
       console.log('Running database migrations...');
 
@@ -315,11 +299,7 @@ function register(router, { db, authenticateToken, extractFileMetadata, scanLibr
   });
 
   // Force rescan - re-extract metadata for all audiobooks while preserving IDs
-  router.post('/force-rescan', maintenanceWriteLimiter, authenticateToken, async (req, res) => {
-    if (!req.user.is_admin) {
-      return res.status(403).json({ error: 'Admin access required' });
-    }
-
+  router.post('/force-rescan', maintenanceWriteLimiter, authenticateToken, requireAdmin, async (req, res) => {
     if (getForceRescanInProgress()) {
       return res.status(409).json({ error: 'Force rescan already in progress. Please wait.' });
     }

--- a/server/routes/maintenance/logs.js
+++ b/server/routes/maintenance/logs.js
@@ -4,13 +4,9 @@
  */
 const { maintenanceLimiter, maintenanceWriteLimiter, logBuffer, LOG_BUFFER_SIZE, getLogStats, clearLogBuffer, getForceRescanInProgress } = require('./helpers');
 
-function register(router, { authenticateToken, isScanningLocked, getJobStatus }) {
+function register(router, { authenticateToken, requireAdmin, isScanningLocked, getJobStatus }) {
   // Get server logs
-  router.get('/logs', maintenanceLimiter, authenticateToken, (req, res) => {
-    if (!req.user.is_admin) {
-      return res.status(403).json({ error: 'Admin access required' });
-    }
-
+  router.get('/logs', maintenanceLimiter, authenticateToken, requireAdmin, (req, res) => {
     const limit = Math.min(parseInt(req.query.limit) || 100, LOG_BUFFER_SIZE);
     const logs = logBuffer.slice(-limit);
 
@@ -24,11 +20,7 @@ function register(router, { authenticateToken, isScanningLocked, getJobStatus })
   });
 
   // Clear server logs
-  router.delete('/logs', maintenanceWriteLimiter, authenticateToken, (req, res) => {
-    if (!req.user.is_admin) {
-      return res.status(403).json({ error: 'Admin access required' });
-    }
-
+  router.delete('/logs', maintenanceWriteLimiter, authenticateToken, requireAdmin, (req, res) => {
     const cleared = clearLogBuffer();
     res.json({
       success: true,
@@ -38,11 +30,7 @@ function register(router, { authenticateToken, isScanningLocked, getJobStatus })
   });
 
   // Get background jobs status
-  router.get('/jobs', maintenanceLimiter, authenticateToken, (req, res) => {
-    if (!req.user.is_admin) {
-      return res.status(403).json({ error: 'Admin access required' });
-    }
-
+  router.get('/jobs', maintenanceLimiter, authenticateToken, requireAdmin, (req, res) => {
     const jobs = getJobStatus();
 
     res.json({

--- a/server/routes/maintenance/statistics.js
+++ b/server/routes/maintenance/statistics.js
@@ -5,15 +5,11 @@
 const { maintenanceLimiter } = require('./helpers');
 const { createDbHelpers } = require('../../utils/db');
 
-function register(router, { db, authenticateToken }) {
+function register(router, { db, authenticateToken, requireAdmin }) {
   const { dbGet, dbAll } = createDbHelpers(db);
 
   // Get library statistics
-  router.get('/statistics', maintenanceLimiter, authenticateToken, async (req, res) => {
-    if (!req.user.is_admin) {
-      return res.status(403).json({ error: 'Admin access required' });
-    }
-
+  router.get('/statistics', maintenanceLimiter, authenticateToken, requireAdmin, async (req, res) => {
     try {
       const totals = await dbGet(
         `SELECT
@@ -117,11 +113,7 @@ function register(router, { db, authenticateToken }) {
   });
 
   // Get audiobooks by file format
-  router.get('/books-by-format/:format', authenticateToken, async (req, res) => {
-    if (!req.user.is_admin) {
-      return res.status(403).json({ error: 'Admin access required' });
-    }
-
+  router.get('/books-by-format/:format', authenticateToken, requireAdmin, async (req, res) => {
     try {
       const format = req.params.format.toLowerCase();
       const books = await dbAll(

--- a/server/utils/queryHelpers.js
+++ b/server/utils/queryHelpers.js
@@ -1,0 +1,59 @@
+/**
+ * Shared query helpers for common database patterns.
+ *
+ * Usage:
+ *   const { createQueryHelpers } = require('../../utils/queryHelpers');
+ *   const { getAudiobookById, transformAudiobookRow } = createQueryHelpers(db);
+ */
+
+const { createDbHelpers } = require('./db');
+
+/**
+ * Create shared query helpers bound to a specific database instance.
+ * @param {Object} db - sqlite3 database instance
+ * @returns {{ getAudiobookById, transformAudiobookRow }}
+ */
+function createQueryHelpers(db) {
+  const { dbGet } = createDbHelpers(db);
+
+  /**
+   * Fetch a single audiobook by ID.
+   * @param {number|string} id
+   * @returns {Promise<Object|null>}
+   */
+  async function getAudiobookById(id) {
+    return dbGet('SELECT * FROM audiobooks WHERE id = ?', [id]);
+  }
+
+  /**
+   * Transform a flat DB row (with joined progress/rating fields) into a
+   * clean nested object.  Works with rows produced by queries that LEFT JOIN
+   * playback_progress, user_favorites, and user_ratings.
+   *
+   * @param {Object} book - raw DB row
+   * @param {Function} [normalizeGenres] - optional genre normalizer
+   * @returns {Object} transformed row
+   */
+  function transformAudiobookRow(book, normalizeGenres) {
+    const {
+      progress_position, progress_completed, progress_updated_at,
+      is_favorite, user_rating, average_rating, ...rest
+    } = book;
+    return {
+      ...rest,
+      normalized_genre: normalizeGenres ? normalizeGenres(book.genre) : book.genre,
+      is_favorite: !!is_favorite,
+      user_rating: user_rating || null,
+      average_rating: average_rating ? Math.round(average_rating * 10) / 10 : null,
+      progress: progress_position !== null ? {
+        position: progress_position,
+        completed: progress_completed,
+        updated_at: progress_updated_at
+      } : null
+    };
+  }
+
+  return { getAudiobookById, transformAudiobookRow };
+}
+
+module.exports = { createQueryHelpers };

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -143,7 +143,7 @@ describe('requireAdmin', () => {
     requireAdmin(mockReq, mockRes, mockNext);
     expect(mockNext).not.toHaveBeenCalled();
     expect(mockRes.status).toHaveBeenCalledWith(403);
-    expect(mockRes.json).toHaveBeenCalledWith({ error: 'Admin privileges required' });
+    expect(mockRes.json).toHaveBeenCalledWith({ error: 'Admin access required' });
   });
 
   test('returns 403 when user is not set', () => {


### PR DESCRIPTION
## Summary

- **New shared helper module** (`server/utils/queryHelpers.js`) with `getAudiobookById()` and `transformAudiobookRow()` to eliminate the three most duplicated patterns across routes
- **14 inline `SELECT * FROM audiobooks WHERE id = ?` queries** replaced with `getAudiobookById()` across 8 route files
- **39 inline `if (!req.user.is_admin)` checks** replaced with `requireAdmin` middleware across 11 route files, reducing ~150 lines of boilerplate
- **Inline progress/rating transform** in `crud.js` replaced with shared `transformAudiobookRow()`
- **Standardized** `requireAdmin` error message to `'Admin access required'` for consistency

Net result: **-91 lines** (141 added, 232 removed).

Closes #307

## Test plan

- [x] All 1552 tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [x] `grep -rn "SELECT \* FROM audiobooks WHERE id = ?" server/routes/` returns only the expected transaction-scoped query in `upload.js`
- [x] `grep -rn "if (!req.user.is_admin)" server/routes/` returns 0 hits
- [ ] Docker rebuild + smoke test backup, metadata edit, conversion, and maintenance endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)