### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sappho",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Audiobook server with streaming, metadata scraping, and library management",
   "main": "server/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump version from 0.1.1 to 0.2.0 for new tag release

After merge, tag with `git tag v0.2.0 && git push origin v0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)