### PR TITLE
Fix author normalization for initials with inconsistent spacing

### DIFF
--- a/server/migrations/028_normalize_author_names.js
+++ b/server/migrations/028_normalize_author_names.js
@@ -1,0 +1,40 @@
+const { normalizeAuthor } = require('../utils/normalizeAuthor');
+
+async function up(db) {
+  return new Promise((resolve, reject) => {
+    db.all('SELECT id, author FROM audiobooks WHERE author IS NOT NULL', [], (err, rows) => {
+      if (err) return reject(err);
+      if (!rows || rows.length === 0) return resolve();
+
+      let updated = 0;
+      let processed = 0;
+
+      rows.forEach(row => {
+        const normalized = normalizeAuthor(row.author);
+        if (normalized !== row.author) {
+          db.run('UPDATE audiobooks SET author = ? WHERE id = ?', [normalized, row.id], (updateErr) => {
+            processed++;
+            if (!updateErr) updated++;
+            if (processed === rows.length) {
+              console.log(`Normalized ${updated} author names`);
+              resolve();
+            }
+          });
+        } else {
+          processed++;
+          if (processed === rows.length) {
+            console.log(`Normalized ${updated} author names`);
+            resolve();
+          }
+        }
+      });
+    });
+  });
+}
+
+async function down(_db) {
+  console.log('Cannot rollback author normalization');
+  return Promise.resolve();
+}
+
+module.exports = { up, down };

--- a/server/migrations/029_normalize_author_initials.js
+++ b/server/migrations/029_normalize_author_initials.js
@@ -1,0 +1,57 @@
+const { normalizeAuthor } = require('../utils/normalizeAuthor');
+
+async function up(db) {
+  // Phase 1: Update author names in the database
+  const updated = await new Promise((resolve, reject) => {
+    db.all('SELECT id, author FROM audiobooks WHERE author IS NOT NULL', [], (err, rows) => {
+      if (err) return reject(err);
+      if (!rows || rows.length === 0) return resolve(0);
+
+      let updatedCount = 0;
+      let processed = 0;
+
+      rows.forEach(row => {
+        const normalized = normalizeAuthor(row.author);
+        if (normalized !== row.author) {
+          db.run('UPDATE audiobooks SET author = ? WHERE id = ?', [normalized, row.id], (updateErr) => {
+            processed++;
+            if (!updateErr) {
+              updatedCount++;
+              console.log(`  "${row.author}" → "${normalized}"`);
+            }
+            if (processed === rows.length) {
+              resolve(updatedCount);
+            }
+          });
+        } else {
+          processed++;
+          if (processed === rows.length) {
+            resolve(updatedCount);
+          }
+        }
+      });
+    });
+  });
+
+  console.log(`Normalized ${updated} author names (initial spacing)`);
+
+  // Phase 2: Reorganize files on disk to match updated author names
+  if (updated > 0) {
+    try {
+      const { organizeLibrary } = require('../services/fileOrganizer');
+      console.log('Reorganizing files to match updated author names...');
+      const stats = await organizeLibrary();
+      console.log(`File reorganization complete: ${stats.moved} moved, ${stats.skipped} unchanged, ${stats.errors} errors`);
+    } catch (e) {
+      console.error('File reorganization failed (database was updated successfully):', e.message);
+      console.log('Run "Organize Library" from admin panel to complete file reorganization.');
+    }
+  }
+}
+
+async function down(_db) {
+  console.log('Cannot rollback author initial normalization');
+  return Promise.resolve();
+}
+
+module.exports = { up, down };

--- a/server/routes/audiobooks/metadata.js
+++ b/server/routes/audiobooks/metadata.js
@@ -16,6 +16,7 @@ const { downloadCover } = require('../../services/coverDownloader');
 const { embedWithTone, embedWithFfmpeg } = require('../../services/metadataEmbedder');
 const { invalidateThumbnails } = require('../../services/thumbnailService');
 const { extractFileMetadata } = require('../../services/fileProcessor');
+const { normalizeAuthor } = require('../../utils/normalizeAuthor');
 const { execFile } = require('child_process');
 const { promisify } = require('util');
 
