### PR TITLE
Add comprehensive test coverage (#234, #235, #232, #153, #233)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,9 +15,82 @@
         "react-window": "^1.8.11"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@vitejs/plugin-react": "^4.2.1",
-        "vite": "^5.0.8"
+        "jsdom": "^28.0.0",
+        "vite": "^5.0.8",
+        "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.8",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.8.tgz",
+      "integrity": "sha512-stisC1nULNc9oH5lakAj8MH88ZxeGxzyWNDfbdCxvJSJIvDsHNZqYvscGTgy/ysgXWLJPt6K/4t0/GjvtKcFJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -310,6 +383,138 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
+      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
+      "integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
+      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.1",
+        "@csstools/css-calc": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
+      "integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -599,6 +804,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -616,6 +838,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -631,6 +870,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -699,6 +955,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.12.0.tgz",
+      "integrity": "sha512-BuCOHA/EJdPN0qQ5MdgAiJSt9fYDHbghlgrj33gRdy/Yp1/FMCDhU6vJfcKrLC0TPWGSrfH3vYXBQWmFHxlddw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1117,6 +1391,97 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1162,6 +1527,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1190,6 +1573,145 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1215,6 +1737,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -1285,6 +1817,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1304,6 +1846,67 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1322,6 +1925,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1330,6 +1940,24 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -1352,6 +1980,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1369,6 +2010,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -1444,6 +2092,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/follow-redirects": {
@@ -1604,11 +2290,109 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.0.0.tgz",
+      "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^5.3.7",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.20.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1658,6 +2442,27 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1666,6 +2471,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -1692,6 +2504,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -1727,12 +2549,56 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -1763,11 +2629,37 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -1793,6 +2685,14 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -1853,6 +2753,30 @@
         "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.55.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
@@ -1898,6 +2822,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -1917,6 +2854,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1925,6 +2869,140 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
+      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.23"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
+      "integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2017,6 +3095,701 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
+      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "axios": "^1.6.5",
@@ -16,7 +17,11 @@
     "react-window": "^1.8.11"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@vitejs/plugin-react": "^4.2.1",
-    "vite": "^5.0.8"
+    "jsdom": "^28.0.0",
+    "vite": "^5.0.8",
+    "vitest": "^4.0.18"
   }
 }

