### PR TITLE
Add admin delete tests and fix error logging

### DIFF
--- a/client/src/pages/CollectionDetail.jsx
+++ b/client/src/pages/CollectionDetail.jsx
@@ -27,7 +27,9 @@ export default function CollectionDetail() {
       try {
         const response = await getProfile();
         setIsAdmin(!!response.data.is_admin);
-      } catch (_) {}
+      } catch (err) {
+        console.warn('Failed to check admin status:', err);
+      }
     };
     checkAdmin();
   }, []);

--- a/client/src/pages/Collections.jsx
+++ b/client/src/pages/Collections.jsx
@@ -65,7 +65,9 @@ export default function Collections() {
       try {
         const response = await getProfile();
         setIsAdmin(!!response.data.is_admin);
-      } catch (_) {}
+      } catch (err) {
+        console.warn('Failed to check admin status:', err);
+      }
     };
     checkAdmin();
   }, []);

--- a/server/routes/collections.js
+++ b/server/routes/collections.js
@@ -252,7 +252,8 @@ function createCollectionsRouter(deps = {}) {
 
       await dbRun('DELETE FROM user_collections WHERE id = ?', [collection.id]);
       res.json({ success: true });
-    } catch (_err) {
+    } catch (err) {
+      console.error(`Failed to delete collection ${req.params.id}:`, err);
       res.status(500).json({ error: 'Internal server error' });
     }
   });

--- a/tests/integration/collections.test.js
+++ b/tests/integration/collections.test.js
@@ -653,6 +653,51 @@ describe('Collections Routes', () => {
 
         expect(res.body.error).toBe('Collection not found or not owned by you');
       });
+
+      it('admin can delete public collection from another user', async () => {
+        const collection = await createTestCollection(db, {
+          user_id: user1.id,
+          name: 'Admin Delete Public Test',
+          is_public: 1
+        });
+
+        const res = await request(app)
+          .delete(`/api/collections/${collection.id}`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .expect(200);
+
+        expect(res.body.success).toBe(true);
+      });
+
+      it('admin cannot delete private collection from another user', async () => {
+        const collection = await createTestCollection(db, {
+          user_id: user1.id,
+          name: 'Admin Delete Private Test',
+          is_public: 0
+        });
+
+        const res = await request(app)
+          .delete(`/api/collections/${collection.id}`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .expect(404);
+
+        expect(res.body.error).toBe('Collection not found or not owned by you');
+      });
+
+      it('admin can delete own collection', async () => {
+        const collection = await createTestCollection(db, {
+          user_id: adminUser.id,
+          name: 'Admin Own Collection',
+          is_public: 0
+        });
+
+        const res = await request(app)
+          .delete(`/api/collections/${collection.id}`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .expect(200);
+
+        expect(res.body.success).toBe(true);
+      });
     });
 
     describe('Not found', () => {


### PR DESCRIPTION
## Summary
- Add 3 integration tests for admin collection deletion paths (71 → 74 tests):
  - Admin can delete public collection from another user
  - Admin cannot delete private collection from another user
  - Admin can delete own collection
- Log errors in DELETE handler instead of silently swallowing with `catch (_err)`
- Replace silent `catch (_) {}` with `console.warn` in admin status checks on Collections and CollectionDetail pages

## Test plan
- [x] All 74 integration tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)