### PR TITLE
Revert cover aspect ratio back to square

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -50,7 +50,7 @@
   position: relative;
   flex-shrink: 0;
   width: 135px;
-  aspect-ratio: 2 / 3;
+  height: 135px;
   border-radius: 8px;
   overflow: hidden;
   cursor: pointer;
@@ -270,7 +270,7 @@
   .audiobook-card {
     width: 100% !important;
     height: 0 !important;
-    padding-bottom: 150% !important;
+    padding-bottom: 100% !important;
     min-width: unset !important;
     flex: unset !important;
     position: relative !important;
@@ -306,10 +306,10 @@
   }
 
   .continue-listening-section .audiobook-card {
-    width: 40vw !important;
-    min-width: 40vw !important;
+    width: 45vw !important;
+    min-width: 45vw !important;
     height: 0 !important;
-    padding-bottom: 60vw !important;
+    padding-bottom: 45vw !important;
     flex-shrink: 0 !important;
   }
 
@@ -325,7 +325,7 @@
     width: calc(33.333vw - 0.5rem) !important;
     min-width: calc(33.333vw - 0.5rem) !important;
     height: 0 !important;
-    padding-bottom: calc(50vw - 0.75rem) !important;
+    padding-bottom: calc(33.333vw - 0.5rem) !important;
     flex-shrink: 0 !important;
   }
 
@@ -341,7 +341,7 @@
     width: calc(33.333vw - 0.5rem) !important;
     min-width: calc(33.333vw - 0.5rem) !important;
     height: 0 !important;
-    padding-bottom: calc(50vw - 0.75rem) !important;
+    padding-bottom: calc(33.333vw - 0.5rem) !important;
     flex-shrink: 0 !important;
   }
 
@@ -357,7 +357,7 @@
     width: calc(33.333vw - 0.5rem) !important;
     min-width: calc(33.333vw - 0.5rem) !important;
     height: 0 !important;
-    padding-bottom: calc(50vw - 0.75rem) !important;
+    padding-bottom: calc(33.333vw - 0.5rem) !important;
     flex-shrink: 0 !important;
   }
 

--- a/client/src/pages/Library.css
+++ b/client/src/pages/Library.css
@@ -545,15 +545,15 @@
 /* Audiobook Grid */
 .audiobook-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   gap: 1.25rem;
 }
 
 .audiobook-card {
   position: relative;
   flex-shrink: 0;
-  width: 100%;
-  aspect-ratio: 2 / 3;
+  width: 180px;
+  height: 180px;
   border-radius: 8px;
   overflow: hidden;
   cursor: pointer;
@@ -714,7 +714,7 @@
 
 .favorites-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   gap: 1.25rem;
 }
 
@@ -731,7 +731,7 @@
 
 .book-cover {
   width: 100%;
-  aspect-ratio: 2 / 3;
+  aspect-ratio: 1;
   border-radius: 8px;
   overflow: hidden;
   background: linear-gradient(135deg, #374151 0%, #1f2937 100%);
@@ -1437,7 +1437,7 @@
   .audiobook-card {
     width: 100% !important;
     height: 0 !important;
-    padding-bottom: 150% !important;
+    padding-bottom: 100% !important;
     min-width: unset !important;
     border-radius: 6px !important;
   }


### PR DESCRIPTION
## Summary

- Reverts PR #389 — cover aspect ratio back to 1:1 (square) from 2:3

🤖 Generated with [Claude Code](https://claude.com/claude-code)