### PR TITLE
Fix refresh metadata not reverting to embedded cover

### DIFF
--- a/server/routes/audiobooks/metadata.js
+++ b/server/routes/audiobooks/metadata.js
@@ -466,12 +466,15 @@ function register(router, { db, authenticateToken, requireAdmin, normalizeGenres
       }
 
       // Update database with refreshed metadata (preserve is_multi_file status)
+      // Clear cover_path so the re-extracted cover_image takes precedence.
+      // The cover endpoint checks cover_path first, so leaving a stale
+      // downloaded cover there would prevent the embedded cover from showing.
       metadata.author = normalizeAuthor(metadata.author);
       await dbRun(
         `UPDATE audiobooks
          SET title = ?, author = ?, narrator = ?, description = ?, genre = ?,
              series = ?, series_position = ?, published_year = ?, cover_image = ?,
-             duration = ?, updated_at = CURRENT_TIMESTAMP
+             cover_path = ?, duration = ?, updated_at = CURRENT_TIMESTAMP
          WHERE id = ?`,
         [
           metadata.title,
@@ -482,6 +485,7 @@ function register(router, { db, authenticateToken, requireAdmin, normalizeGenres
           metadata.series,
           metadata.series_position,
           metadata.published_year,
+          metadata.cover_image,
           metadata.cover_image,
           totalDuration,
           req.params.id


### PR DESCRIPTION
## Summary
- When "refresh metadata" re-extracted the cover from the audio file, it updated `cover_image` but left `cover_path` unchanged
- The cover serving endpoint checks `cover_path` first, so the old downloaded cover always won
- Now sets both `cover_path` and `cover_image` to the re-extracted cover so the embedded one takes precedence

## Test plan
- [ ] Change a book's cover via edit metadata (download external cover)
- [ ] Hit "Refresh Metadata" — cover should revert to the one embedded in the audio file
- [ ] Verify other metadata fields also refresh correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)