### PR TITLE
Add stop button to desktop player

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -269,13 +269,7 @@
 }
 
 .player-actions {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-shrink: 0;
+  display: none;
   z-index: 10;
 }
 
@@ -307,13 +301,13 @@
   opacity: 1;
 }
 
-.btn-close {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background: #dc2626;
-  border: none;
-  color: #fff;
+.btn-stop {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: rgba(75, 85, 99, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #9ca3af;
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -322,9 +316,10 @@
   flex-shrink: 0;
 }
 
-.btn-close:hover {
-  background: #b91c1c;
-  transform: scale(1.1);
+.btn-stop:hover {
+  background: rgba(239, 68, 68, 0.2);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: #f87171;
 }
 
 .casting-indicator {
@@ -1223,9 +1218,11 @@
     display: none;
   }
 
-  /* Hide close button on desktop */
-  .player-actions {
-    display: none !important;
+  .player-controls .stop-btn {
+    width: 38px !important;
+    height: 38px !important;
+    border-radius: 6px !important;
+    margin-right: 12px;
   }
 }
 
@@ -1603,7 +1600,7 @@
   }
 
   .player-actions {
-    display: none !important; /* Hide desktop close button on mobile */
+    display: none !important;
   }
 
   /* Remove any bottom margin/padding that creates gap */

--- a/client/src/components/AudioPlayer.jsx
+++ b/client/src/components/AudioPlayer.jsx
@@ -971,16 +971,8 @@ const AudioPlayer = forwardRef(({ audiobook, progress, onClose }, ref) => {
         onSkipForward={skipForward}
         onSkipToPreviousChapter={skipToPreviousChapter}
         onSkipToNextChapter={skipToNextChapter}
+        onStop={handleClose}
       />
-
-      <div className="player-actions">
-        <button className="btn-close" onClick={handleClose} title="Close Player" aria-label="Close player">
-          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <line x1="18" y1="6" x2="6" y2="18"></line>
-            <line x1="6" y1="6" x2="18" y2="18"></line>
-          </svg>
-        </button>
-      </div>
 
       <div
         ref={progressBarRef}

--- a/client/src/components/player/PlaybackControls.jsx
+++ b/client/src/components/player/PlaybackControls.jsx
@@ -70,12 +70,21 @@ function ForwardIcon({ size, strokeWidth = 2 }) {
   );
 }
 
+function StopIcon({ size }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="currentColor" stroke="none">
+      <rect x="4" y="4" width="16" height="16" rx="2"></rect>
+    </svg>
+  );
+}
+
 export default function PlaybackControls({
   variant = 'desktop',
   playing, isBuffering,
   chapters, currentChapter,
   onTogglePlay, onSkipBackward, onSkipForward,
   onSkipToPreviousChapter, onSkipToNextChapter,
+  onStop,
 }) {
   if (variant === 'fullscreen') {
     return (
@@ -111,6 +120,11 @@ export default function PlaybackControls({
       {chapters.length > 0 && (
         <button className="control-btn chapter-skip-desktop" onClick={onSkipToPreviousChapter} disabled={currentChapter === 0} title="Previous Chapter" aria-label="Previous chapter">
           <PrevChapterIcon size={20} />
+        </button>
+      )}
+      {onStop && (
+        <button className="control-btn stop-btn" onClick={onStop} title="Stop Playback" aria-label="Stop playback">
+          <StopIcon size={16} />
         </button>
       )}
       <button className="control-btn" onClick={onSkipBackward} title="Skip back 15 seconds" aria-label="Rewind 15 seconds">


### PR DESCRIPTION
## Summary
- Added a stop button to the desktop playback controls, positioned left of the rewind button
- Replaces the old hidden close button (X) with an inline stop icon that matches the seek button styling
- Subtle gray appearance with soft red hover effect
- Hidden on mobile where the fullscreen player handles dismissal

## Test plan
- [ ] Play an audiobook on desktop and verify the stop button appears in the controls
- [ ] Click the stop button — playback should stop and the player should dismiss
- [ ] Verify the button is not visible on mobile
- [ ] Verify hover turns the button soft red

🤖 Generated with [Claude Code](https://claude.com/claude-code)