### PR TITLE
Add desktop action buttons to audiobook detail page

### DIFF
--- a/client/src/pages/AudiobookDetail.css
+++ b/client/src/pages/AudiobookDetail.css
@@ -1109,6 +1109,68 @@
   font-weight: 600;
 }
 
+/* Desktop Action Buttons - visible on desktop, hidden on mobile */
+.desktop-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.desktop-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  background: rgba(107, 114, 128, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  color: #d1d5db;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.desktop-action-btn:hover {
+  background: rgba(107, 114, 128, 0.25);
+  border-color: rgba(255, 255, 255, 0.15);
+  color: #f3f4f6;
+}
+
+.desktop-action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.desktop-action-btn svg {
+  flex-shrink: 0;
+  color: #9ca3af;
+}
+
+.desktop-action-btn:hover svg {
+  color: #d1d5db;
+}
+
+.desktop-action-btn svg.spinning {
+  animation: spin 1s linear infinite;
+}
+
+.desktop-action-btn.danger {
+  color: #fca5a5;
+}
+
+.desktop-action-btn.danger svg {
+  color: #f87171;
+}
+
+.desktop-action-btn.danger:hover {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.3);
+}
+
 @media (max-width: 768px) {
   /* Hide desktop-only blocks on mobile */
   .desktop-only-block {
@@ -1117,6 +1179,11 @@
 
   /* Hide desktop cover buttons on mobile */
   .desktop-cover-buttons {
+    display: none !important;
+  }
+
+  /* Hide desktop actions on mobile (overflow menu used instead) */
+  .desktop-actions {
     display: none !important;
   }
 
@@ -1870,26 +1937,10 @@
   background: rgba(239, 68, 68, 0.15);
 }
 
-/* Desktop: Show more menu in play-button-row (play button hidden, cover overlay used instead) */
+/* Desktop: Hide more menu (desktop-actions section used instead) */
 @media (min-width: 769px) {
-  .play-button-row {
-    display: flex;
-    margin-top: 0.75rem;
-  }
-
-  .play-button-row .detail-play-button {
+  .more-menu-container {
     display: none;
-  }
-
-  .play-button-row .more-menu-container {
-    display: block;
-  }
-
-  .play-button-row .more-menu-dropdown {
-    bottom: auto;
-    top: 100%;
-    margin-bottom: 0;
-    margin-top: 8px;
   }
 }
 

--- a/client/src/pages/AudiobookDetail.jsx
+++ b/client/src/pages/AudiobookDetail.jsx
@@ -709,6 +709,69 @@ export default function AudiobookDetail({ onPlay }) {
             </div>
           )}
 
+          {/* Desktop Action Buttons - hidden on mobile where overflow menu is used */}
+          <div className="desktop-actions">
+            <button className="desktop-action-btn" onClick={() => setShowCollectionModal(true)}>
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
+                <line x1="12" y1="11" x2="12" y2="17"></line>
+                <line x1="9" y1="14" x2="15" y2="14"></line>
+              </svg>
+              Add to Collection
+            </button>
+            <button className="desktop-action-btn" onClick={handleMarkFinished}>
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
+                <polyline points="22 4 12 14.01 9 11.01"></polyline>
+              </svg>
+              Mark Finished
+            </button>
+            {hasProgress && (
+              <button className="desktop-action-btn" onClick={handleClearProgress}>
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="1 4 1 10 7 10"></polyline>
+                  <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path>
+                </svg>
+                Clear Progress
+              </button>
+            )}
+            <button className="desktop-action-btn" onClick={handleDownload}>
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                <polyline points="7 10 12 15 17 10"></polyline>
+                <line x1="12" y1="15" x2="12" y2="3"></line>
+              </svg>
+              Export File
+            </button>
+            {isAdmin && (
+              <>
+                <button className="desktop-action-btn" onClick={handleRefreshMetadata} disabled={refreshingMetadata}>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={refreshingMetadata ? 'spinning' : ''}>
+                    <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
+                  </svg>
+                  {refreshingMetadata ? 'Refreshing...' : 'Refresh Metadata'}
+                </button>
+                {audiobook?.file_path && !audiobook.file_path.toLowerCase().endsWith('.m4b') && (
+                  <button className="desktop-action-btn" onClick={handleConvertToM4B} disabled={converting}>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={converting ? 'spinning' : ''}>
+                      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                      <polyline points="17 8 12 3 7 8"/>
+                      <line x1="12" y1="3" x2="12" y2="15"/>
+                    </svg>
+                    {converting ? 'Converting...' : 'Convert to M4B'}
+                  </button>
+                )}
+                <button className="desktop-action-btn danger" onClick={handleDelete}>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="3 6 5 6 21 6"></polyline>
+                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                  </svg>
+                  Delete
+                </button>
+              </>
+            )}
+          </div>
+
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- All actions (Add to Collection, Mark Finished, Clear Progress, Export, Refresh Metadata, Convert to M4B, Delete) were only accessible via the mobile overflow menu, which was hidden on desktop
- Adds visible action buttons in the detail-info section on desktop
- Hidden on mobile where the three-dot overflow menu handles them
- Replaces previous approach of showing the three-dot menu on desktop

## Test plan
- [ ] Open any audiobook detail on desktop — action buttons visible below description
- [ ] Admin buttons (Refresh Metadata, Convert to M4B, Delete) only shown for admin users
- [ ] Clear Progress only shown when there is progress
- [ ] Convert to M4B only shown for non-M4B files
- [ ] All buttons functional (collection, mark finished, clear progress, export, etc.)
- [ ] Mobile layout unchanged — buttons hidden, three-dot menu still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)