### PR TITLE
Fix batch action bar hidden behind mini player

### DIFF
--- a/client/src/components/BatchActionBar.css
+++ b/client/src/components/BatchActionBar.css
@@ -7,7 +7,7 @@
   background: #1f2937;
   padding: 12px 8px;
   padding-bottom: calc(12px + env(safe-area-inset-bottom, 0));
-  z-index: 1000;
+  z-index: 1002;
   box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.3);
 }
 


### PR DESCRIPTION
## Summary
- Batch action bar z-index (1000) was below the audio player (1001), making batch actions inaccessible when the mini player was visible
- Bumped batch action bar to z-index 1002

## Test plan
- [ ] Start playing a book (mini player visible)
- [ ] Go to All Books, enter selection mode
- [ ] Verify batch action buttons are accessible above the mini player

🤖 Generated with [Claude Code](https://claude.com/claude-code)