### PR TITLE
Fix back/edit buttons cut off on mobile detail view

### DIFF
--- a/client/src/pages/AudiobookDetail.css
+++ b/client/src/pages/AudiobookDetail.css
@@ -1111,7 +1111,7 @@
   }
 
   .audiobook-detail {
-    padding-top: 0 !important;
+    padding-top: 0.75rem !important;
     padding-bottom: calc(80px + env(safe-area-inset-bottom, 0)) !important;
     padding-left: 1rem !important;
     padding-right: 1rem !important;
@@ -1123,7 +1123,7 @@
   }
 
   .detail-top-bar {
-    margin-top: -8px;
+    margin-top: 0;
     margin-bottom: 1rem;
   }
 


### PR DESCRIPTION
## Summary
- Back and edit buttons in the audiobook detail view were partially hidden behind the fixed navbar on mobile/PWA
- Root cause: `padding-top: 0` on `.audiobook-detail` and `margin-top: -8px` on `.detail-top-bar` pushed the buttons up under the navbar
- Fix: restore `0.75rem` top padding and remove the negative margin

## Test plan
- [ ] Open any audiobook detail on mobile/PWA view
- [ ] Back button and edit button (admin) are fully visible below the navbar
- [ ] No extra whitespace gap introduced on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)