### PR TITLE
Fix desktop layout: widen admin pages and show overflow menu

### DIFF
--- a/client/src/components/settings/StatisticsSettings.css
+++ b/client/src/components/settings/StatisticsSettings.css
@@ -19,6 +19,12 @@
   gap: 0.5rem;
 }
 
+@media (min-width: 600px) {
+  .stats-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
 .stats-card {
   background: var(--bg-secondary);
   border-radius: 10px;

--- a/client/src/pages/AudiobookDetail.css
+++ b/client/src/pages/AudiobookDetail.css
@@ -1870,10 +1870,26 @@
   background: rgba(239, 68, 68, 0.15);
 }
 
-/* Desktop: Hide more menu button, show detail-actions */
+/* Desktop: Show more menu in play-button-row (play button hidden, cover overlay used instead) */
 @media (min-width: 769px) {
-  .more-menu-container {
+  .play-button-row {
+    display: flex;
+    margin-top: 0.75rem;
+  }
+
+  .play-button-row .detail-play-button {
     display: none;
+  }
+
+  .play-button-row .more-menu-container {
+    display: block;
+  }
+
+  .play-button-row .more-menu-dropdown {
+    bottom: auto;
+    top: 100%;
+    margin-bottom: 0;
+    margin-top: 8px;
   }
 }
 

--- a/client/src/pages/Settings.css
+++ b/client/src/pages/Settings.css
@@ -3,7 +3,7 @@
 .settings-page {
   padding: 1rem;
   padding-bottom: calc(80px + env(safe-area-inset-bottom, 0));
-  max-width: 500px;
+  max-width: 900px;
   margin: 0 auto;
 }
 
@@ -32,9 +32,15 @@
 
 /* Menu */
 .settings-menu {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr;
   gap: 0.5rem;
+}
+
+@media (min-width: 600px) {
+  .settings-menu {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 .settings-menu-item {


### PR DESCRIPTION
## Summary
- Settings page `max-width` increased from 500px to 900px so admin pages use available desktop width
- Settings menu uses 2-column grid layout on desktop (≥600px)
- Statistics grid uses 4 columns on desktop instead of always 2
- Three-dot overflow menu now visible on desktop audiobook detail page — previously hidden, making Convert to M4B, Refresh Metadata, Export, Delete etc. completely inaccessible on desktop

## Test plan
- [ ] Open admin/settings page in desktop browser — should use full width, menu items in 2 columns
- [ ] Open Statistics settings — overview cards should be in 4 columns on desktop
- [ ] Open any audiobook detail on desktop — three-dot menu should be visible below the cover
- [ ] Click three-dot menu on desktop — dropdown should open downward with all options (Convert to M4B, Refresh Metadata, etc.)
- [ ] Verify mobile layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)