### PR TITLE
Remove title and author text from book cards

### DIFF
--- a/client/src/pages/AllBooks.jsx
+++ b/client/src/pages/AllBooks.jsx
@@ -443,10 +443,6 @@ export default function AllBooks({ onPlay }) {
             )}
           </div>
         </div>
-        <div className="book-card-info">
-          <div className="book-card-title">{book.title}</div>
-          {book.author && <div className="book-card-author">{book.author}</div>}
-        </div>
       </div>
     );
   };

--- a/client/src/pages/AuthorDetail.jsx
+++ b/client/src/pages/AuthorDetail.jsx
@@ -207,25 +207,6 @@ export default function AuthorDetail({ onPlay }) {
                   )}
                 </div>
 
-                <div className="book-card-info">
-                  <h3 className="book-card-title">{book.title}</h3>
-                  {book.series && (
-                    <p className="book-card-series">
-                      {book.series}{book.series_position ? ` #${book.series_position}` : ''}
-                    </p>
-                  )}
-                  <div className="book-card-meta">
-                    {book.narrator && (
-                      <span className="book-card-narrator">{book.narrator}</span>
-                    )}
-                    {book.duration && (
-                      <>
-                        {book.narrator && <span>·</span>}
-                        <span className="book-card-duration">{formatDuration(book.duration)}</span>
-                      </>
-                    )}
-                  </div>
-                </div>
               </div>
             ))}
           </div>

--- a/client/src/pages/Library.jsx
+++ b/client/src/pages/Library.jsx
@@ -535,10 +535,6 @@ export default function Library({ onPlay }) {
                         }}
                       />
                     </div>
-                    <div className="book-info">
-                      <h4 className="book-title">{book.title}</h4>
-                      <p className="book-author">{book.author}</p>
-                    </div>
                   </div>
                 ))}
               </div>

--- a/client/src/pages/SeriesDetail.jsx
+++ b/client/src/pages/SeriesDetail.jsx
@@ -182,10 +182,6 @@ export default function SeriesDetail({ onPlay }) {
             </div>
           </div>
         </div>
-        <div className="book-card-info">
-          <div className="book-card-title">{book.title}</div>
-          {book.author && <div className="book-card-author">{book.author}</div>}
-        </div>
       </div>
     );
   };


### PR DESCRIPTION
## Summary

- Remove title, author, and metadata text below book cover art on all grid views
- Cards now show only the cover image for a cleaner browsing experience
- Affects: All Books, Library (Reading List), Series Detail, Author Detail

## Test plan

- [ ] All Books grid shows covers only
- [ ] Series detail shows covers only
- [ ] Author detail shows covers only
- [ ] Library reading list shows covers only
- [ ] Placeholder text still appears when no cover image exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)