### PR TITLE
Inject version from git tag at Docker build time

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,6 +44,15 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Extract version from tag or package.json
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "version=$(node -p "require('./package.json').version")" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -51,5 +60,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ WORKDIR /app
 # Set production environment
 ENV NODE_ENV=production
 
+# Version injected from git tag at build time (falls back to package.json)
+ARG APP_VERSION
+ENV APP_VERSION=${APP_VERSION}
+
 # Install ffmpeg for m4b chapter extraction
 RUN apk add --no-cache ffmpeg
 

--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -4,7 +4,7 @@
 // ---------------------------------------------------------------------------
 // Cache names - bump version to invalidate
 // ---------------------------------------------------------------------------
-const APP_SHELL_CACHE = 'app-shell-v3';
+const APP_SHELL_CACHE = 'app-shell-v4';
 const API_CACHE = 'api-cache-v1';
 const COVER_CACHE = 'cover-cache-v2';
 

--- a/server/index.js
+++ b/server/index.js
@@ -139,7 +139,7 @@ app.get('/api/health', (req, res) => {
   res.json({
     status: 'ok',
     message: 'Sappho server is running',
-    version: packageJson.version
+    version: process.env.APP_VERSION || packageJson.version
   });
 });
 


### PR DESCRIPTION
## Summary

- CI now extracts version from git tag (e.g. `v0.1.1` → `0.1.1`) and passes it as `APP_VERSION` build arg to Docker
- Health endpoint prefers `APP_VERSION` env var over `package.json` for accurate version reporting
- Service worker cache bumped (`app-shell-v3` → `app-shell-v4`) to force PWA clients to re-fetch assets

Fixes the issue where the Docker image tag shows `0.1.1` but `/api/health` reports `0.1.0` because `package.json` wasn't updated before tagging.

## Test plan

- [ ] CI passes
- [ ] Local build: `curl localhost:3003/api/health` returns correct version
- [ ] After next tag release: verify `/api/health` matches the git tag version

🤖 Generated with [Claude Code](https://claude.com/claude-code)