### PR TITLE
Fix book deletion blocked by FK constraint

### DIFF
--- a/server/routes/audiobooks/batch.js
+++ b/server/routes/audiobooks/batch.js
@@ -566,7 +566,8 @@ The reader has started this book and wants to remember what it's about and any k
             continue;
           }
 
-          // Delete from database
+          // Delete related data first (playback_progress lacks ON DELETE CASCADE)
+          await dbRun('DELETE FROM playback_progress WHERE audiobook_id = ?', [audiobookId]);
           await dbRun('DELETE FROM audiobooks WHERE id = ?', [audiobookId]);
 
           // Optionally delete files and directory

--- a/server/routes/audiobooks/crud.js
+++ b/server/routes/audiobooks/crud.js
@@ -264,7 +264,8 @@ function register(router, { db, authenticateToken, requireAdmin, normalizeGenres
         return res.status(404).json({ error: 'Audiobook not found' });
       }
 
-      // Delete from database first
+      // Delete related data first (playback_progress lacks ON DELETE CASCADE)
+      await dbRun('DELETE FROM playback_progress WHERE audiobook_id = ?', [req.params.id]);
       await dbRun('DELETE FROM audiobooks WHERE id = ?', [req.params.id]);
 
       // Delete entire audiobook directory (contains audio file, cover, etc.)

--- a/server/routes/maintenance/library.js
+++ b/server/routes/maintenance/library.js
@@ -93,6 +93,7 @@ function register(router, { db, authenticateToken, requireAdmin, extractFileMeta
 
           if (sortedBooks.length > 1) {
             const idsToDelete = sortedBooks.slice(1).map(b => b.id);
+            await dbRun(`DELETE FROM playback_progress WHERE audiobook_id IN (${idsToDelete.join(',')})`);
             await dbRun(`DELETE FROM audiobooks WHERE id IN (${idsToDelete.join(',')})`);
           }
 


### PR DESCRIPTION
## Summary
- `playback_progress` table has `FOREIGN KEY (audiobook_id) REFERENCES audiobooks(id)` **without** `ON DELETE CASCADE`
- With foreign keys enabled, deleting any book that has playback progress silently fails
- This caused batch delete to return `count: 0` for books users had listened to
- Fixed in single delete, batch delete, and maintenance consolidation endpoints

## Root Cause
All other related tables (`audiobook_chapters`, `user_favorites`, `user_ratings`, `collection_items`, `book_recaps`) have `ON DELETE CASCADE`, but `playback_progress` (defined in the original schema) does not.

## Test plan
- [x] All 1675 tests pass
- [ ] Batch delete books with progress entries
- [ ] Single delete a book with progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)