--- a/client/src/__tests__/WebSocketContext.test.jsx
+++ b/client/src/__tests__/WebSocketContext.test.jsx
@@ -1,0 +1,304 @@
+/**
+ * Tests for WebSocketContext
+ * Tests the WebSocket provider, hooks, and subscription system
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { WebSocketProvider, useWebSocket } from '../contexts/WebSocketContext.jsx';
+
+// Mock WebSocket
+class MockWebSocket {
+  constructor(url) {
+    this.url = url;
+    this.readyState = 0; // CONNECTING
+    this.onopen = null;
+    this.onclose = null;
+    this.onmessage = null;
+    this.onerror = null;
+    MockWebSocket.instances.push(this);
+  }
+
+  close() {
+    this.readyState = 3; // CLOSED
+    if (this.onclose) {
+      this.onclose({ code: 1000, reason: '' });
+    }
+  }
+
+  // Helper to simulate connection open
+  simulateOpen() {
+    this.readyState = 1; // OPEN
+    if (this.onopen) this.onopen();
+  }
+
+  // Helper to simulate message
+  simulateMessage(data) {
+    if (this.onmessage) {
+      this.onmessage({ data: JSON.stringify(data) });
+    }
+  }
+
+  // Helper to simulate close
+  simulateClose(code = 1000) {
+    this.readyState = 3;
+    if (this.onclose) {
+      this.onclose({ code, reason: '' });
+    }
+  }
+}
+
+MockWebSocket.OPEN = 1;
+MockWebSocket.instances = [];
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  vi.stubGlobal('WebSocket', MockWebSocket);
+});
+
+function wrapper({ children }) {
+  return <WebSocketProvider>{children}</WebSocketProvider>;
+}
+
+describe('WebSocketContext', () => {
+  describe('WebSocketProvider', () => {
+    it('connects when token exists in localStorage', () => {
+      localStorage.setItem('token', 'test-token');
+
+      render(
+        <WebSocketProvider>
+          <div>test</div>
+        </WebSocketProvider>
+      );
+
+      expect(MockWebSocket.instances.length).toBe(1);
+      expect(MockWebSocket.instances[0].url).toContain('ws://');
+      expect(MockWebSocket.instances[0].url).toContain('token=test-token');
+    });
+
+    it('does not connect when no token in localStorage', () => {
+      render(
+        <WebSocketProvider>
+          <div>test</div>
+        </WebSocketProvider>
+      );
+
+      expect(MockWebSocket.instances.length).toBe(0);
+    });
+
+    it('reports connected status after WebSocket opens', () => {
+      localStorage.setItem('token', 'test-token');
+
+      const { result } = renderHook(() => useWebSocket(), { wrapper });
+
+      expect(result.current.isConnected).toBe(false);
+
+      act(() => {
+        MockWebSocket.instances[0].simulateOpen();
+      });
+
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    it('reports disconnected status after WebSocket closes', () => {
+      localStorage.setItem('token', 'test-token');
+
+      const { result } = renderHook(() => useWebSocket(), { wrapper });
+
+      act(() => {
+        MockWebSocket.instances[0].simulateOpen();
+      });
+      expect(result.current.isConnected).toBe(true);
+
+      act(() => {
+        // Close with code 1008 (policy violation) to prevent reconnect
+        MockWebSocket.instances[0].simulateClose(1008);
+      });
+      expect(result.current.isConnected).toBe(false);
+    });
+  });
+
+  describe('useWebSocket hook', () => {
+    it('throws when used outside provider', () => {
+      // Suppress console.error for expected error
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useWebSocket());
+      }).toThrow('useWebSocket must be used within a WebSocketProvider');
+
+      consoleSpy.mockRestore();
+    });
+
+    it('provides subscribe function', () => {
+      localStorage.setItem('token', 'test-token');
+
+      const { result } = renderHook(() => useWebSocket(), { wrapper });
+      expect(typeof result.current.subscribe).toBe('function');
+    });
+
+    it('provides connect and disconnect functions', () => {
+      const { result } = renderHook(() => useWebSocket(), { wrapper });
+      expect(typeof result.current.connect).toBe('function');
+      expect(typeof result.current.disconnect).toBe('function');
+    });
+  });
+
+  describe('Subscribe/Unsubscribe', () => {
+    it('notifies matching event listeners', () => {
+      localStorage.setItem('token', 'test-token');
+
+      const listener = vi.fn();
+      const { result } = renderHook(() => useWebSocket(), { wrapper });
+
+      act(() => {
+        MockWebSocket.instances[0].simulateOpen();
+      });
+
+      // Subscribe to 'library.update' events
+      let unsubscribe;
+      act(() => {
+        unsubscribe = result.current.subscribe('library.update', listener);
+      });
+
+      // Simulate a matching message
+      act(() => {
+        MockWebSocket.instances[0].simulateMessage({
+          type: 'library.update',
+          data: { id: 1, title: 'New Book' },
+        });
+      });
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'library.update' })
+      );
+    });
+
+    it('does not notify listeners for non-matching events', () => {
+      localStorage.setItem('token', 'test-token');
+
+      const listener = vi.fn();
+      const { result } = renderHook(() => useWebSocket(), { wrapper });
+
+      act(() => {
+        MockWebSocket.instances[0].simulateOpen();
+        result.current.subscribe('library.update', listener);
+      });
+
+      // Simulate a non-matching message
+      act(() => {
+        MockWebSocket.instances[0].simulateMessage({
+          type: 'session.update',
+          data: {},
+        });
+      });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('unsubscribe removes the listener', () => {
+      localStorage.setItem('token', 'test-token');
+
+      const listener = vi.fn();
+      const { result } = renderHook(() => useWebSocket(), { wrapper });
+
+      act(() => {
+        MockWebSocket.instances[0].simulateOpen();
+      });
+
+      let unsubscribe;
+      act(() => {
+        unsubscribe = result.current.subscribe('library.update', listener);
+      });
+
+      // Unsubscribe
+      act(() => {
+        unsubscribe();
+      });
+
+      // Simulate event after unsubscribe
+      act(() => {
+        MockWebSocket.instances[0].simulateMessage({
+          type: 'library.update',
+          data: {},
+        });
+      });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('wildcard listener receives all events', () => {
+      localStorage.setItem('token', 'test-token');
+
+      const listener = vi.fn();
+      const { result } = renderHook(() => useWebSocket(), { wrapper });
+
+      act(() => {
+        MockWebSocket.instances[0].simulateOpen();
+        result.current.subscribe('*', listener);
+      });
+
+      act(() => {
+        MockWebSocket.instances[0].simulateMessage({
+          type: 'library.update',
+          data: {},
+        });
+      });
+
+      act(() => {
+        MockWebSocket.instances[0].simulateMessage({
+          type: 'session.start',
+          data: {},
+        });
+      });
+
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('lastEvent', () => {
+    it('updates lastEvent on message received', () => {
+      localStorage.setItem('token', 'test-token');
+
+      const { result } = renderHook(() => useWebSocket(), { wrapper });
+
+      act(() => {
+        MockWebSocket.instances[0].simulateOpen();
+      });
+
+      expect(result.current.lastEvent).toBeNull();
+
+      act(() => {
+        MockWebSocket.instances[0].simulateMessage({
+          type: 'library.update',
+          data: { id: 1 },
+        });
+      });
+
+      expect(result.current.lastEvent).toEqual(
+        expect.objectContaining({ type: 'library.update' })
+      );
+    });
+  });
+
+  describe('disconnect', () => {
+    it('closes the WebSocket connection', () => {
+      localStorage.setItem('token', 'test-token');
+
+      const { result } = renderHook(() => useWebSocket(), { wrapper });
+
+      act(() => {
+        MockWebSocket.instances[0].simulateOpen();
+      });
+
+      expect(result.current.isConnected).toBe(true);
+
+      act(() => {
+        result.current.disconnect();
+      });
+
+      expect(result.current.isConnected).toBe(false);
+    });
+  });
+});

--- a/client/src/__tests__/api.test.js
+++ b/client/src/__tests__/api.test.js
@@ -1,0 +1,278 @@
+/**
+ * Tests for client API module (api.js)
+ * Tests axios interceptors, URL builders, and API function calls
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// Mock axios before importing api module
+vi.mock('axios', () => {
+  const mockAxiosInstance = {
+    get: vi.fn().mockResolvedValue({ data: {} }),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+    put: vi.fn().mockResolvedValue({ data: {} }),
+    delete: vi.fn().mockResolvedValue({ data: {} }),
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+  };
+
+  return {
+    default: {
+      create: vi.fn(() => mockAxiosInstance),
+    },
+  };
+});
+
+let api;
+let login, getProfile, getAudiobooks, getAudiobook, deleteAudiobook;
+let getStreamUrl, getCoverUrl, getDownloadUrl;
+let updateProgress, getProgress, markFinished, clearProgress;
+let getSeries, getAuthors, getGenres, getRecentlyAdded;
+let getApiKeys, createApiKey;
+let scanLibrary;
+
+let axiosInstance;
+let requestInterceptor;
+let responseErrorInterceptor;
+
+beforeEach(async () => {
+  vi.resetModules();
+
+  const axiosMod = await import('axios');
+  const apiMod = await import('../api.js');
+
+  api = apiMod.default;
+  login = apiMod.login;
+  getProfile = apiMod.getProfile;
+  getAudiobooks = apiMod.getAudiobooks;
+  getAudiobook = apiMod.getAudiobook;
+  deleteAudiobook = apiMod.deleteAudiobook;
+  getStreamUrl = apiMod.getStreamUrl;
+  getCoverUrl = apiMod.getCoverUrl;
+  getDownloadUrl = apiMod.getDownloadUrl;
+  updateProgress = apiMod.updateProgress;
+  getProgress = apiMod.getProgress;
+  markFinished = apiMod.markFinished;
+  clearProgress = apiMod.clearProgress;
+  getSeries = apiMod.getSeries;
+  getAuthors = apiMod.getAuthors;
+  getGenres = apiMod.getGenres;
+  getRecentlyAdded = apiMod.getRecentlyAdded;
+  getApiKeys = apiMod.getApiKeys;
+  createApiKey = apiMod.createApiKey;
+  scanLibrary = apiMod.scanLibrary;
+
+  axiosInstance = axiosMod.default.create();
+
+  // Extract the interceptor callbacks that were registered
+  requestInterceptor = axiosInstance.interceptors.request.use.mock.calls[0]?.[0];
+  const responseArgs = axiosInstance.interceptors.response.use.mock.calls[0];
+  responseErrorInterceptor = responseArgs?.[1];
+});
+
+describe('API Module', () => {
+  describe('Axios instance creation', () => {
+    it('creates axios instance with correct base URL', async () => {
+      const axios = (await import('axios')).default;
+      expect(axios.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: '/api',
+        })
+      );
+    });
+
+    it('registers request interceptor', () => {
+      expect(axiosInstance.interceptors.request.use).toHaveBeenCalled();
+    });
+
+    it('registers response interceptor', () => {
+      expect(axiosInstance.interceptors.response.use).toHaveBeenCalled();
+    });
+  });
+
+  describe('Request interceptor', () => {
+    it('adds Authorization header when token exists', () => {
+      localStorage.setItem('token', 'test-jwt-token');
+
+      const config = { headers: {} };
+      const result = requestInterceptor(config);
+
+      expect(result.headers.Authorization).toBe('Bearer test-jwt-token');
+    });
+
+    it('does not add Authorization header when no token', () => {
+      const config = { headers: {} };
+      const result = requestInterceptor(config);
+
+      expect(result.headers.Authorization).toBeUndefined();
+    });
+  });
+
+  describe('Response interceptor (error handling)', () => {
+    it('clears localStorage on 401 response', async () => {
+      localStorage.setItem('token', 'some-token');
+      localStorage.setItem('currentAudiobook', '123');
+      localStorage.setItem('currentProgress', '50');
+      localStorage.setItem('playerPlaying', 'true');
+
+      const error = { response: { status: 401 } };
+
+      await expect(responseErrorInterceptor(error)).rejects.toEqual(error);
+
+      expect(localStorage.removeItem).toHaveBeenCalledWith('token');
+      expect(localStorage.removeItem).toHaveBeenCalledWith('currentAudiobook');
+      expect(localStorage.removeItem).toHaveBeenCalledWith('currentProgress');
+      expect(localStorage.removeItem).toHaveBeenCalledWith('playerPlaying');
+    });
+
+    it('clears localStorage on 403 response', async () => {
+      localStorage.setItem('token', 'some-token');
+
+      const error = { response: { status: 403 } };
+      await expect(responseErrorInterceptor(error)).rejects.toEqual(error);
+
+      expect(localStorage.removeItem).toHaveBeenCalledWith('token');
+    });
+
+    it('redirects to root on auth error', async () => {
+      const error = { response: { status: 401 } };
+      await expect(responseErrorInterceptor(error)).rejects.toEqual(error);
+
+      expect(window.location.href).toBe('/');
+    });
+
+    it('does not clear localStorage on other errors', async () => {
+      // Clear any previous calls from other tests
+      localStorage.removeItem.mockClear();
+
+      const error = { response: { status: 500 } };
+      await expect(responseErrorInterceptor(error)).rejects.toEqual(error);
+
+      expect(localStorage.removeItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('URL builders', () => {
+    it('getStreamUrl includes token as query param', () => {
+      localStorage.setItem('token', 'my-token');
+
+      const url = getStreamUrl(42);
+      expect(url).toBe('/api/audiobooks/42/stream?token=my-token');
+    });
+
+    it('getCoverUrl includes token as query param', () => {
+      localStorage.setItem('token', 'my-token');
+
+      const url = getCoverUrl(42);
+      expect(url).toBe('/api/audiobooks/42/cover?token=my-token');
+    });
+
+    it('getCoverUrl includes width parameter when provided', () => {
+      localStorage.setItem('token', 'my-token');
+
+      const url = getCoverUrl(42, null, 200);
+      expect(url).toBe('/api/audiobooks/42/cover?token=my-token&width=200');
+    });
+
+    it('getCoverUrl includes cache bust parameter when provided', () => {
+      localStorage.setItem('token', 'my-token');
+
+      const url = getCoverUrl(42, 'bust123');
+      expect(url).toBe('/api/audiobooks/42/cover?token=my-token&t=bust123');
+    });
+
+    it('getDownloadUrl includes token as query param', () => {
+      localStorage.setItem('token', 'my-token');
+
+      const url = getDownloadUrl(42);
+      expect(url).toBe('/api/audiobooks/42/download?token=my-token');
+    });
+
+    it('URL encodes token in stream URL', () => {
+      localStorage.setItem('token', 'token with spaces+special');
+
+      const url = getStreamUrl(1);
+      expect(url).toContain(encodeURIComponent('token with spaces+special'));
+    });
+  });
+
+  describe('API function calls', () => {
+    it('login calls POST /auth/login', async () => {
+      await login('user', 'pass');
+      expect(axiosInstance.post).toHaveBeenCalledWith('/auth/login', { username: 'user', password: 'pass' });
+    });
+
+    it('getProfile calls GET /profile', async () => {
+      await getProfile();
+      expect(axiosInstance.get).toHaveBeenCalledWith('/profile');
+    });
+
+    it('getAudiobooks calls GET /audiobooks with params', async () => {
+      await getAudiobooks({ search: 'test' });
+      expect(axiosInstance.get).toHaveBeenCalledWith('/audiobooks', { params: { search: 'test' } });
+    });
+
+    it('getAudiobook calls GET /audiobooks/:id', async () => {
+      await getAudiobook(42);
+      expect(axiosInstance.get).toHaveBeenCalledWith('/audiobooks/42');
+    });
+
+    it('deleteAudiobook calls DELETE /audiobooks/:id', async () => {
+      await deleteAudiobook(42);
+      expect(axiosInstance.delete).toHaveBeenCalledWith('/audiobooks/42');
+    });
+
+    it('updateProgress calls POST /audiobooks/:id/progress', async () => {
+      await updateProgress(42, 1800, 0, 'playing', {});
+      expect(axiosInstance.post).toHaveBeenCalledWith(
+        '/audiobooks/42/progress',
+        { position: 1800, completed: 0, state: 'playing', clientInfo: {} },
+        expect.any(Object)
+      );
+    });
+
+    it('markFinished calls POST /audiobooks/:id/progress with completed=1', async () => {
+      await markFinished(42);
+      expect(axiosInstance.post).toHaveBeenCalledWith(
+        '/audiobooks/42/progress',
+        { position: 0, completed: 1, state: 'stopped' }
+      );
+    });
+
+    it('clearProgress calls DELETE /audiobooks/:id/progress', async () => {
+      await clearProgress(42);
+      expect(axiosInstance.delete).toHaveBeenCalledWith('/audiobooks/42/progress');
+    });
+
+    it('getSeries calls GET /audiobooks/meta/series', async () => {
+      await getSeries();
+      expect(axiosInstance.get).toHaveBeenCalledWith('/audiobooks/meta/series');
+    });
+
+    it('getAuthors calls GET /audiobooks/meta/authors', async () => {
+      await getAuthors();
+      expect(axiosInstance.get).toHaveBeenCalledWith('/audiobooks/meta/authors');
+    });
+
+    it('getRecentlyAdded calls GET /audiobooks/meta/recent with limit', async () => {
+      await getRecentlyAdded(5);
+      expect(axiosInstance.get).toHaveBeenCalledWith('/audiobooks/meta/recent', { params: { limit: 5 } });
+    });
+
+    it('createApiKey calls POST /api-keys', async () => {
+      await createApiKey('test-key', 'read', 30);
+      expect(axiosInstance.post).toHaveBeenCalledWith('/api-keys', {
+        name: 'test-key',
+        permissions: 'read',
+        expires_in_days: 30,
+      });
+    });
+
+    it('scanLibrary calls POST /maintenance/scan-library', async () => {
+      await scanLibrary(true);
+      expect(axiosInstance.post).toHaveBeenCalledWith('/maintenance/scan-library', { refreshMetadata: true });
+    });
+  });
+});

--- a/client/src/test/setup.js
+++ b/client/src/test/setup.js
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store = {};
+  return {
+    getItem: vi.fn((key) => store[key] ?? null),
+    setItem: vi.fn((key, value) => { store[key] = String(value); }),
+    removeItem: vi.fn((key) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+    get length() { return Object.keys(store).length; },
+    key: vi.fn((index) => Object.keys(store)[index] || null),
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+// Mock window.location
+delete window.location;
+window.location = { href: '/', protocol: 'http:', host: 'localhost:3000' };
+
+// Reset localStorage between tests
+afterEach(() => {
+  localStorageMock.clear();
+  vi.restoreAllMocks();
+});

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -21,5 +21,10 @@ export default defineConfig({
         changeOrigin: true,
       }
     }
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.js',
   }
 })

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   testEnvironment: 'node',
-  testMatch: ['**/tests/**/*.test.js'],
+  rootDir: __dirname,
+  testMatch: ['<rootDir>/tests/**/*.test.js'],
   collectCoverageFrom: [
     'server/**/*.js',
     '!server/migrations/**',
@@ -12,10 +13,10 @@ module.exports = {
     // Global thresholds - minimum coverage for entire codebase
     // Set to current coverage levels to prevent regression
     global: {
-      statements: 14,
-      branches: 12,
-      functions: 19,
-      lines: 14
+      statements: 28,
+      branches: 28,
+      functions: 38,
+      lines: 29
     },
     // Utility functions require 100% coverage
     'server/utils/**/*.js': {
@@ -25,6 +26,7 @@ module.exports = {
       lines: 100
     }
   },
+  testPathIgnorePatterns: ['/node_modules/', '/client/'],
   setupFilesAfterEnv: ['./tests/setup.js'],
   testTimeout: 10000,
   verbose: true

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:integration": "jest tests/integration",
     "test:docker": "jest tests/docker",
     "test:all": "jest --coverage",
+    "test:client": "cd client && npx vitest run",
     "lint": "eslint server/"
   },
   "keywords": [

--- a/server/services/fileProcessor.js
+++ b/server/services/fileProcessor.js
@@ -16,6 +16,9 @@ const execFileAsync = promisify(execFile);
 // music-metadata is ESM only, use dynamic import
 let parseFile;
 
+// Allow tests to inject parseFile mock (ESM import() not available in Jest VM)
+function _setParseFile(fn) { parseFile = fn; }
+
 const audiobooksDir = process.env.AUDIOBOOKS_DIR || path.join(__dirname, '../../data/audiobooks');
 
 // Ensure audiobooks directory exists
@@ -947,4 +950,5 @@ async function saveToDatabase(metadata, filePath, fileSize, userId) {
 module.exports = {
   processAudiobook,
   extractFileMetadata,
+  _setParseFile,
 };

--- a/tests/unit/database-init.test.js
+++ b/tests/unit/database-init.test.js
@@ -1,0 +1,676 @@
+/**
+ * Unit tests for database.js initialization and error paths
+ * Uses jest.isolateModules() because database.js has top-level side effects
+ *
+ * Key insight: sqlite3.Database() returns the db object synchronously, then calls
+ * its callback asynchronously. Our mock must replicate this: return mockDb from
+ * the constructor immediately, then invoke the callback via process.nextTick.
+ */
+
+// Save original env
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+  process.env.NODE_ENV = 'test';
+  process.env.JWT_SECRET = 'test-secret-for-jest-testing-only';
+  process.env.DATABASE_PATH = ':memory:';
+  jest.restoreAllMocks();
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+/**
+ * Helper: create a mock sqlite3 Database object and a Database constructor.
+ * The constructor returns mockDb immediately and fires the callback on nextTick,
+ * matching real sqlite3 behavior where `const db = new Database(...)` assigns `db`
+ * before the callback runs.
+ */
+function createMockSetup({ openErr = null, allHandler, runHandler } = {}) {
+  const mockDb = {
+    run: runHandler || jest.fn((sql, ...args) => {
+      const cb = args.find(a => typeof a === 'function');
+      if (cb) cb(null);
+    }),
+    get: jest.fn((sql, params, cb) => {
+      if (cb) cb(null, null);
+    }),
+    all: allHandler || jest.fn((sql, ...args) => {
+      const cb = args.find(a => typeof a === 'function');
+      if (cb) cb(null, []);
+    }),
+    serialize: jest.fn((fn) => { if (fn) fn(); }),
+    close: jest.fn((cb) => { if (cb) cb(null); }),
+  };
+
+  const DatabaseConstructor = jest.fn(function(_path, cb) {
+    // Schedule callback on nextTick so `const db = new Database(...)` assigns first
+    if (cb) process.nextTick(() => cb(openErr));
+    return mockDb;
+  });
+
+  return { mockDb, DatabaseConstructor };
+}
+
+/** Standard fs mock that says everything exists */
+function mockFsExists() {
+  return {
+    existsSync: jest.fn().mockReturnValue(true),
+    mkdirSync: jest.fn(),
+    readdirSync: jest.fn().mockReturnValue([]),
+    renameSync: jest.fn(),
+  };
+}
+
+/** allHandler that returns full columns for users and audiobooks (no ALTER needed) */
+function allColumnsPresent() {
+  return jest.fn((sql, ...args) => {
+    const cb = args.find(a => typeof a === 'function');
+    if (!cb) return;
+    if (sql.includes('table_info(users)')) {
+      cb(null, [{ name: 'id' }, { name: 'username' }, { name: 'display_name' }, { name: 'avatar' }]);
+    } else if (sql.includes('table_info(audiobooks)')) {
+      cb(null, [{ name: 'id' }, { name: 'series_index' }]);
+    } else {
+      cb(null, []);
+    }
+  });
+}
+
+/**
+ * Helper to require database.js with mocks and wait for async initialization.
+ * Returns the exported db object after all nextTick callbacks have resolved.
+ */
+function requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor) {
+  jest.doMock('fs', () => fsMock);
+  jest.doMock('sqlite3', () => ({
+    verbose: () => ({ Database: DatabaseConstructor }),
+  }));
+
+  const db = require('../../server/database');
+
+  // Return a promise that resolves after the nextTick callback chain completes
+  return new Promise((resolve) => {
+    // Give enough ticks for the initialization chain to complete
+    setImmediate(() => setImmediate(() => resolve(db)));
+  });
+}
+
+describe('Database Initialization - Error Paths', () => {
+  describe('Directory creation', () => {
+    it('creates data directory if it does not exist', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const fsMock = {
+          existsSync: jest.fn().mockReturnValue(false),
+          mkdirSync: jest.fn(),
+          readdirSync: jest.fn().mockReturnValue([]),
+          renameSync: jest.fn(),
+        };
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          allHandler: allColumnsPresent(),
+        });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(fsMock.mkdirSync).toHaveBeenCalled();
+      });
+    });
+
+    it('handles directory creation failure', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const fsMock = {
+          existsSync: jest.fn().mockReturnValue(false),
+          mkdirSync: jest.fn().mockImplementation(() => {
+            throw new Error('EACCES: permission denied');
+          }),
+          readdirSync: jest.fn().mockReturnValue([]),
+          renameSync: jest.fn(),
+        };
+        const { mockDb, DatabaseConstructor } = createMockSetup();
+
+        jest.doMock('fs', () => fsMock);
+        jest.doMock('sqlite3', () => ({
+          verbose: () => ({ Database: DatabaseConstructor }),
+        }));
+
+        expect(() => {
+          require('../../server/database');
+        }).toThrow('EACCES: permission denied');
+      });
+    });
+  });
+
+  describe('Legacy database migration', () => {
+    it('renames legacy sapho.db to sappho.db when found', async () => {
+      await jest.isolateModulesAsync(async () => {
+        delete process.env.DATABASE_PATH;
+
+        const mockRenameSync = jest.fn();
+        const fsMock = {
+          existsSync: jest.fn().mockImplementation((p) => {
+            if (p.endsWith('sappho.db')) return false;
+            if (p.endsWith('sapho.db')) return true;
+            return false;
+          }),
+          mkdirSync: jest.fn(),
+          renameSync: mockRenameSync,
+          readdirSync: jest.fn().mockReturnValue([]),
+        };
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          allHandler: allColumnsPresent(),
+        });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(mockRenameSync).toHaveBeenCalled();
+      });
+    });
+
+    it('handles legacy rename failure gracefully', async () => {
+      await jest.isolateModulesAsync(async () => {
+        delete process.env.DATABASE_PATH;
+
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const fsMock = {
+          existsSync: jest.fn().mockImplementation((p) => {
+            if (p.endsWith('sappho.db')) return false;
+            if (p.endsWith('sapho.db')) return true;
+            return false;
+          }),
+          mkdirSync: jest.fn(),
+          renameSync: jest.fn().mockImplementation(() => {
+            throw new Error('Rename failed');
+          }),
+          readdirSync: jest.fn().mockReturnValue([]),
+        };
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          allHandler: allColumnsPresent(),
+        });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(consoleSpy).toHaveBeenCalledWith('Migration failed:', 'Rename failed');
+        consoleSpy.mockRestore();
+      });
+    });
+
+    it('skips legacy migration when DATABASE_PATH env is set', async () => {
+      await jest.isolateModulesAsync(async () => {
+        process.env.DATABASE_PATH = '/custom/path/sappho.db';
+
+        const mockRenameSync = jest.fn();
+        const fsMock = {
+          existsSync: jest.fn().mockReturnValue(true),
+          mkdirSync: jest.fn(),
+          renameSync: mockRenameSync,
+          readdirSync: jest.fn().mockReturnValue([]),
+        };
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          allHandler: allColumnsPresent(),
+        });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(mockRenameSync).not.toHaveBeenCalled();
+      });
+    });
+
+    it('skips legacy migration when both files exist', async () => {
+      await jest.isolateModulesAsync(async () => {
+        delete process.env.DATABASE_PATH;
+
+        const mockRenameSync = jest.fn();
+        const fsMock = {
+          existsSync: jest.fn().mockReturnValue(true),
+          mkdirSync: jest.fn(),
+          renameSync: mockRenameSync,
+          readdirSync: jest.fn().mockReturnValue([]),
+        };
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          allHandler: allColumnsPresent(),
+        });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(mockRenameSync).not.toHaveBeenCalled();
+      });
+    });
+
+    it('skips legacy migration when neither file exists', async () => {
+      await jest.isolateModulesAsync(async () => {
+        delete process.env.DATABASE_PATH;
+
+        const mockRenameSync = jest.fn();
+        const fsMock = {
+          existsSync: jest.fn().mockReturnValue(false),
+          mkdirSync: jest.fn(),
+          renameSync: mockRenameSync,
+          readdirSync: jest.fn().mockReturnValue([]),
+        };
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          allHandler: allColumnsPresent(),
+        });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(mockRenameSync).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Database connection', () => {
+    it('handles sqlite3 Database constructor error', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const fsMock = mockFsExists();
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          openErr: new Error('SQLITE_CANTOPEN'),
+        });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(consoleSpy).toHaveBeenCalledWith('Error opening database:', expect.any(Error));
+        consoleSpy.mockRestore();
+      });
+    });
+  });
+
+  describe('PRAGMA errors', () => {
+    it('handles PRAGMA foreign_keys error', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const fsMock = mockFsExists();
+
+        const runHandler = jest.fn((sql, ...args) => {
+          const cb = args.find(a => typeof a === 'function');
+          if (sql.includes('PRAGMA foreign_keys')) {
+            if (cb) cb(new Error('FK pragma failed'));
+            return;
+          }
+          if (cb) cb(null);
+        });
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          allHandler: allColumnsPresent(),
+          runHandler,
+        });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(consoleSpy).toHaveBeenCalledWith('Error enabling foreign keys:', expect.any(Error));
+        consoleSpy.mockRestore();
+      });
+    });
+
+    it('handles PRAGMA journal_mode WAL error', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const fsMock = mockFsExists();
+
+        const runHandler = jest.fn((sql, ...args) => {
+          const cb = args.find(a => typeof a === 'function');
+          if (sql.includes('PRAGMA journal_mode')) {
+            if (cb) cb(new Error('WAL pragma failed'));
+            return;
+          }
+          if (cb) cb(null);
+        });
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          allHandler: allColumnsPresent(),
+          runHandler,
+        });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(consoleSpy).toHaveBeenCalledWith('Error enabling WAL mode:', expect.any(Error));
+        consoleSpy.mockRestore();
+      });
+    });
+  });
+
+  describe('ALTER TABLE migrations', () => {
+    it('adds display_name column when missing', async () => {
+      await jest.isolateModulesAsync(async () => {
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        const fsMock = mockFsExists();
+
+        const runCalls = [];
+        const runHandler = jest.fn((sql, ...args) => {
+          runCalls.push(sql);
+          const cb = args.find(a => typeof a === 'function');
+          if (cb) cb(null);
+        });
+        const allHandler = jest.fn((sql, ...args) => {
+          const cb = args.find(a => typeof a === 'function');
+          if (!cb) return;
+          if (sql.includes('table_info(users)')) {
+            cb(null, [{ name: 'id' }, { name: 'username' }]); // missing display_name and avatar
+          } else if (sql.includes('table_info(audiobooks)')) {
+            cb(null, [{ name: 'id' }, { name: 'series_index' }]);
+          } else {
+            cb(null, []);
+          }
+        });
+        const { mockDb, DatabaseConstructor } = createMockSetup({ allHandler, runHandler });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        const alterCalls = runCalls.filter(s => s.includes('ALTER TABLE'));
+        expect(alterCalls.some(s => s.includes('display_name'))).toBe(true);
+        expect(alterCalls.some(s => s.includes('avatar'))).toBe(true);
+      });
+    });
+
+    it('skips display_name and avatar columns when they already exist', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const fsMock = mockFsExists();
+
+        const runCalls = [];
+        const runHandler = jest.fn((sql, ...args) => {
+          runCalls.push(sql);
+          const cb = args.find(a => typeof a === 'function');
+          if (cb) cb(null);
+        });
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          allHandler: allColumnsPresent(),
+          runHandler,
+        });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        const alterCalls = runCalls.filter(s => s.includes('ALTER TABLE users'));
+        expect(alterCalls).toHaveLength(0);
+      });
+    });
+
+    it('handles PRAGMA table_info error for users table', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const fsMock = mockFsExists();
+
+        const allHandler = jest.fn((sql, ...args) => {
+          const cb = args.find(a => typeof a === 'function');
+          if (!cb) return;
+          if (sql.includes('table_info(users)')) {
+            cb(new Error('Table info error'), null);
+          } else if (sql.includes('table_info(audiobooks)')) {
+            cb(null, [{ name: 'id' }, { name: 'series_index' }]);
+          } else {
+            cb(null, []);
+          }
+        });
+        const { mockDb, DatabaseConstructor } = createMockSetup({ allHandler });
+
+        // Should not throw - error is handled internally
+        const db = await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(db).toBeDefined();
+      });
+    });
+
+    it('adds series_index column and migrates data when missing', async () => {
+      await jest.isolateModulesAsync(async () => {
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        const fsMock = mockFsExists();
+
+        const runCalls = [];
+        const runHandler = jest.fn((sql, ...args) => {
+          runCalls.push(sql);
+          const cb = args.find(a => typeof a === 'function');
+          if (cb) cb(null);
+        });
+        const allHandler = jest.fn((sql, ...args) => {
+          const cb = args.find(a => typeof a === 'function');
+          if (!cb) return;
+          if (sql.includes('table_info(users)')) {
+            cb(null, [{ name: 'id' }, { name: 'display_name' }, { name: 'avatar' }]);
+          } else if (sql.includes('table_info(audiobooks)')) {
+            cb(null, [{ name: 'id' }, { name: 'series_position' }]); // missing series_index
+          } else {
+            cb(null, []);
+          }
+        });
+        const { mockDb, DatabaseConstructor } = createMockSetup({ allHandler, runHandler });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(runCalls.some(s => s.includes('ADD COLUMN series_index'))).toBe(true);
+        expect(runCalls.some(s => s.includes('UPDATE audiobooks SET series_index'))).toBe(true);
+      });
+    });
+
+    it('handles ALTER TABLE series_index error', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const fsMock = mockFsExists();
+
+        const runHandler = jest.fn((sql, ...args) => {
+          const cb = args.find(a => typeof a === 'function');
+          if (sql.includes('ALTER TABLE audiobooks ADD COLUMN series_index')) {
+            if (cb) cb(new Error('ALTER TABLE failed'));
+            return;
+          }
+          if (cb) cb(null);
+        });
+        const allHandler = jest.fn((sql, ...args) => {
+          const cb = args.find(a => typeof a === 'function');
+          if (!cb) return;
+          if (sql.includes('table_info(users)')) {
+            cb(null, [{ name: 'id' }, { name: 'display_name' }, { name: 'avatar' }]);
+          } else if (sql.includes('table_info(audiobooks)')) {
+            cb(null, [{ name: 'id' }]); // missing series_index
+          } else {
+            cb(null, []);
+          }
+        });
+        const { mockDb, DatabaseConstructor } = createMockSetup({ allHandler, runHandler });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(consoleSpy).toHaveBeenCalledWith('Error adding series_index column:', expect.any(Error));
+        consoleSpy.mockRestore();
+      });
+    });
+
+    it('handles UPDATE series_position migration error', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const fsMock = mockFsExists();
+
+        const runHandler = jest.fn((sql, ...args) => {
+          const cb = args.find(a => typeof a === 'function');
+          if (sql.includes('UPDATE audiobooks SET series_index')) {
+            if (cb) cb(new Error('Migration data copy failed'));
+            return;
+          }
+          if (cb) cb(null);
+        });
+        const allHandler = jest.fn((sql, ...args) => {
+          const cb = args.find(a => typeof a === 'function');
+          if (!cb) return;
+          if (sql.includes('table_info(users)')) {
+            cb(null, [{ name: 'id' }, { name: 'display_name' }, { name: 'avatar' }]);
+          } else if (sql.includes('table_info(audiobooks)')) {
+            cb(null, [{ name: 'id' }]); // missing series_index
+          } else {
+            cb(null, []);
+          }
+        });
+        const { mockDb, DatabaseConstructor } = createMockSetup({ allHandler, runHandler });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          'Error migrating series_position to series_index:',
+          expect.any(Error)
+        );
+        consoleSpy.mockRestore();
+      });
+    });
+
+    it('handles PRAGMA table_info error for audiobooks table', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const fsMock = mockFsExists();
+
+        const runCalls = [];
+        const runHandler = jest.fn((sql, ...args) => {
+          runCalls.push(sql);
+          const cb = args.find(a => typeof a === 'function');
+          if (cb) cb(null);
+        });
+        const allHandler = jest.fn((sql, ...args) => {
+          const cb = args.find(a => typeof a === 'function');
+          if (!cb) return;
+          if (sql.includes('table_info(users)')) {
+            cb(null, [{ name: 'id' }, { name: 'display_name' }, { name: 'avatar' }]);
+          } else if (sql.includes('table_info(audiobooks)')) {
+            cb(new Error('Table info error'), null);
+          } else {
+            cb(null, []);
+          }
+        });
+        const { mockDb, DatabaseConstructor } = createMockSetup({ allHandler, runHandler });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(runCalls.filter(s => s.includes('ALTER TABLE audiobooks'))).toHaveLength(0);
+      });
+    });
+  });
+
+  describe('Migrations', () => {
+    it('handles missing migrations directory', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        const fsMock = {
+          existsSync: jest.fn().mockImplementation((p) => {
+            if (p.includes('migrations')) return false;
+            return true;
+          }),
+          mkdirSync: jest.fn(),
+          readdirSync: jest.fn().mockReturnValue([]),
+          renameSync: jest.fn(),
+        };
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          allHandler: allColumnsPresent(),
+        });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(consoleSpy).toHaveBeenCalledWith('No migrations directory found');
+        consoleSpy.mockRestore();
+      });
+    });
+
+    it('runs migration files in order and filters non-js files', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        const migrationUp = jest.fn();
+
+        const fsMock = {
+          existsSync: jest.fn().mockReturnValue(true),
+          mkdirSync: jest.fn(),
+          readdirSync: jest.fn().mockImplementation((dir) => {
+            if (dir.includes('migrations')) {
+              return ['001_test.js', '002_test.js', 'readme.md'];
+            }
+            return [];
+          }),
+          renameSync: jest.fn(),
+        };
+
+        const mockMigration = { up: migrationUp, down: jest.fn() };
+        jest.doMock('../../server/migrations/001_test.js', () => mockMigration, { virtual: true });
+        jest.doMock('../../server/migrations/002_test.js', () => mockMigration, { virtual: true });
+
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          allHandler: allColumnsPresent(),
+        });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(consoleSpy).toHaveBeenCalledWith('Found 2 migration(s)');
+        expect(migrationUp).toHaveBeenCalledTimes(2);
+        consoleSpy.mockRestore();
+      });
+    });
+
+    it('handles broken migration file gracefully', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+
+        const fsMock = {
+          existsSync: jest.fn().mockReturnValue(true),
+          mkdirSync: jest.fn(),
+          readdirSync: jest.fn().mockImplementation((dir) => {
+            if (dir.includes('migrations')) return ['001_broken.js'];
+            return [];
+          }),
+          renameSync: jest.fn(),
+        };
+
+        jest.doMock('../../server/migrations/001_broken.js', () => ({
+          up: () => { throw new Error('Migration syntax error'); },
+          down: jest.fn(),
+        }), { virtual: true });
+
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          allHandler: allColumnsPresent(),
+        });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Error running migration 001_broken.js:'),
+          expect.any(Error)
+        );
+        consoleSpy.mockRestore();
+      });
+    });
+
+    it('handles migration file with missing up function', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+
+        const fsMock = {
+          existsSync: jest.fn().mockReturnValue(true),
+          mkdirSync: jest.fn(),
+          readdirSync: jest.fn().mockImplementation((dir) => {
+            if (dir.includes('migrations')) return ['001_noup.js'];
+            return [];
+          }),
+          renameSync: jest.fn(),
+        };
+
+        jest.doMock('../../server/migrations/001_noup.js', () => ({
+          down: jest.fn(),
+        }), { virtual: true });
+
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          allHandler: allColumnsPresent(),
+        });
+
+        await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Error running migration 001_noup.js:'),
+          expect.any(Error)
+        );
+        consoleSpy.mockRestore();
+      });
+    });
+  });
+
+  describe('Database ready promise', () => {
+    it('resolves dbReady promise after initialization', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const fsMock = mockFsExists();
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          allHandler: allColumnsPresent(),
+        });
+
+        const db = await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(db.ready).toBeDefined();
+        expect(db.ready).toBeInstanceOf(Promise);
+        await db.ready;
+      });
+    });
+
+    it('exports db object with standard methods', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const fsMock = mockFsExists();
+        const { mockDb, DatabaseConstructor } = createMockSetup({
+          allHandler: allColumnsPresent(),
+        });
+
+        const db = await requireDatabaseWithMocks(fsMock, mockDb, DatabaseConstructor);
+        expect(db.run).toBeDefined();
+        expect(db.all).toBeDefined();
+        expect(db.get).toBeDefined();
+        expect(db.serialize).toBeDefined();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Phase 1 (#234):** 23 tests for `server/database.js` error paths — directory creation failures, legacy DB migration, PRAGMA errors, ALTER TABLE errors, broken migrations. Brings `database.js` to **100% coverage**.
- **Phase 2 (#235):** 20 security edge case tests — deleted user token rejection, cross-user data isolation, API key deactivation, MFA bypass prevention.
- **Phase 3 (#232/#153):** 25 `libraryScanner.js` export tests (lock/unlock, job status, periodic scan, availability checks) + 17 `fileProcessor.js` export tests (metadata extraction, cover art, series detection, narrator, genre filtering).
- **Phase 4 (#233):** Frontend test infrastructure (vitest + jsdom + testing-library) with 28 API module tests and 13 WebSocket context tests.

**126 new tests total.** Global coverage thresholds raised from 14/12/19/14 to 28/28/38/29.

## Test plan

- [x] `npm test` — 1633 server tests passing (49 suites)
- [x] `npm run test:client` — 41 client tests passing (2 suites)
- [x] `npm run lint` — clean
- [x] `npx jest --coverage` — all thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)