### PR TITLE
Fix file organizer renaming first chapter of multi-file audiobooks

### DIFF
--- a/server/routes/upload.js
+++ b/server/routes/upload.js
@@ -10,6 +10,7 @@ const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
 const { createDbHelpers } = require('../utils/db');
+const { sanitizeName } = require('../services/fileOrganizer');
 
 // SECURITY: Sanitize uploaded filename to prevent path traversal
 function sanitizeFilename(name) {
@@ -208,10 +209,9 @@ router.post('/multifile', uploadLimiter, authenticateToken, upload.array('audiob
 
     const author = firstFileMetadata.author || 'Unknown Author';
 
-    // Create organized directory structure
-    const sanitize = (str) => str.replace(/[^a-z0-9\s]/gi, '_').trim();
-    const authorDir = path.join(audiobooksDir, sanitize(author));
-    const bookDir = path.join(authorDir, sanitize(title));
+    // Create organized directory structure (use sanitizeName for consistency with file organizer)
+    const authorDir = path.join(audiobooksDir, sanitizeName(author) || 'Unknown Author');
+    const bookDir = path.join(authorDir, sanitizeName(title) || 'Unknown Title');
 
     if (!fs.existsSync(bookDir)) {
       fs.mkdirSync(bookDir, { recursive: true });


### PR DESCRIPTION
## Summary
- **Bug**: The file organizer was renaming the first chapter file of multi-file audiobooks to `{BookTitle}.ext` while other chapters kept their original `{NN} - {name}.ext` format. This caused DB chapter paths to not match actual filenames, breaking playback of the first chapter.
- **Root cause 1**: `organizeAudiobook()` treated multi-file books the same as single-file books — renaming the main `file_path` to `{Title}.ext`. For multi-file books, `file_path` references the first chapter, which shouldn't be renamed.
- **Root cause 2**: `upload.js` used a different sanitize function than `fileOrganizer.js` for directory names, causing false-positive reorganization triggers after upload.

## Changes
- `fileOrganizer.js`: Multi-file books now preserve all chapter filenames during organization (only directory changes, no file renames)
- `fileOrganizer.js`: `needsOrganization()` skips filename checks for multi-file books
- `upload.js`: Uses `sanitizeName` from `fileOrganizer` for consistent directory naming
- Updated tests for new multi-file behavior and `db.get` mock for user ID resolution

## Test plan
- [x] All 41 fileOrganizer tests pass (including new multi-file preservation test)
- [x] All 57 libraryScanner tests pass  
- [x] All 55 upload route tests pass
- [ ] Upload a multi-file audiobook, then trigger "Organize Library" — verify all chapter filenames are preserved
- [ ] Edit metadata on a multi-file book — verify chapter files aren't renamed

🤖 Generated with [Claude Code](https://claude.com/claude-code)