### PR TITLE
Bust browser cache for cover images after changes

### DIFF
--- a/client/src/components/AudioPlayer.jsx
+++ b/client/src/components/AudioPlayer.jsx
@@ -825,7 +825,7 @@ const AudioPlayer = forwardRef(({ audiobook, progress, onClose }, ref) => {
       <div className="player-info">
         {audiobook.cover_image && (
           <img
-            src={getCoverUrl(audiobook.id, null, 120)}
+            src={getCoverUrl(audiobook.id, audiobook.updated_at, 120)}
             alt={`${audiobook.title} by ${audiobook.author || 'Unknown Author'}`}
             className="player-cover"
             onClick={(e) => {

--- a/client/src/components/SearchModal.jsx
+++ b/client/src/components/SearchModal.jsx
@@ -181,7 +181,7 @@ export default function SearchModal({ isOpen, onClose }) {
                     >
                       {book.cover_image && (
                         <img
-                          src={getCoverUrl(book.id, null, 120)}
+                          src={getCoverUrl(book.id, book.updated_at, 120)}
                           alt={book.title}
                           className="search-result-cover"
                           loading="lazy"

--- a/client/src/components/player/FullscreenPlayer.jsx
+++ b/client/src/components/player/FullscreenPlayer.jsx
@@ -190,7 +190,7 @@ export default function FullscreenPlayer({
 
           <div className="fullscreen-cover">
             {audiobook.cover_image ? (
-              <img src={getCoverUrl(audiobook.id, null, 600)} alt={`${audiobook.title} by ${audiobook.author || 'Unknown Author'}`} />
+              <img src={getCoverUrl(audiobook.id, audiobook.updated_at, 600)} alt={`${audiobook.title} by ${audiobook.author || 'Unknown Author'}`} />
             ) : (
               <div className="fullscreen-cover-placeholder">{audiobook.title}</div>
             )}

--- a/client/src/components/player/useMediaSession.js
+++ b/client/src/components/player/useMediaSession.js
@@ -19,7 +19,7 @@ export function useMediaSession({
         artist: audiobook.author || 'Unknown Author',
         album: audiobook.series || 'Audiobook',
         artwork: audiobook.cover_image ? [
-          { src: getCoverUrl(audiobook.id, null, 600), sizes: '512x512', type: 'image/jpeg' }
+          { src: getCoverUrl(audiobook.id, audiobook.updated_at, 600), sizes: '512x512', type: 'image/jpeg' }
         ] : []
       });
 

--- a/client/src/pages/AllBooks.jsx
+++ b/client/src/pages/AllBooks.jsx
@@ -408,7 +408,7 @@ export default function AllBooks({ onPlay }) {
             </div>
             {book.cover_image && (
               <img
-                src={getCoverUrl(book.id, null, 300)}
+                src={getCoverUrl(book.id, book.updated_at, 300)}
                 alt={book.title}
                 loading="lazy"
                 onError={(e) => { e.target.style.display = 'none'; }}

--- a/client/src/pages/CollectionDetail.jsx
+++ b/client/src/pages/CollectionDetail.jsx
@@ -249,7 +249,7 @@ export default function CollectionDetail() {
               <div className="drag-handle">⋮⋮</div>
               <div className="book-cover" onClick={() => navigate(`/audiobook/${book.id}`)}>
                 <img
-                  src={getCoverUrl(book.id, null, 300)}
+                  src={getCoverUrl(book.id, book.updated_at, 300)}
                   alt={book.title}
                   loading="lazy"
                   onError={(e) => e.target.src = '/placeholder-cover.png'}

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -115,7 +115,7 @@ export default function Home({ onPlay }) {
           <h3>{book.title}</h3>
         </div>
         {book.cover_image && (
-          <img src={getCoverUrl(book.id, null, 300)} alt={book.title} loading="lazy" onError={(e) => e.target.style.display = 'none'} />
+          <img src={getCoverUrl(book.id, book.updated_at, 300)} alt={book.title} loading="lazy" onError={(e) => e.target.style.display = 'none'} />
         )}
         {book.progress && (book.progress.position > 0 || book.progress.completed === 1) && book.duration && (
           <div className="progress-bar-overlay">

--- a/client/src/pages/Library.jsx
+++ b/client/src/pages/Library.jsx
@@ -527,7 +527,7 @@ export default function Library({ onPlay }) {
                   >
                     <div className="book-cover">
                       <img
-                        src={getCoverUrl(book.id, null, 300)}
+                        src={getCoverUrl(book.id, book.updated_at, 300)}
                         alt={book.title}
                         loading="lazy"
                         onError={(e) => {

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -334,7 +334,7 @@ export default function Profile() {
                 onClick={() => navigate(`/audiobook/${book.id}`)}
               >
                 {book.cover_image ? (
-                  <img src={getCoverUrl(book.id, null, 120)} alt={`${book.title || 'Audiobook'} by ${book.author || 'Unknown Author'}`} className="recent-book-cover" loading="lazy" />
+                  <img src={getCoverUrl(book.id, book.updated_at, 120)} alt={`${book.title || 'Audiobook'} by ${book.author || 'Unknown Author'}`} className="recent-book-cover" loading="lazy" />
                 ) : (
                   <div className="recent-book-placeholder">{book.title?.charAt(0)}</div>
                 )}

--- a/client/src/pages/SeriesDetail.jsx
+++ b/client/src/pages/SeriesDetail.jsx
@@ -143,7 +143,7 @@ export default function SeriesDetail({ onPlay }) {
               <h3>{book.title}</h3>
             </div>
             {book.cover_image && (
-              <img src={getCoverUrl(book.id, null, 300)} alt={book.title} loading="lazy" onError={(e) => e.target.style.display = 'none'} />
+              <img src={getCoverUrl(book.id, book.updated_at, 300)} alt={book.title} loading="lazy" onError={(e) => e.target.style.display = 'none'} />
             )}
             {book.progress && (book.progress.position > 0 || book.progress.completed === 1) && book.duration && (
               <div className="progress-bar-overlay">

--- a/server/routes/audiobooks/stream.js
+++ b/server/routes/audiobooks/stream.js
@@ -255,7 +255,7 @@ function register(router, { db, authenticateToken, authenticateMediaToken, requi
             return res.status(304).end();
           }
 
-          res.setHeader('Cache-Control', 'public, max-age=3600');
+          res.setHeader('Cache-Control', 'public, no-cache');
           res.setHeader('ETag', etag);
           res.setHeader('Content-Type', 'image/jpeg');
           return res.sendFile(path.resolve(thumbPath));
@@ -266,7 +266,7 @@ function register(router, { db, authenticateToken, authenticateMediaToken, requi
       }
 
       // Serve original cover (no width requested, or invalid width, or thumbnail generation failed)
-      res.setHeader('Cache-Control', 'public, max-age=3600');
+      res.setHeader('Cache-Control', 'public, no-cache');
       res.sendFile(resolvedPath);
     } catch (_err) {
       res.status(500).json({ error: 'Internal server error' });


### PR DESCRIPTION
## Summary
- Server: switch cover `Cache-Control` from `max-age=3600` to `no-cache` so browsers always revalidate via ETag
- Client: pass `updated_at` as cache-bust parameter in all cover URLs — when a cover changes, the URL changes, forcing the browser to fetch the new image
- Fixes the issue where changing a cover showed correctly on the detail page but reverted on Home/Library/etc.

## Test plan
- [x] Change a cover, navigate away from detail page — new cover persists everywhere
- [ ] Verify covers still load efficiently (ETag 304s for unchanged covers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)