@@ -465,6 +466,7 @@ function register(router, { db, authenticateToken, requireAdmin, normalizeGenres
       }
 
       // Update database with refreshed metadata (preserve is_multi_file status)
+      metadata.author = normalizeAuthor(metadata.author);
       await dbRun(
         `UPDATE audiobooks
          SET title = ?, author = ?, narrator = ?, description = ?, genre = ?,
@@ -597,10 +599,11 @@ function register(router, { db, authenticateToken, requireAdmin, normalizeGenres
     }
 
     const {
-      title, subtitle, author, narrator, description, genre, tags,
+      title, subtitle, author: rawAuthor, narrator, description, genre, tags,
       series, series_position, published_year, copyright_year,
       publisher, isbn, asin, language, rating, abridged, cover_url
     } = req.body;
+    const author = normalizeAuthor(rawAuthor);
 
     try {
       // Get current audiobook to check if author/title changed

--- a/server/services/fileProcessor.js
+++ b/server/services/fileProcessor.js
@@ -10,6 +10,7 @@ const websocketManager = require('./websocketManager');
 const { generateBestHash } = require('../utils/contentHash');
 const { cleanDescription } = require('../utils/cleanDescription');
 const { sanitizeName } = require('./fileOrganizer');
+const { normalizeAuthor } = require('../utils/normalizeAuthor');
 
 const execFileAsync = promisify(execFile);
 
@@ -759,7 +760,7 @@ function extractAuthor(common, nativeTags, iTunesTags) {
       }
     }
   }
-  return author;
+  return normalizeAuthor(author);
 }
 
 async function extractFileMetadata(filePath) {

--- a/server/utils/normalizeAuthor.js
+++ b/server/utils/normalizeAuthor.js
@@ -1,0 +1,9 @@
+function normalizeAuthor(author) {
+  if (!author) return author;
+  return author
+    .replace(/\.([A-Z])/g, '. $1')  // Standardize initials: "B.V." → "B. V."
+    .replace(/\s+/g, ' ')            // Collapse whitespace
+    .trim() || null;
+}
+
+module.exports = { normalizeAuthor };

--- a/tests/unit/normalizeAuthor.test.js
+++ b/tests/unit/normalizeAuthor.test.js
@@ -1,0 +1,64 @@
+const { normalizeAuthor } = require('../../server/utils/normalizeAuthor');
+
+describe('normalizeAuthor', () => {
+  test('trims leading and trailing whitespace', () => {
+    expect(normalizeAuthor('  Brandon Sanderson  ')).toBe('Brandon Sanderson');
+  });
+
+  test('collapses multiple internal spaces to single space', () => {
+    expect(normalizeAuthor('Brandon  Sanderson')).toBe('Brandon Sanderson');
+    expect(normalizeAuthor('Brandon    Sanderson')).toBe('Brandon Sanderson');
+  });
+
+  test('handles tabs and mixed whitespace', () => {
+    expect(normalizeAuthor('Brandon\tSanderson')).toBe('Brandon Sanderson');
+    expect(normalizeAuthor('Brandon \t Sanderson')).toBe('Brandon Sanderson');
+    expect(normalizeAuthor('\t Brandon  Sanderson \t')).toBe('Brandon Sanderson');
+  });
+
+  test('returns null for null input', () => {
+    expect(normalizeAuthor(null)).toBeNull();
+  });
+
+  test('returns undefined for undefined input', () => {
+    expect(normalizeAuthor(undefined)).toBeUndefined();
+  });
+
+  test('returns null for whitespace-only input', () => {
+    expect(normalizeAuthor('   ')).toBeNull();
+    expect(normalizeAuthor('\t\n')).toBeNull();
+  });
+
+  test('returns empty string for empty string', () => {
+    expect(normalizeAuthor('')).toBe('');
+  });
+
+  test('preserves case (no case normalization)', () => {
+    expect(normalizeAuthor('e.e. cummings')).toBe('e.e. cummings');
+    expect(normalizeAuthor('bell hooks')).toBe('bell hooks');
+  });
+
+  test('handles normal author name unchanged', () => {
+    expect(normalizeAuthor('Brandon Sanderson')).toBe('Brandon Sanderson');
+  });
+
+  test('standardizes spacing after initials', () => {
+    expect(normalizeAuthor('B.V. Larson')).toBe('B. V. Larson');
+    expect(normalizeAuthor('James S.A. Corey')).toBe('James S. A. Corey');
+    expect(normalizeAuthor('J.R.R. Tolkien')).toBe('J. R. R. Tolkien');
+  });
+
+  test('does not add extra space when initials already spaced', () => {
+    expect(normalizeAuthor('B. V. Larson')).toBe('B. V. Larson');
+    expect(normalizeAuthor('James S. A. Corey')).toBe('James S. A. Corey');
+    expect(normalizeAuthor('J. R. R. Tolkien')).toBe('J. R. R. Tolkien');
+  });
+
+  test('does not affect lowercase initials', () => {
+    expect(normalizeAuthor('e.e. cummings')).toBe('e.e. cummings');
+  });
+
+  test('handles compound authors with initials', () => {
+    expect(normalizeAuthor('B.V. Larson, David VanDyke')).toBe('B. V. Larson, David VanDyke');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `normalizeAuthor()` utility that standardizes initials (e.g., `B.V. Larson` → `B. V. Larson`) and collapses whitespace
- Migration 028 normalizes existing author whitespace in the database
- Migration 029 normalizes initials and triggers file reorganization on disk to match
- Integrates normalization into all author save paths (tag extraction, metadata refresh, manual edit) to prevent future duplicates

## Problem
Duplicate authors in the library due to inconsistent spacing in initials:
- "B. V. Larson" (28 books) vs "B.V. Larson" (4 books)
- "B. V. Larson, David VanDyke" (2) vs "B.V. Larson, David VanDyke" (1)
- "James S. A. Corey" (8) vs "James S.A. Corey" (1)

## Test plan
- [x] Unit tests pass for all normalization cases (13 tests)
- [ ] Run migrations from admin panel after deploy
- [ ] Verify duplicate authors are merged in library view
- [ ] Verify files are reorganized into correct author directories
- [ ] Add a new book with "B.V. Larson" in tags and verify it normalizes to "B. V. Larson"

🤖 Generated with [Claude Code](https://claude.com/claude-code)