### PR TITLE
Fix duplicate audiobook creation and safe delete

### DIFF
--- a/server/routes/audiobooks/crud.js
+++ b/server/routes/audiobooks/crud.js
@@ -285,10 +285,17 @@ function register(router, { db, authenticateToken, requireAdmin, normalizeGenres
       await dbRun('DELETE FROM collection_items WHERE audiobook_id = ?', [req.params.id]);
       await dbRun('DELETE FROM audiobooks WHERE id = ?', [req.params.id]);
 
-      // Delete entire audiobook directory (contains audio file, cover, etc.)
+      // Delete audiobook files only if no other entries reference the same directory
       if (audiobook.file_path) {
         const audioDir = path.dirname(audiobook.file_path);
-        if (fs.existsSync(audioDir)) {
+        const othersInSameDir = await dbAll(
+          'SELECT id FROM audiobooks WHERE file_path LIKE ? AND id != ?',
+          [audioDir + '%', req.params.id]
+        );
+
+        if (othersInSameDir.length > 0) {
+          console.log(`Skipping directory delete for ${audioDir} — ${othersInSameDir.length} other audiobook(s) still reference it`);
+        } else if (fs.existsSync(audioDir)) {
           fs.rmSync(audioDir, { recursive: true, force: true });
           console.log(`Deleted audiobook directory: ${audioDir}`);
 

--- a/server/services/fileProcessor.js
+++ b/server/services/fileProcessor.js
@@ -978,6 +978,19 @@ async function saveToDatabase(metadata, filePath, fileSize, userId) {
   // Generate content hash for stable identification
   const contentHash = generateBestHash({ ...metadata, fileSize }, filePath);
 
+  // Check for existing entry with the same file_path to prevent duplicates
+  const existing = await new Promise((resolve, reject) => {
+    db.get('SELECT * FROM audiobooks WHERE file_path = ?', [filePath], (err, row) => {
+      if (err) reject(err);
+      else resolve(row);
+    });
+  });
+
+  if (existing) {
+    console.log(`Duplicate prevented: audiobook already exists at file_path "${filePath}" (id=${existing.id})`);
+    return existing;
+  }
+
   return new Promise((resolve, reject) => {
     db.run(
       `INSERT INTO audiobooks


### PR DESCRIPTION
## Summary
- **Duplicate upload prevention**: `saveToDatabase()` in `fileProcessor.js` now checks for an existing audiobook with the same `file_path` before INSERT. If found, returns the existing record instead of creating a duplicate.
- **Safe delete**: The DELETE endpoint in `crud.js` now checks if other audiobook entries reference files in the same directory before deleting it. If other entries exist, the directory is preserved.

## Context
When re-uploading an audiobook (e.g., Slaughterhouse 5), the system would create a second DB entry pointing to the same file. Deleting one duplicate via the admin UI would then remove the shared file directory, breaking the remaining entry.

## Test plan
- [ ] Upload an audiobook, then upload the same file again — should not create a duplicate
- [ ] Create a duplicate manually (if one exists), delete one entry — files should remain for the other
- [ ] Normal delete of a non-duplicate audiobook still removes files as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)