### PR TITLE
Fix format display, file ordering, and conversion progress panel

### DIFF
--- a/client/src/components/JobsIndicator.css
+++ b/client/src/components/JobsIndicator.css
@@ -68,7 +68,7 @@
 
 .jobs-panel.compact {
   width: 320px;
-  max-height: 80px;
+  max-height: 100px;
   cursor: pointer;
 }
 

--- a/server/routes/audiobooks/stream.js
+++ b/server/routes/audiobooks/stream.js
@@ -30,7 +30,10 @@ function register(router, { db, authenticateToken, authenticateMediaToken, requi
       // List all files in the directory
       const files = fs.readdirSync(directory);
 
-      // Return all files in the directory, sorted by name
+      // Audio extensions for sorting priority
+      const audioExtensions = new Set(['.mp3', '.m4a', '.m4b', '.mp4', '.ogg', '.flac', '.opus', '.aac', '.wav', '.wma']);
+
+      // Return all files in the directory, sorted: audio first, then non-audio
       const allFiles = files
         .map(file => {
           const fullPath = path.join(directory, file);
@@ -42,7 +45,12 @@ function register(router, { db, authenticateToken, authenticateMediaToken, requi
             extension: path.extname(file).toLowerCase()
           };
         })
-        .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
+        .sort((a, b) => {
+          const aIsAudio = audioExtensions.has(a.extension);
+          const bIsAudio = audioExtensions.has(b.extension);
+          if (aIsAudio !== bIsAudio) return aIsAudio ? -1 : 1;
+          return a.name.localeCompare(b.name, undefined, { numeric: true });
+        });
 
       res.json(allFiles);
     } catch (error) {

--- a/server/services/conversionService.js
+++ b/server/services/conversionService.js
@@ -755,7 +755,7 @@ class ConversionService {
       return null;
     }
     return {
-      id: job.id,
+      jobId: job.id,
       audiobookId: job.audiobookId,
       audiobookTitle: job.audiobookTitle,
       status: job.status,

--- a/tests/unit/conversionService.test.js
+++ b/tests/unit/conversionService.test.js
@@ -90,7 +90,7 @@ describe('Conversion Service', () => {
       const result = conversionService.getJobStatus('test-job-id');
 
       expect(result).toEqual({
-        id: 'test-job-id',
+        jobId: 'test-job-id',
         audiobookId: 1,
         audiobookTitle: 'Test Book',
         status: 'converting',
@@ -135,9 +135,9 @@ describe('Conversion Service', () => {
       const result = conversionService.getActiveJobs();
 
       expect(result.length).toBe(2);
-      expect(result.map(j => j.id)).toContain('job-1');
-      expect(result.map(j => j.id)).toContain('job-3');
-      expect(result.map(j => j.id)).not.toContain('job-2');
+      expect(result.map(j => j.jobId)).toContain('job-1');
+      expect(result.map(j => j.jobId)).toContain('job-3');
+      expect(result.map(j => j.jobId)).not.toContain('job-2');
     });
 
     test('includes queued jobs', () => {
@@ -159,8 +159,8 @@ describe('Conversion Service', () => {
       const result = conversionService.getActiveJobs();
 
       expect(result.length).toBe(2);
-      expect(result.map(j => j.id)).toContain('job-1');
-      expect(result.map(j => j.id)).toContain('job-2');
+      expect(result.map(j => j.jobId)).toContain('job-1');
+      expect(result.map(j => j.jobId)).toContain('job-2');
     });
   });
 
@@ -225,7 +225,7 @@ describe('Conversion Service', () => {
       const result = conversionService.getActiveJobForAudiobook(5);
 
       expect(result).not.toBeNull();
-      expect(result.id).toBe('job-1');
+      expect(result.jobId).toBe('job-1');
       expect(result.status).toBe('queued');
     });
 
@@ -284,7 +284,7 @@ describe('Conversion Service', () => {
       const result = conversionService.getActiveJobForAudiobook(5);
 
       expect(result).not.toBeNull();
-      expect(result.id).toBe('job-1');
+      expect(result.jobId).toBe('job-1');
       expect(result.audiobookId).toBe(5);
     });
 


### PR DESCRIPTION
## Summary
- **Format display**: Android app derived format from first file in directory (could be `cover.jpg`). Now uses audiobook's `file_path` which is always audio. Web app also made defensive with audio extension whitelist.
- **File ordering**: Directory files endpoint now sorts audio files before non-audio files, keeping numeric locale sort within each group.
- **Conversion progress panel**: `getJobStatus()` returned `id` but the client `JobsIndicator` expected `jobId` (matching the WebSocket event format). Also increased compact panel `max-height` from 80px to 100px so the progress bar isn't clipped.
- **Premature success alert**: Removed the immediate "Converted to M4B successfully!" alert that fired before conversion actually completed. Detail page now listens for WebSocket `job.update` completion to reload audiobook data.

## Test plan
- [ ] Open audiobook detail — format shows correct audio extension (not JPG/PNG)
- [ ] View directory files list — audio files appear before non-audio files (covers, NFO, etc.)
- [ ] Start a conversion — progress panel appears with visible progress bar
- [ ] Conversion completes — detail page reloads automatically, no premature success alert
- [ ] `npm test` passes, `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)