### PR TITLE
Fix M4B conversion for non-MP3 formats

### DIFF
--- a/server/routes/upload.js
+++ b/server/routes/upload.js
@@ -174,7 +174,7 @@ router.post('/batch', uploadLimiter, authenticateToken, upload.array('audiobooks
 });
 
 // Upload multiple files as a single audiobook (multi-file book with chapters)
-router.post('/multifile', uploadLimiter, authenticateToken, upload.array('audiobooks', 100), async (req, res) => {
+router.post('/multifile', uploadLimiter, authenticateToken, upload.array('audiobooks', 500), async (req, res) => {
   try {
     if (!req.files || req.files.length === 0) {
       return res.status(400).json({ error: 'No files uploaded' });


### PR DESCRIPTION
## Summary
- **Multifile M4A fix**: Replace concat demuxer with concat filter (`-filter_complex`) — the concat demuxer produces massively bloated output (~7x expected size) with MP4-based containers. Each source file is now a separate `-i` input concatenated via `[0:a][1:a]...concat=n=N:v=0:a=1`
- **Single M4A fix**: Add `-vn` and re-encode instead of stream copy — embedded cover art video streams cause ipod muxer failures
- **Progress tracking**: Pre-calculate total duration by summing source file durations (with ffprobe fallback for unknowns), since the concat filter doesn't report a combined `Duration:` on stderr
- **Upload limit**: Raise multifile upload limit from 100 to 500 files

## Test plan
- [ ] Convert a multifile M4A audiobook → output size should be ~450MB for 8hrs at 128kbps mono (not 3.5GB+)
- [ ] Convert a multifile MP3 audiobook → still works (regression check)
- [ ] Convert a single M4A file → succeeds without hanging
- [ ] Progress bar updates smoothly throughout conversion
- [ ] Chapters embedded correctly in output M4B
- [ ] Upload a folder with >100 files → accepted by server

🤖 Generated with [Claude Code](https://claude.com/claude-code)