### PR TITLE
Fix orphaned collection items when audiobooks are deleted

### DIFF
--- a/server/routes/audiobooks/batch.js
+++ b/server/routes/audiobooks/batch.js
@@ -566,8 +566,9 @@ The reader has started this book and wants to remember what it's about and any k
             continue;
           }
 
-          // Delete related data first (playback_progress lacks ON DELETE CASCADE)
+          // Delete related data first (explicit cleanup ensures no orphans)
           await dbRun('DELETE FROM playback_progress WHERE audiobook_id = ?', [audiobookId]);
+          await dbRun('DELETE FROM collection_items WHERE audiobook_id = ?', [audiobookId]);
           await dbRun('DELETE FROM audiobooks WHERE id = ?', [audiobookId]);
 
           // Optionally delete files and directory

--- a/server/routes/audiobooks/crud.js
+++ b/server/routes/audiobooks/crud.js
@@ -264,8 +264,9 @@ function register(router, { db, authenticateToken, requireAdmin, normalizeGenres
         return res.status(404).json({ error: 'Audiobook not found' });
       }
 
-      // Delete related data first (playback_progress lacks ON DELETE CASCADE)
+      // Delete related data first (explicit cleanup ensures no orphans)
       await dbRun('DELETE FROM playback_progress WHERE audiobook_id = ?', [req.params.id]);
+      await dbRun('DELETE FROM collection_items WHERE audiobook_id = ?', [req.params.id]);
       await dbRun('DELETE FROM audiobooks WHERE id = ?', [req.params.id]);
 
       // Delete entire audiobook directory (contains audio file, cover, etc.)

--- a/server/routes/maintenance/duplicates.js
+++ b/server/routes/maintenance/duplicates.js
@@ -320,6 +320,7 @@ function register(router, { db, authenticateToken, requireAdmin }) {
       const placeholders = deleteIds.map(() => '?').join(',');
       await dbRun(`DELETE FROM playback_progress WHERE audiobook_id IN (${placeholders})`, deleteIds);
       await dbRun(`DELETE FROM audiobook_chapters WHERE audiobook_id IN (${placeholders})`, deleteIds);
+      await dbRun(`DELETE FROM collection_items WHERE audiobook_id IN (${placeholders})`, deleteIds);
       await dbRun(`DELETE FROM audiobooks WHERE id IN (${placeholders})`, deleteIds);
 
       // Optionally delete the actual files

--- a/server/routes/maintenance/library.js
+++ b/server/routes/maintenance/library.js
@@ -95,6 +95,7 @@ function register(router, { db, authenticateToken, requireAdmin, extractFileMeta
           if (sortedBooks.length > 1) {
             const idsToDelete = sortedBooks.slice(1).map(b => b.id);
             await dbRun(`DELETE FROM playback_progress WHERE audiobook_id IN (${idsToDelete.join(',')})`);
+            await dbRun(`DELETE FROM collection_items WHERE audiobook_id IN (${idsToDelete.join(',')})`);
             await dbRun(`DELETE FROM audiobooks WHERE id IN (${idsToDelete.join(',')})`);
           }
 
@@ -124,6 +125,7 @@ function register(router, { db, authenticateToken, requireAdmin, extractFileMeta
 
       await dbRun('DELETE FROM audiobook_chapters');
       await dbRun('DELETE FROM playback_progress');
+      await dbRun('DELETE FROM collection_items');
       await dbRun('DELETE FROM audiobooks');
 
       console.log('Library database cleared successfully');

--- a/server/scripts/fix-multifile-audiobooks.js
+++ b/server/scripts/fix-multifile-audiobooks.js
@@ -137,6 +137,7 @@ async function consolidateGroup(books) {
                     const idsToDelete = sortedBooks.slice(1).map(b => b.id);
 
                     if (idsToDelete.length > 0) {
+                      db.run(`DELETE FROM collection_items WHERE audiobook_id IN (${idsToDelete.join(',')})`, () => {});
                       db.run(
                         `DELETE FROM audiobooks WHERE id IN (${idsToDelete.join(',')})`,
                         (err) => {


### PR DESCRIPTION
## Summary
- Explicitly delete `collection_items` before deleting audiobooks in all 5 delete code paths
- Previously relied solely on SQLite `ON DELETE CASCADE`, which could leave orphaned items if `PRAGMA foreign_keys` wasn't active
- Affected paths: single delete, batch delete, consolidation, clear-library, duplicate cleanup, and fix-multifile script

## Test plan
- [ ] Add a book to a collection, then delete the book from its detail page — verify it disappears from the collection
- [ ] Run clear-library and verify collections are emptied
- [ ] Run duplicate cleanup with books in collections and verify orphaned items are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)