### PR TITLE
Skip file move when target already exists instead of creating duplicates

### DIFF
--- a/server/services/fileOrganizer.js
+++ b/server/services/fileOrganizer.js
@@ -302,13 +302,10 @@ async function organizeAudiobook(audiobook) {
       const targetFilename = getTargetFilename(audiobook, audiobook.file_path);
       newFilePath = path.join(targetDir, targetFilename);
 
-      // Handle potential filename conflicts
-      let counter = 1;
-      while (fs.existsSync(newFilePath) && newFilePath !== audiobook.file_path) {
-        const ext = path.extname(targetFilename);
-        const base = path.basename(targetFilename, ext);
-        newFilePath = path.join(targetDir, `${base} (${counter})${ext}`);
-        counter++;
+      // If target already exists and isn't the source file, skip the move
+      if (fs.existsSync(newFilePath) && path.normalize(newFilePath) !== path.normalize(audiobook.file_path)) {
+        console.log(`  Skipping move: target already exists at ${newFilePath}`);
+        return { moved: false };
       }
 
       if (!moveFile(audiobook.file_path, newFilePath)) {

--- a/tests/unit/fileOrganizer.test.js
+++ b/tests/unit/fileOrganizer.test.js
@@ -370,9 +370,8 @@ describe('File Organizer Service', () => {
       };
 
       const result = await organizeAudiobook(audiobook);
-      expect(result.moved).toBe(true);
-      // Should have added a (1) suffix
-      expect(result.newPath).toContain('(1)');
+      // Should skip the move rather than create a duplicate with (1) suffix
+      expect(result.moved).toBe(false);
     });
 
     test('handles cross-filesystem move', async () => {


### PR DESCRIPTION
## Summary
- Replaced the file organizer's "(1)" suffix duplication logic with a simple skip when the target file already exists
- Metadata is already saved to the DB before file organization runs, so skipping the move doesn't lose any data
- Updated the corresponding test to verify the skip behavior

## Test plan
- [ ] All existing tests pass (1828 tests)
- [ ] Rebuild local container with `podman compose up -d --build` and test
- [ ] Change an audiobook's metadata to trigger file organization — verify no "(1)" duplicates are created
- [ ] Verify metadata changes are still saved correctly even when the file move is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)