### PR TITLE
Fix position not restoring when reopening PWA

### DIFF
--- a/client/src/components/player/usePositionRestoration.js
+++ b/client/src/components/player/usePositionRestoration.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 /**
  * Restores saved playback position when audio metadata loads,
@@ -12,6 +12,7 @@ export function usePositionRestoration({
   setCurrentTime
 }) {
   const [hasRestoredPosition, setHasRestoredPosition] = useState(false);
+  const initialProgressRef = useRef(progress?.position ?? null);
   const [isNewLoad, setIsNewLoad] = useState(() => {
     // Check if this is a page refresh by checking session storage
     // sessionStorage persists during the same tab session but clears on refresh
@@ -149,6 +150,31 @@ export function usePositionRestoration({
       return () => audio.removeEventListener('loadedmetadata', handleLoadedMetadata);
     }
   }, [progress, hasRestoredPosition, isNewLoad]);
+
+  // When server progress arrives after initial restoration and differs
+  // significantly from the initially restored position, re-seek to the
+  // correct position. This handles the case where localStorage had a stale
+  // position and the server has a more recent one.
+  useEffect(() => {
+    if (!hasRestoredPosition || !progress || !audioRef.current) return;
+    if (!audioRef.current.duration) return;
+
+    const serverPosition = progress.position;
+    const initialPosition = initialProgressRef.current ?? 0;
+
+    // Only re-seek if the server position differs significantly from what
+    // was initially restored (meaning localStorage was stale)
+    if (Math.abs(serverPosition - initialPosition) > 10) {
+      const audioDuration = audioRef.current.duration;
+      const isFinished = (audioDuration - serverPosition) < 30;
+      if (!isFinished && serverPosition > 0) {
+        audioRef.current.currentTime = serverPosition;
+        setCurrentTime(serverPosition);
+      }
+      // Update the ref so we don't re-seek on subsequent renders
+      initialProgressRef.current = serverPosition;
+    }
+  }, [progress, hasRestoredPosition]);
 
   return { hasRestoredPosition, isNewLoad };
 }

--- a/client/src/components/player/useProgressSync.js
+++ b/client/src/components/player/useProgressSync.js
@@ -133,6 +133,13 @@ export function useProgressSync(audiobookId, playing, audioRef) {
         const progressPercent = duration > 0 ? (currentTime / duration) * 100 : 0;
         const isFinished = progressPercent >= 98;
         updateProgressSafe(audiobookId, currentTime, isFinished ? 1 : 0, 'playing');
+        // Keep localStorage in sync so position survives app restarts
+        try {
+          const saved = localStorage.getItem('currentProgress');
+          const parsed = saved ? JSON.parse(saved) : {};
+          parsed.position = currentTime;
+          localStorage.setItem('currentProgress', JSON.stringify(parsed));
+        } catch (e) { /* ignore */ }
       }
     }, 5000);
 


### PR DESCRIPTION
## Summary
- Fix stale playback position when reopening PWA after closing/backgrounding
- Save current position to localStorage every 5s during playback so it's always up-to-date
- Re-seek to server position if it differs significantly from the stale localStorage position on reopen

## Root cause
`currentProgress` in localStorage was only saved when a book was first clicked from the detail page, never updated during playback. When the user reopened the PWA hours later, the position restored was from when they first started playing, not where they actually left off.

## Test plan
- [ ] Play a book for a few minutes, then close/background the PWA
- [ ] Reopen the PWA — mini player should show the correct position
- [ ] Tap the mini player to open fullscreen — position should be correct
- [ ] Verify position updates in localStorage during playback (check devtools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)