### PR TITLE
Show app version in user dropdown menu

### DIFF
--- a/client/src/components/Navigation.css
+++ b/client/src/components/Navigation.css
@@ -220,6 +220,14 @@
   color: var(--text-primary);
 }
 
+.dropdown-version {
+  padding: 8px 16px;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-align: center;
+  border-top: 1px solid var(--border-primary);
+}
+
 /* Logo styling */
 .nav-logo {
   display: block;

--- a/client/src/components/Navigation.jsx
+++ b/client/src/components/Navigation.jsx
@@ -13,6 +13,7 @@ export default function Navigation({ onLogout }) {
   const [showSearchModal, setShowSearchModal] = useState(false);
   const [castReady, setCastReady] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [appVersion, setAppVersion] = useState(null);
 
   // Check for Cast SDK availability
   useEffect(() => {
@@ -91,6 +92,10 @@ export default function Navigation({ onLogout }) {
         .catch(err => console.error('Error fetching profile:', err));
     }
   };
+
+  useEffect(() => {
+    fetch('/api/health').then(r => r.json()).then(d => setAppVersion(d.version)).catch(() => {});
+  }, []);
 
   useEffect(() => {
     loadUserProfile();
@@ -317,6 +322,9 @@ export default function Navigation({ onLogout }) {
                     </svg>
                     Logout
                   </button>
+                  {appVersion && (
+                    <div className="dropdown-version">v{appVersion}</div>
+                  )}
                 </div>
               )}
             </div>
@@ -390,6 +398,9 @@ export default function Navigation({ onLogout }) {
               </svg>
               <span>Logout</span>
             </button>
+            {appVersion && (
+              <div className="dropdown-version">v{appVersion}</div>
+            )}
           </div>
         </div>
       )}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sappho",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Audiobook server with streaming, metadata scraping, and library management",
   "main": "server/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Fetches server version from `/api/health` endpoint
- Displays version (e.g. "v0.2.2") at the bottom of both desktop and mobile user dropdown menus
- Matches the Android app's behavior of showing version in the user menu

## Test plan
- [ ] Open desktop user dropdown — version appears below Logout
- [ ] Open mobile menu — version appears below Logout
- [ ] Version matches the value from `/api/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)