### PR TITLE
Add floating conversion progress panel & fix post-conversion duration

### DIFF
--- a/client/src/components/JobsIndicator.css
+++ b/client/src/components/JobsIndicator.css
@@ -1,3 +1,4 @@
+/* Gear icon button in navbar */
 .jobs-indicator {
   position: relative;
   display: flex;
@@ -24,17 +25,13 @@
   color: var(--text-primary);
 }
 
-.jobs-indicator-button svg {
+.jobs-indicator-button.has-active svg {
   animation: jobs-spin 2s linear infinite;
 }
 
 @keyframes jobs-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }
 
 .jobs-badge {
@@ -55,112 +52,84 @@
   box-shadow: 0 2px 4px rgba(59, 130, 246, 0.3);
 }
 
-.jobs-dropdown {
-  position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
+/* Floating progress panel */
+.jobs-panel {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  z-index: 1000;
   background: var(--bg-card);
   border: 1px solid var(--border-secondary);
-  border-radius: 8px;
-  box-shadow: 0 10px 25px var(--shadow-color);
-  min-width: 280px;
-  max-width: 360px;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3), 0 2px 8px rgba(0, 0, 0, 0.2);
   overflow: hidden;
-  z-index: 100;
+  transition: width 0.25s ease, max-height 0.25s ease;
 }
 
