### PR TITLE
Fix batch delete to accept camelCase request keys

### DIFF
--- a/server/routes/audiobooks/batch.js
+++ b/server/routes/audiobooks/batch.js
@@ -539,9 +539,12 @@ The reader has started this book and wants to remember what it's about and any k
 
   // Batch delete (admin only)
   router.post('/batch/delete', batchDeleteLimiter, authenticateToken, requireAdmin, async (req, res) => {
-    const { audiobook_ids, delete_files } = req.body;
+    // Accept both snake_case and camelCase keys (Android Gson may send camelCase)
+    const audiobook_ids = req.body.audiobook_ids || req.body.audiobookIds;
+    const delete_files = req.body.delete_files !== undefined ? req.body.delete_files : req.body.deleteFiles;
 
     if (!Array.isArray(audiobook_ids) || audiobook_ids.length === 0) {
+      console.error('Batch delete validation failed. req.body keys:', Object.keys(req.body), 'audiobook_ids type:', typeof audiobook_ids);
       return res.status(400).json({ error: 'audiobook_ids must be a non-empty array' });
     }
 


### PR DESCRIPTION
## Summary
- Android Gson serialization may send camelCase keys (`audiobookIds`, `deleteFiles`) instead of snake_case (`audiobook_ids`, `delete_files`)
- Server batch delete endpoint now accepts both formats
- Added debug logging to diagnose if the issue persists

## Context
Android app batch delete returns 400 "audiobook_ids must be a non-empty array" despite sending a valid JSON body (4569 bytes). All other batch endpoints work fine with `BatchActionRequest`. The `BatchDeleteRequest` class has correct `@SerializedName` annotations but the server isn't finding the expected keys.

## Test plan
- [ ] Test batch delete from Android app
- [ ] Check server logs for debug output if issue persists
- [ ] Verify other batch endpoints still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)