### PR TITLE
Fix cover images not updating after change

### DIFF
--- a/server/routes/audiobooks/stream.js
+++ b/server/routes/audiobooks/stream.js
@@ -255,7 +255,7 @@ function register(router, { db, authenticateToken, authenticateMediaToken, requi
             return res.status(304).end();
           }
 
-          res.setHeader('Cache-Control', 'public, max-age=604800, immutable');
+          res.setHeader('Cache-Control', 'public, max-age=3600');
           res.setHeader('ETag', etag);
           res.setHeader('Content-Type', 'image/jpeg');
           return res.sendFile(path.resolve(thumbPath));
@@ -266,7 +266,7 @@ function register(router, { db, authenticateToken, authenticateMediaToken, requi
       }
 
       // Serve original cover (no width requested, or invalid width, or thumbnail generation failed)
-      res.setHeader('Cache-Control', 'public, max-age=604800, immutable');
+      res.setHeader('Cache-Control', 'public, max-age=3600');
       res.sendFile(resolvedPath);
     } catch (_err) {
       res.status(500).json({ error: 'Internal server error' });

--- a/server/services/coverDownloader.js
+++ b/server/services/coverDownloader.js
@@ -95,6 +95,16 @@ async function downloadCover(url, audiobookId, redirectCount = 0) {
 
     const coverPath = path.join(coversDir, `audiobook_${audiobookId}${ext}`);
 
+    // Remove any existing cover files for this audiobook (may have different extension)
+    const existingCovers = fs.readdirSync(coversDir)
+      .filter(f => f.startsWith(`audiobook_${audiobookId}.`));
+    for (const old of existingCovers) {
+      const oldPath = path.join(coversDir, old);
+      if (oldPath !== coverPath) {
+        fs.unlinkSync(oldPath);
+      }
+    }
+
     return new Promise((resolve, reject) => {
       const protocol = url.startsWith('https') ? https : http;
       // Build request options with headers (required for Amazon CDN and other image servers)


### PR DESCRIPTION
## Summary
- Reduced cover image `Cache-Control` from 7-day `immutable` to 1-hour revalidation, so browsers pick up new covers after changing them
- Clean up old cover files with different extensions before downloading new ones (prevents orphaned files)

## Test plan
- [ ] Change a cover on an audiobook via Edit Metadata
- [ ] Verify the new cover appears immediately on the detail page
- [ ] Navigate to Home/Library and verify the new cover appears within a page refresh
- [ ] Verify covers still load efficiently on repeated visits (ETag 304 responses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)