### PR TITLE
Add reading list management with drag-and-drop to PWA

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,10 @@
       "name": "sappho-client",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "axios": "^1.6.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -513,6 +517,73 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2994,6 +3065,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/undici": {
       "version": "7.21.0",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,10 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "axios": "^1.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -289,12 +289,18 @@ export const uploadAndRestoreBackup = (file, options = {}) => {
   });
 };
 
-// Favorites
-export const getFavorites = () =>
-  api.get('/audiobooks/favorites');
+// Favorites / Reading List
+export const getFavorites = (sort = 'custom') =>
+  api.get(`/audiobooks/favorites?sort=${sort}`);
 
 export const toggleFavorite = (id) =>
   api.post(`/audiobooks/${id}/favorite/toggle`);
+
+export const removeFavorite = (id) =>
+  api.delete(`/audiobooks/${id}/favorite`);
+
+export const reorderFavorites = (order) =>
+  api.put('/audiobooks/favorites/reorder', { order });
 
 // Duplicates
 export const getDuplicates = () =>

--- a/client/src/pages/Library.css
+++ b/client/src/pages/Library.css
@@ -712,6 +712,147 @@
   padding: 0.5rem 0;
 }
 
+.reading-list-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex: 1;
+}
+
+.reading-list-header-row h2 {
+  margin: 0;
+}
+
+.reading-list-count {
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: #9ca3af;
+  margin-left: 0.25rem;
+}
+
+.reading-list-sort select {
+  background: #1a1a2e;
+  color: #e0e7f1;
+  border: 1px solid #374151;
+  border-radius: 6px;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  outline: none;
+}
+
+.reading-list-sort select:focus {
+  border-color: #3b82f6;
+}
+
+.reading-list-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.reading-list-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  background: #1a1a2e;
+  border-radius: 10px;
+  transition: background 0.15s ease, box-shadow 0.15s ease;
+}
+
+.reading-list-row.dragging {
+  background: #252542;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+}
+
+.reading-list-number {
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: #3b82f6;
+  min-width: 28px;
+  text-align: center;
+}
+
+.reading-list-cover {
+  width: 48px;
+  height: 48px;
+  border-radius: 6px;
+  overflow: hidden;
+  background: linear-gradient(135deg, #374151 0%, #1f2937 100%);
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.reading-list-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.reading-list-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  cursor: pointer;
+}
+
+.reading-list-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #e0e7f1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reading-list-subtitle {
+  font-size: 0.75rem;
+  color: #9ca3af;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reading-list-remove {
+  background: none;
+  border: none;
+  color: #6b7280;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: color 0.15s ease;
+}
+
+.reading-list-remove:hover {
+  color: #f87171;
+}
+
+.reading-list-drag {
+  background: none;
+  border: none;
+  color: #6b7280;
+  cursor: grab;
+  padding: 0.25rem;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  touch-action: none;
+}
+
+.reading-list-drag:active {
+  cursor: grabbing;
+}
+
+/* Keep old classes for other pages that may use them */
 .favorites-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));

--- a/client/src/pages/Library.jsx
+++ b/client/src/pages/Library.jsx
@@ -1,11 +1,107 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { getAudiobooks, getSeries, getAuthors, getFavorites, getCollections, createCollection, deleteCollection, getCoverUrl, getProfile } from '../api';
+import { getAudiobooks, getSeries, getAuthors, getFavorites, removeFavorite, reorderFavorites, getCollections, createCollection, deleteCollection, getCoverUrl, getProfile } from '../api';
 import { useWebSocket } from '../contexts/WebSocketContext';
 import UploadModal from '../components/UploadModal';
 import { LibrarySkeleton } from '../components/Skeleton';
-import { formatDurationParts } from '../utils/formatting';
+import { formatDurationParts, formatDuration } from '../utils/formatting';
+import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
 import './Library.css';
