### PR TITLE
Fix chapter toggle visual feedback and remove buffer setting

### DIFF
--- a/client/src/components/AudioPlayer.jsx
+++ b/client/src/components/AudioPlayer.jsx
@@ -583,6 +583,7 @@ const AudioPlayer = forwardRef(({ audiobook, progress, onClose }, ref) => {
     return () => window.removeEventListener('playerSettingsChanged', handleSettingsChange);
   }, []);
 
+
   // Load and save playback speed per audiobook
   useEffect(() => {
     if (!audiobook?.id) return;

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -44,6 +44,9 @@ export default function Profile() {
   });
   const [changingPassword, setChangingPassword] = useState(false);
 
+  // Player settings (local state for immediate UI feedback)
+  const [chapterMode, setChapterMode] = useState(() => localStorage.getItem('progressDisplayMode') === 'chapter');
+
   // MFA state
   const [mfaStatus, setMfaStatus] = useState({ enabled: false, remainingBackupCodes: 0 });
   const [showMFASetup, setShowMFASetup] = useState(false);
@@ -501,33 +504,15 @@ export default function Profile() {
           <span>Show chapter progress</span>
           <input
             type="checkbox"
-            checked={localStorage.getItem('progressDisplayMode') === 'chapter'}
+            checked={chapterMode}
             onChange={(e) => {
-              localStorage.setItem('progressDisplayMode', e.target.checked ? 'chapter' : 'book');
+              const newMode = e.target.checked ? 'chapter' : 'book';
+              localStorage.setItem('progressDisplayMode', newMode);
+              setChapterMode(e.target.checked);
               window.dispatchEvent(new CustomEvent('playerSettingsChanged'));
             }}
           />
         </label>
-        <div className="select-row">
-          <span>Buffer size</span>
-          <select
-            value={localStorage.getItem('audioBufferSize') || '60'}
-            onChange={(e) => {
-              localStorage.setItem('audioBufferSize', e.target.value);
-              window.dispatchEvent(new CustomEvent('playerSettingsChanged'));
-            }}
-          >
-            <option value="30">30 seconds</option>
-            <option value="60">1 minute</option>
-            <option value="120">2 minutes</option>
-            <option value="300">5 minutes</option>
-            <option value="600">10 minutes</option>
-            <option value="1800">30 minutes</option>
-            <option value="3600">1 hour</option>
-            <option value="7200">2 hours</option>
-            <option value="10800">3 hours</option>
-          </select>
-        </div>
       </div>
 
       {/* Spacer for bottom nav */}


### PR DESCRIPTION
## Summary
- Chapter mode toggle in Profile now updates visually without page refresh (uses React state instead of reading localStorage directly)
- Removed non-functional buffer size dropdown — HTML5 audio doesn't support configurable buffer sizes

## Test plan
- [ ] Toggle chapter mode in Profile — checkbox should update immediately
- [ ] Player should switch between chapter/book mode without refresh
- [ ] Buffer size dropdown no longer appears in Player settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)