### PR TITLE
Use ffprobe for accurate audio duration

### DIFF
--- a/server/services/fileProcessor.js
+++ b/server/services/fileProcessor.js
@@ -834,12 +834,31 @@ async function extractFileMetadata(filePath) {
     const extended = extractExtendedMetadata(iTunesTags, common);
     const author = extractAuthor(common, nativeTags, iTunesTags);
 
+    // music-metadata can misreport duration for some m4b files (e.g. reporting
+    // half the real duration due to sample rate misdetection). Use ffprobe as
+    // the authoritative source when available, fall back to music-metadata.
+    let duration = format.duration ? Math.round(format.duration) : null;
+    try {
+      const { stdout } = await execFileAsync('ffprobe', [
+        '-v', 'quiet',
+        '-show_entries', 'format=duration',
+        '-of', 'csv=p=0',
+        filePath
+      ]);
+      const ffprobeDuration = Math.round(parseFloat(stdout.trim()));
+      if (ffprobeDuration > 0) {
+        duration = ffprobeDuration;
+      }
+    } catch (_) {
+      // ffprobe not available — keep music-metadata duration
+    }
+
     return {
       title,
       author,
       narrator,
       description,
-      duration: format.duration ? Math.round(format.duration) : null,
+      duration,
       genre: common.genre ? (Array.isArray(common.genre) ? common.genre.join(', ') : String(common.genre)) : null,
       published_year: extended.published_year,
       isbn: extended.isbn,


### PR DESCRIPTION
## Summary
- `music-metadata` misreports duration for some m4b files by exactly 2x due to sample rate misdetection (reports 44100 instead of actual 22050)
- Affected 26 books in production including Wind and Truth, Oathbringer, Name of the Wind, etc.
- Now uses ffprobe as the authoritative duration source during metadata extraction, falling back to music-metadata if ffprobe is unavailable
- Already fixed 26 existing books in production DB via one-off script

## Test plan
- [ ] Verify Wind and Truth shows correct duration (~62h not ~31h) in web UI
- [ ] Verify new imports get correct duration
- [ ] All 1828 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)