+
+function SortableReadingListRow({ book, index, canDrag, navigate, onRemove }) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: book.id, disabled: !canDrag });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    zIndex: isDragging ? 10 : 'auto',
+  };
+
+  const subtitle = [
+    book.author,
+    book.duration ? formatDuration(book.duration) : null
+  ].filter(Boolean).join(' · ');
+
+  return (
+    <div ref={setNodeRef} style={style} className={`reading-list-row ${isDragging ? 'dragging' : ''}`}>
+      <span className="reading-list-number">#{index + 1}</span>
+      <div className="reading-list-cover" onClick={() => navigate(`/audiobook/${book.id}`)}>
+        <img
+          src={getCoverUrl(book.id, book.updated_at, 120)}
+          alt={book.title}
+          loading="lazy"
+          onError={(e) => { e.target.style.display = 'none'; }}
+        />
+      </div>
+      <div className="reading-list-info" onClick={() => navigate(`/audiobook/${book.id}`)}>
+        <span className="reading-list-title">{book.title}</span>
+        {subtitle && <span className="reading-list-subtitle">{subtitle}</span>}
+      </div>
+      <button
+        className="reading-list-remove"
+        onClick={(e) => { e.stopPropagation(); onRemove(book.id); }}
+        title="Remove from reading list"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+      {canDrag && (
+        <button className="reading-list-drag" {...attributes} {...listeners} title="Drag to reorder">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="8" y1="6" x2="16" y2="6" /><line x1="8" y1="12" x2="16" y2="12" /><line x1="8" y1="18" x2="16" y2="18" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}
+
+function ReadingList({ favorites, readingListSort, navigate, onReorder, onRemove }) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const canDrag = readingListSort === 'custom';
+
+  const handleDragEnd = (event) => {
+    const { active, over } = event;
+    if (active && over && active.id !== over.id) {
+      onReorder(active.id, over.id);
+    }
+  };
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} modifiers={[restrictToVerticalAxis]}>
+      <SortableContext items={favorites.map(b => b.id)} strategy={verticalListSortingStrategy}>
+        <div className="reading-list-rows">
+          {favorites.map((book, index) => (
+            <SortableReadingListRow
+              key={book.id}
+              book={book}
+              index={index}
+              canDrag={canDrag}
+              navigate={navigate}
+              onRemove={onRemove}
+            />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+}
 
 // Component for rotating collection covers
 function RotatingCover({ bookIds, collectionName }) {
@@ -67,6 +163,7 @@ export default function Library({ onPlay }) {
   // Reading List state
   const [favorites, setFavorites] = useState([]);
   const [loadingFavorites, setLoadingFavorites] = useState(false);
+  const [readingListSort, setReadingListSort] = useState('custom');
 
   // Collections state
   const [collections, setCollections] = useState([]);
@@ -152,15 +249,44 @@ export default function Library({ onPlay }) {
     }
   }, [activeTab]);
 
-  const loadFavorites = async () => {
+  const loadFavorites = async (sort = readingListSort) => {
     setLoadingFavorites(true);
     try {
-      const response = await getFavorites();
+      const response = await getFavorites(sort);
       setFavorites(response.data);
     } catch (error) {
       console.error('Error loading favorites:', error);
     } finally {
       setLoadingFavorites(false);
+    }
+  };
+
+  const handleReadingListSortChange = (sort) => {
+    setReadingListSort(sort);
+    loadFavorites(sort);
+  };
+
+  const handleRemoveFavorite = async (id) => {
+    setFavorites(prev => prev.filter(b => b.id !== id));
+    try {
+      await removeFavorite(id);
+    } catch (error) {
+      console.error('Error removing favorite:', error);
+      loadFavorites();
+    }
+  };
+
+  const handleReorderFavorites = async (activeId, overId) => {
+    const oldIndex = favorites.findIndex(b => b.id === activeId);
+    const newIndex = favorites.findIndex(b => b.id === overId);
+    if (oldIndex === newIndex) return;
+
+    const reordered = arrayMove(favorites, oldIndex, newIndex);
+    setFavorites(reordered);
+    try {
+      await reorderFavorites(reordered.map(b => b.id));
+    } catch (error) {
+      console.error('Error reordering favorites:', error);
     }
   };
 
@@ -504,7 +630,19 @@ export default function Library({ onPlay }) {
                 </svg>
                 Library
               </button>
-              <h2>Reading List</h2>
+              <div className="reading-list-header-row">
+                <h2>Reading List <span className="reading-list-count">{favorites.length}</span></h2>
+                <div className="reading-list-sort">
+                  <select
+                    value={readingListSort}
+                    onChange={(e) => handleReadingListSortChange(e.target.value)}
+                  >
+                    <option value="custom">Custom Order</option>
+                    <option value="title">Title</option>
+                    <option value="date">Date Added</option>
+                  </select>
+                </div>
+              </div>
             </div>
             {loadingFavorites ? (
               <div className="loading">Loading your reading list...</div>
@@ -518,26 +656,13 @@ export default function Library({ onPlay }) {
                 <p className="empty-state-hint">Add books to your reading list by clicking the bookmark icon on any audiobook.</p>
               </div>
             ) : (
-              <div className="favorites-grid">
-                {favorites.map((book) => (
-                  <div
-                    key={book.id}
-                    className="book-card"
-                    onClick={() => navigate(`/audiobook/${book.id}`)}
-                  >
-                    <div className="book-cover">
-                      <img
-                        src={getCoverUrl(book.id, book.updated_at, 300)}
-                        alt={book.title}
-                        loading="lazy"
-                        onError={(e) => {
-                          e.target.style.display = 'none';
-                        }}
-                      />
-                    </div>
-                  </div>
-                ))}
-              </div>
+              <ReadingList
+                favorites={favorites}
+                readingListSort={readingListSort}
+                navigate={navigate}
+                onReorder={handleReorderFavorites}
+                onRemove={handleRemoveFavorite}
+              />
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Replace reading list cover grid with numbered vertical list layout
- Add drag-and-drop reordering via @dnd-kit (syncs order to server)
- Add X button to remove books from reading list
- Add sort dropdown: Custom Order, Title, Date Added (server-side sorting)
- Drag handles hidden when using non-custom sort order
- New API functions: `getFavorites(sort)`, `removeFavorite`, `reorderFavorites`

Matches the Android app's reading list implementation from sappho-android#211.

## Test plan
- [ ] Open Library → Reading List
- [ ] Verify books show as numbered rows with cover thumbnail, title, author, duration
- [ ] Drag a book via the ≡ handle to reorder — verify number updates and order persists after refresh
- [ ] Click X on a row to remove from reading list
- [ ] Switch sort between Custom, Title, Date Added — verify list reorders
- [ ] Verify drag handles disappear when sort is Title or Date Added
- [ ] Verify empty state still shows when no books in reading list
- [ ] Click a row to navigate to audiobook detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)