### PR TITLE
Fix fresh database startup race condition

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -196,12 +196,15 @@ function initializeDatabase() {
     // Run migrations after core tables are created
     runMigrations();
 
-    console.log('Database initialized');
-
-    // Signal that database is ready
-    if (dbReadyResolve) {
-      dbReadyResolve();
-    }
+    // Signal that database is ready AFTER all queued SQL has executed.
+    // db.get() inside serialize ensures the callback fires only after
+    // all preceding serialized statements have completed.
+    db.get('SELECT 1', [], () => {
+      console.log('Database initialized');
+      if (dbReadyResolve) {
+        dbReadyResolve();
+      }
+    });
   });
 }
 

--- a/server/services/emailService.js
+++ b/server/services/emailService.js
@@ -565,8 +565,12 @@ async function sendAccountUnlockEmail(user, unlockToken) {
   });
 }
 
-// Initialize transporter on module load
-initializeTransporter();
+// Initialize transporter after database is ready
+if (db.ready) {
+  db.ready.then(() => initializeTransporter());
+} else {
+  initializeTransporter();
+}
 
 module.exports = {
   getSMTPSettings,


### PR DESCRIPTION
## Summary
- Fixed a race condition where `dbReadyResolve()` fired synchronously inside `db.serialize()` before CREATE TABLE statements actually executed
- On first-time startup with an empty database, `createDefaultAdmin()` would query the non-existent `users` table, triggering `SQLITE_ERROR` and `process.exit(1)` before schema creation could commit
- Deferred `emailService` transporter initialization until after `db.ready` resolves, preventing premature `email_settings` table queries

## Root Cause
The `db.ready` promise was resolved synchronously at the end of the `db.serialize()` callback, which only *queues* SQL statements — it doesn't wait for them to complete. On existing databases this was harmless (tables already exist), but on a fresh database the tables hadn't been created yet when downstream code tried to query them.

## Fix
- Resolve `db.ready` inside a `db.get("SELECT 1")` callback at the end of the serialize block, ensuring all preceding SQL has completed
- Defer `emailService.initializeTransporter()` to run after `db.ready` instead of at module load time

## Test plan
- [x] All 1675 tests pass
- [ ] Deploy to Sappho-Dev container (fresh DB) and verify it starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)