### PR TITLE
Hide incomplete books from recently added feed

### DIFF
--- a/server/routes/audiobooks/aggregates.js
+++ b/server/routes/audiobooks/aggregates.js
@@ -159,6 +159,7 @@ function register(router, { db, authenticateToken, requireAdmin, normalizeGenres
          LEFT JOIN playback_progress p ON a.id = p.audiobook_id AND p.user_id = ?
          LEFT JOIN user_favorites f ON a.id = f.audiobook_id AND f.user_id = ?
          WHERE (a.is_available = 1 OR a.is_available IS NULL)
+           AND a.duration IS NOT NULL
          ORDER BY a.created_at DESC
          LIMIT ?`,
         [userId, userId, limit]

--- a/tests/integration/audiobooks.routes.test.js
+++ b/tests/integration/audiobooks.routes.test.js
@@ -1266,6 +1266,19 @@ describe('Audiobooks Routes', () => {
         expect(res.status).toBe(200);
         expect(res.body).toHaveLength(1);
       });
+
+      it('excludes books with no duration (incomplete/converting)', async () => {
+        await createTestAudiobook(db, { title: 'Complete Book', duration: 3600 });
+        await createTestAudiobook(db, { title: 'Converting Book', duration: null });
+
+        const res = await request(app)
+          .get('/api/audiobooks/meta/recent')
+          .set('Authorization', `Bearer ${userToken}`);
+
+        expect(res.status).toBe(200);
+        expect(res.body).toHaveLength(1);
+        expect(res.body[0].title).toBe('Complete Book');
+      });
     });
 
     describe('GET /api/audiobooks/meta/in-progress', () => {


### PR DESCRIPTION
## Summary
- Books without duration (still converting/processing) were appearing in the "Recently Added" feed with no title, author, or cover
- Add `AND a.duration IS NOT NULL` filter to the `/api/audiobooks/meta/recent` query
- Add integration test verifying incomplete books are excluded

## Test plan
- [x] 110 audiobook route tests pass (including new test)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)