-.jobs-dropdown-header {
-  padding: 12px 16px;
-  font-weight: 600;
-  font-size: 13px;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+.jobs-panel.compact {
+  width: 320px;
+  max-height: 80px;
+  cursor: pointer;
+}
+
+.jobs-panel.compact:hover {
+  border-color: var(--accent-primary, #3b82f6);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(59, 130, 246, 0.2);
+}
+
+.jobs-panel.expanded {
+  width: 380px;
+  max-height: 420px;
+}
+
+/* Slide-in animation */
+.jobs-panel-slide-in {
+  animation: jobs-slide-in 0.3s ease-out;
+}
+
+@keyframes jobs-slide-in {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+/* Shift up when player is active */
+.player-active .jobs-panel {
+  bottom: 96px;
+}
+
+/* Panel header */
+.jobs-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
   border-bottom: 1px solid var(--border-secondary);
   background: var(--bg-tertiary);
 }
 
-.job-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--border-secondary);
-}
-
-.job-item:last-child {
-  border-bottom: none;
-}
-
-.job-info {
-  flex: 1;
-  min-width: 0;
-}
-
-.job-title {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--text-primary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin-bottom: 4px;
-}
-
-.job-message {
-  font-size: 12px;
-  color: var(--text-secondary);
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.job-status-badge {
-  display: inline-block;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 10px;
+.jobs-panel-title {
+  font-size: 13px;
   font-weight: 600;
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.3px;
 }
 
-.job-status-completed {
-  background: rgba(34, 197, 94, 0.15);
-  color: #22c55e;
+.jobs-panel-actions {
+  display: flex;
+  gap: 4px;
 }
 
-.job-status-failed {
-  background: rgba(239, 68, 68, 0.15);
-  color: #ef4444;
-}
-
-.job-status-cancelled {
-  background: rgba(156, 163, 175, 0.15);
-  color: #9ca3af;
-}
-
-.job-progress-bar {
-  height: 4px;
-  background: var(--bg-tertiary);
-  border-radius: 2px;
-  margin-top: 8px;
-  overflow: hidden;
-}
-
-.job-progress-fill {
-  height: 100%;
-  background: linear-gradient(90deg, #3b82f6 0%, #60a5fa 100%);
-  border-radius: 2px;
-  transition: width 0.3s ease;
-}
-
-.job-cancel {
-  flex-shrink: 0;
-  width: 24px;
-  height: 24px;
-  border-radius: 4px;
+.jobs-panel-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
   background: transparent;
   border: none;
   color: var(--text-secondary);
@@ -168,13 +137,184 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.2s;
-  margin-top: 2px;
+  transition: all 0.15s;
 }
 
-.job-cancel:hover {
+.jobs-panel-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+/* Job list */
+.jobs-panel-list {
+  overflow-y: auto;
+  max-height: 340px;
+}
+
+.jobs-panel-item {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-secondary);
+}
+
+.jobs-panel-item:last-child {
+  border-bottom: none;
+}
+
+.jobs-panel-item-completed {
+  background: rgba(34, 197, 94, 0.06);
+}
+
+.jobs-panel-item-failed {
+  background: rgba(239, 68, 68, 0.06);
+}
+
+.jobs-panel-item-cancelled {
+  background: rgba(156, 163, 175, 0.06);
+}
+
+.jobs-panel-item-info {
+  min-width: 0;
+}
+
+.jobs-panel-item-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.jobs-panel-item-detail {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 4px;
+}
+
+.jobs-panel-item-message {
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.jobs-panel-item-elapsed {
+  font-size: 11px;
+  color: var(--text-tertiary, var(--text-secondary));
+  opacity: 0.7;
+  flex-shrink: 0;
+  margin-left: 8px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Status labels */
+.jobs-panel-status {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.jobs-panel-status-completed {
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+}
+
+.jobs-panel-status-failed {
   background: rgba(239, 68, 68, 0.15);
   color: #ef4444;
+}
+
+.jobs-panel-status-cancelled {
+  background: rgba(156, 163, 175, 0.15);
+  color: #9ca3af;
+}
+
+/* Progress bar row */
+.jobs-panel-item-progress-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.jobs-panel-progress-bar {
+  flex: 1;
+  height: 4px;
+  background: var(--bg-tertiary);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.expanded .jobs-panel-progress-bar {
+  height: 6px;
+  border-radius: 3px;
+}
+
+.jobs-panel-progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #3b82f6 0%, #60a5fa 100%);
+  border-radius: inherit;
+  transition: width 0.5s ease;
+}
+
+.jobs-panel-progress-pct {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+  min-width: 36px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Cancel button */
+.jobs-panel-cancel {
+  margin-top: 8px;
+  padding: 4px 12px;
+  border-radius: 6px;
+  background: transparent;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #ef4444;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.jobs-panel-cancel:hover {
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.5);
+}
+
+/* Compact mode: hide detail elements */
+.compact .jobs-panel-item-detail,
+.compact .jobs-panel-cancel {
+  display: none;
+}
+
+.compact .jobs-panel-item {
+  padding: 8px 12px;
+}
+
+.compact .jobs-panel-header {
+  padding: 8px 12px;
+}
+
+.compact .jobs-panel-list {
+  max-height: none;
+  overflow: hidden;
+}
+
+/* Only show first job in compact */
+.compact .jobs-panel-item:not(:first-child) {
+  display: none;
 }
 
 /* Mobile styles */
@@ -189,20 +329,30 @@
     height: 18px;
   }
 
-  .jobs-dropdown {
-    position: fixed;
-    top: 70px;
-    right: 1rem;
-    left: auto;
-    min-width: 260px;
-    max-width: calc(100vw - 2rem);
-  }
-
   .jobs-badge {
     top: -3px;
     right: -3px;
     min-width: 16px;
     height: 16px;
     font-size: 10px;
+  }
+
+  .jobs-panel {
+    right: 8px;
+    left: 8px;
+    bottom: 8px;
+  }
+
+  .jobs-panel.compact,
+  .jobs-panel.expanded {
+    width: auto;
+  }
+
+  .jobs-panel.expanded {
+    max-height: 60vh;
+  }
+
+  .player-active .jobs-panel {
+    bottom: 88px;
   }
 }

--- a/client/src/components/JobsIndicator.jsx
+++ b/client/src/components/JobsIndicator.jsx
@@ -3,11 +3,30 @@ import { useWebSocketEvent } from '../contexts/WebSocketContext';
 import { getConversionJobs, cancelConversionJob } from '../api';
 import './JobsIndicator.css';
 
+function formatElapsed(startTime) {
+  const seconds = Math.floor((Date.now() - startTime) / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  if (minutes < 60) return `${minutes}m ${secs}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+}
+
 export default function JobsIndicator({ user }) {
   const [jobs, setJobs] = useState([]);
   const [completedJobs, setCompletedJobs] = useState([]);
-  const [showDropdown, setShowDropdown] = useState(false);
-  const dropdownRef = useRef(null);
+  const [panelState, setPanelState] = useState('hidden'); // 'hidden' | 'badge' | 'compact' | 'expanded'
+  const [, forceUpdate] = useState(0);
+  const jobStartTimes = useRef(new Map());
+  const userDismissedRef = useRef(false);
+
+  // Tick elapsed time every second when panel is visible
+  useEffect(() => {
+    if (jobs.length === 0 || panelState === 'hidden' || panelState === 'badge') return;
+    const interval = setInterval(() => forceUpdate(n => n + 1), 1000);
+    return () => clearInterval(interval);
+  }, [jobs.length, panelState]);
 
   // Fetch active jobs on mount
   useEffect(() => {
@@ -19,9 +38,18 @@ export default function JobsIndicator({ user }) {
   const fetchJobs = async () => {
     try {
       const response = await getConversionJobs();
-      setJobs(response.data.jobs || []);
+      const activeJobs = response.data.jobs || [];
+      setJobs(activeJobs);
+      activeJobs.forEach(job => {
+        if (!jobStartTimes.current.has(job.jobId)) {
+          jobStartTimes.current.set(job.jobId, Date.now());
+        }
+      });
+      if (activeJobs.length > 0 && !userDismissedRef.current) {
+        setPanelState('compact');
+      }
     } catch (error) {
-      console.error('Failed to fetch conversion jobs:', error);
+      // Silent fail on fetch
     }
   };
 
@@ -31,22 +59,25 @@ export default function JobsIndicator({ user }) {
     if (!job) return;
 
     if (job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled') {
-      // Move to completed jobs
       setJobs(prev => prev.filter(j => j.jobId !== job.jobId));
       setCompletedJobs(prev => {
-        // Don't add duplicates
         if (prev.some(j => j.jobId === job.jobId)) {
           return prev.map(j => j.jobId === job.jobId ? job : j);
         }
         return [...prev, job];
       });
 
-      // Auto-remove completed job after 3 seconds
+      // Auto-remove completed job after 5 seconds
       setTimeout(() => {
         setCompletedJobs(prev => prev.filter(j => j.jobId !== job.jobId));
-      }, 3000);
+        jobStartTimes.current.delete(job.jobId);
+      }, 5000);
     } else {
-      // Update or add active job
+      // Track start time for new jobs
+      if (!jobStartTimes.current.has(job.jobId)) {
+        jobStartTimes.current.set(job.jobId, Date.now());
+      }
+
       setJobs(prev => {
         const existing = prev.find(j => j.jobId === job.jobId);
         if (existing) {
@@ -54,113 +85,201 @@ export default function JobsIndicator({ user }) {
         }
         return [...prev, job];
       });
+
+      // Auto-show panel for new jobs (unless user explicitly dismissed)
+      if (!userDismissedRef.current) {
+        setPanelState(prev => prev === 'hidden' ? 'compact' : prev);
+      } else {
+        // At minimum show badge when user dismissed
+        setPanelState(prev => prev === 'hidden' ? 'badge' : prev);
+      }
     }
   }, []);
 
   useWebSocketEvent('job.update', handleJobUpdate);
 
-  // Click outside to close dropdown
+  // Reset panel when all jobs finish
   useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (showDropdown && dropdownRef.current && !dropdownRef.current.contains(event.target)) {
-        setShowDropdown(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [showDropdown]);
+    if (jobs.length === 0 && completedJobs.length === 0) {
+      setPanelState('hidden');
+      userDismissedRef.current = false;
+    }
+  }, [jobs.length, completedJobs.length]);
 
   const handleCancel = async (jobId, e) => {
     e.stopPropagation();
     try {
       await cancelConversionJob(jobId);
-      // Job will be removed via WebSocket update
     } catch (error) {
-      console.error('Failed to cancel job:', error);
+      // Job will be removed via WebSocket update
     }
   };
 
-  const getStatusBadgeClass = (status) => {
-    switch (status) {
-      case 'completed': return 'job-status-completed';
-      case 'failed': return 'job-status-failed';
-      case 'cancelled': return 'job-status-cancelled';
-      default: return '';
+  const handleDismiss = (e) => {
+    e.stopPropagation();
+    userDismissedRef.current = true;
+    setPanelState(jobs.length > 0 ? 'badge' : 'hidden');
+  };
+
+  const handleGearClick = () => {
+    const allJobs = [...jobs, ...completedJobs];
+    if (allJobs.length === 0) return;
+    if (panelState === 'hidden' || panelState === 'badge') {
+      userDismissedRef.current = false;
+      setPanelState('compact');
+    } else {
+      userDismissedRef.current = true;
+      setPanelState('badge');
     }
   };
 
-  // Only render for admin users with active or recently completed jobs
+  const handlePanelClick = () => {
+    if (panelState === 'compact') {
+      setPanelState('expanded');
+    }
+  };
+
+  const handleMinimize = (e) => {
+    e.stopPropagation();
+    setPanelState('compact');
+  };
+
   const allJobs = [...jobs, ...completedJobs];
   if (!user?.is_admin || allJobs.length === 0) {
     return null;
   }
 
   const activeCount = jobs.length;
+  const showBadge = panelState === 'badge' || panelState === 'hidden';
 
   return (
-    <div className="jobs-indicator" ref={dropdownRef}>
-      <button
-        className="jobs-indicator-button"
-        onClick={() => setShowDropdown(!showDropdown)}
-        title={`${activeCount} active job${activeCount !== 1 ? 's' : ''}`}
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M12 2v4" />
-          <path d="m16.2 7.8 2.9-2.9" />
-          <path d="M18 12h4" />
-          <path d="m16.2 16.2 2.9 2.9" />
-          <path d="M12 18v4" />
-          <path d="m4.9 19.1 2.9-2.9" />
-          <path d="M2 12h4" />
-          <path d="m4.9 4.9 2.9 2.9" />
-        </svg>
-        {activeCount > 0 && (
-          <span className="jobs-badge">{activeCount}</span>
-        )}
-      </button>
+    <>
+      {/* Gear icon button in navbar */}
+      <div className="jobs-indicator">
+        <button
+          className={`jobs-indicator-button ${activeCount > 0 ? 'has-active' : ''}`}
+          onClick={handleGearClick}
+          title={`${activeCount} active job${activeCount !== 1 ? 's' : ''}`}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 2v4" />
+            <path d="m16.2 7.8 2.9-2.9" />
+            <path d="M18 12h4" />
+            <path d="m16.2 16.2 2.9 2.9" />
+            <path d="M12 18v4" />
+            <path d="m4.9 19.1 2.9-2.9" />
+            <path d="M2 12h4" />
+            <path d="m4.9 4.9 2.9 2.9" />
+          </svg>
+          {showBadge && activeCount > 0 && (
+            <span className="jobs-badge">{activeCount}</span>
+          )}
+        </button>
+      </div>
 
-      {showDropdown && (
-        <div className="jobs-dropdown">
-          <div className="jobs-dropdown-header">
-            Background Jobs
-          </div>
-          {allJobs.map(job => (
-            <div key={job.jobId} className="job-item">
-              <div className="job-info">
-                <div className="job-title">{job.audiobookTitle || 'Conversion'}</div>
-                <div className="job-message">
-                  {job.message || job.status}
-                  {(job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled') && (
-                    <span className={`job-status-badge ${getStatusBadgeClass(job.status)}`}>
-                      {job.status}
-                    </span>
-                  )}
-                </div>
-                {job.status !== 'completed' && job.status !== 'failed' && job.status !== 'cancelled' && (
-                  <div className="job-progress-bar">
-                    <div
-                      className="job-progress-fill"
-                      style={{ width: `${job.progress || 0}%` }}
-                    />
-                  </div>
-                )}
-              </div>
-              {job.status !== 'completed' && job.status !== 'failed' && job.status !== 'cancelled' && (
+      {/* Floating progress panel */}
+      {(panelState === 'compact' || panelState === 'expanded') && (
+        <div
+          className={`jobs-panel ${panelState} ${panelState === 'compact' ? 'jobs-panel-slide-in' : ''}`}
+          onClick={panelState === 'compact' ? handlePanelClick : undefined}
+          role={panelState === 'compact' ? 'button' : undefined}
+          tabIndex={panelState === 'compact' ? 0 : undefined}
+        >
+          {/* Header */}
+          <div className="jobs-panel-header">
+            <span className="jobs-panel-title">
+              {activeCount > 0
+                ? `${activeCount} conversion${activeCount !== 1 ? 's' : ''} running`
+                : 'Jobs complete'}
+            </span>
+            <div className="jobs-panel-actions">
+              {panelState === 'expanded' && (
                 <button
-                  className="job-cancel"
-                  onClick={(e) => handleCancel(job.jobId, e)}
-                  title="Cancel job"
+                  className="jobs-panel-btn"
+                  onClick={handleMinimize}
+                  title="Minimize"
+                  aria-label="Minimize panel"
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <line x1="18" y1="6" x2="6" y2="18" />
-                    <line x1="6" y1="6" x2="18" y2="18" />
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="6 15 12 9 18 15" />
                   </svg>
                 </button>
               )}
+              <button
+                className="jobs-panel-btn"
+                onClick={handleDismiss}
+                title="Dismiss"
+                aria-label="Dismiss panel"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
             </div>
-          ))}
+          </div>
+
+          {/* Job list */}
+          <div className="jobs-panel-list">
+            {allJobs.map(job => {
+              const isFinished = job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled';
+              const startTime = jobStartTimes.current.get(job.jobId);
+              const elapsed = startTime ? formatElapsed(startTime) : '';
+
+              return (
+                <div
+                  key={job.jobId}
+                  className={`jobs-panel-item ${isFinished ? `jobs-panel-item-${job.status}` : ''}`}
+                >
+                  <div className="jobs-panel-item-info">
+                    <div className="jobs-panel-item-title">
+                      {job.audiobookTitle || 'Conversion'}
+                    </div>
+                    {panelState === 'expanded' && (
+                      <div className="jobs-panel-item-detail">
+                        <span className="jobs-panel-item-message">
+                          {isFinished ? (
+                            <span className={`jobs-panel-status jobs-panel-status-${job.status}`}>
+                              {job.status === 'completed' ? 'Completed' : job.status === 'failed' ? 'Failed' : 'Cancelled'}
+                            </span>
+                          ) : (
+                            job.message || 'Processing...'
+                          )}
+                        </span>
+                        {!isFinished && elapsed && (
+                          <span className="jobs-panel-item-elapsed">{elapsed}</span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+
+                  {!isFinished && (
+                    <div className="jobs-panel-item-progress-row">
+                      <div className="jobs-panel-progress-bar">
+                        <div
+                          className="jobs-panel-progress-fill"
+                          style={{ width: `${job.progress || 0}%` }}
+                        />
+                      </div>
+                      <span className="jobs-panel-progress-pct">{job.progress || 0}%</span>
+                    </div>
+                  )}
+
+                  {panelState === 'expanded' && !isFinished && (
+                    <button
+                      className="jobs-panel-cancel"
+                      onClick={(e) => handleCancel(job.jobId, e)}
+                      title="Cancel conversion"
+                    >
+                      Cancel
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/tests/unit/conversionService.test.js
+++ b/tests/unit/conversionService.test.js
@@ -5,7 +5,8 @@
 
 // Mock dependencies before requiring the module
 jest.mock('child_process', () => ({
-  spawn: jest.fn()
+  spawn: jest.fn(),
+  execFile: jest.fn()
 }));
 
 jest.mock('fs', () => ({
@@ -30,6 +31,10 @@ jest.mock('../../server/services/pathCache', () => ({
 
 jest.mock('../../server/utils/contentHash', () => ({
   generateBestHash: jest.fn().mockReturnValue('abcdef1234567890')
+}));
+
+jest.mock('../../server/services/fileSystemUtils', () => ({
+  extractM4BChapters: jest.fn().mockResolvedValue(null)
 }));
 
 const { spawn } = require('child_process');


### PR DESCRIPTION
## Summary
- **Floating progress panel**: Rewrites `JobsIndicator` from a dropdown into a floating bottom panel (like Chrome's download bar) with compact/expanded/hidden states, WebSocket-driven live progress, elapsed time display, and slide-in animations
- **Post-conversion duration fix**: After M4B conversion, ffprobes the new file for actual duration and extracts chapters, fixing a bug where converted books showed the duration of a single source file instead of the full book
- **Test fixes**: Updated conversionService test mocks for new imports

## Changes
- `client/src/components/JobsIndicator.jsx` — Rewritten: floating panel with 4 states (hidden/badge/compact/expanded), auto-appears on WebSocket job updates, elapsed time tracking, minimize/dismiss controls
- `client/src/components/JobsIndicator.css` — Rewritten: floating panel styles, slide-in animation, compact/expanded responsive sizing, player-active offset
- `server/services/conversionService.js` — After conversion: ffprobe new M4B for duration, extract chapters, include both in database UPDATE
- `tests/unit/conversionService.test.js` — Added execFile and fileSystemUtils mocks

## Test plan
- [ ] `npm test` and `npm run lint` pass
- [ ] Trigger conversion → floating panel slides up at bottom-right with live progress
- [ ] Panel shows percentage, status message, elapsed time via WebSocket
- [ ] Can minimize to compact bar, expand back, or fully dismiss
- [ ] Gear icon shows badge count when panel is dismissed but jobs active
- [ ] Completed jobs show success for 5s then dismiss
- [ ] Panel shifts up when audio player is active
- [ ] After conversion completes, audiobook detail shows correct full duration
- [ ] Chapters are extracted from converted M4B

🤖 Generated with [Claude Code](https://claude.com/claude-code)