### PR TITLE
Change cover aspect ratio from square to 2:3 book shape

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -50,7 +50,7 @@
   position: relative;
   flex-shrink: 0;
   width: 135px;
-  height: 135px;
+  aspect-ratio: 2 / 3;
   border-radius: 8px;
   overflow: hidden;
   cursor: pointer;
@@ -270,7 +270,7 @@
   .audiobook-card {
     width: 100% !important;
     height: 0 !important;
-    padding-bottom: 100% !important;
+    padding-bottom: 150% !important;
     min-width: unset !important;
     flex: unset !important;
     position: relative !important;
@@ -306,10 +306,10 @@
   }
 
   .continue-listening-section .audiobook-card {
-    width: 45vw !important;
-    min-width: 45vw !important;
+    width: 40vw !important;
+    min-width: 40vw !important;
     height: 0 !important;
-    padding-bottom: 45vw !important;
+    padding-bottom: 60vw !important;
     flex-shrink: 0 !important;
   }
 
@@ -325,7 +325,7 @@
     width: calc(33.333vw - 0.5rem) !important;
     min-width: calc(33.333vw - 0.5rem) !important;
     height: 0 !important;
-    padding-bottom: calc(33.333vw - 0.5rem) !important;
+    padding-bottom: calc(50vw - 0.75rem) !important;
     flex-shrink: 0 !important;
   }
 
@@ -341,7 +341,7 @@
     width: calc(33.333vw - 0.5rem) !important;
     min-width: calc(33.333vw - 0.5rem) !important;
     height: 0 !important;
-    padding-bottom: calc(33.333vw - 0.5rem) !important;
+    padding-bottom: calc(50vw - 0.75rem) !important;
     flex-shrink: 0 !important;
   }
 
@@ -357,7 +357,7 @@
     width: calc(33.333vw - 0.5rem) !important;
     min-width: calc(33.333vw - 0.5rem) !important;
     height: 0 !important;
-    padding-bottom: calc(33.333vw - 0.5rem) !important;
+    padding-bottom: calc(50vw - 0.75rem) !important;
     flex-shrink: 0 !important;
   }
 

--- a/client/src/pages/Library.css
+++ b/client/src/pages/Library.css
@@ -545,15 +545,15 @@
 /* Audiobook Grid */
 .audiobook-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   gap: 1.25rem;
 }
 
 .audiobook-card {
   position: relative;
   flex-shrink: 0;
-  width: 180px;
-  height: 180px;
+  width: 100%;
+  aspect-ratio: 2 / 3;
   border-radius: 8px;
   overflow: hidden;
   cursor: pointer;
@@ -714,7 +714,7 @@
 
 .favorites-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
   gap: 1.25rem;
 }
 
@@ -731,7 +731,7 @@
 
 .book-cover {
   width: 100%;
-  aspect-ratio: 1;
+  aspect-ratio: 2 / 3;
   border-radius: 8px;
   overflow: hidden;
   background: linear-gradient(135deg, #374151 0%, #1f2937 100%);
@@ -1437,7 +1437,7 @@
   .audiobook-card {
     width: 100% !important;
     height: 0 !important;
-    padding-bottom: 100% !important;
+    padding-bottom: 150% !important;
     min-width: unset !important;
     border-radius: 6px !important;
   }


### PR DESCRIPTION
## Summary

- Changes audiobook cover cards from 1:1 (square) to 2:3 (book-shaped) aspect ratio, matching Audible's layout
- Applies to Home page (all sections) and Library page (browse grid, favorites/reading list)
- `object-fit: contain` preserved so book-shaped covers fill naturally and squarer covers fit inside

## Test plan

- [ ] Home page: verify Continue Listening, Up Next, Recently Added, Listen Again sections show taller cards
- [ ] Library page: verify browse grid and reading list show taller cards
- [ ] Mobile: verify all sections render correctly on phone-width screens
- [ ] Covers with different aspect ratios display correctly (no cropping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)