### PR TITLE
Fix seek button readability and styling

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -169,13 +169,15 @@
 
 .control-btn.skip-btn {
   background: none;
-  padding: 6px;
-  opacity: 0.8;
+  padding: 4px;
+  border-radius: 0;
+  opacity: 0.7;
 }
 
 .control-btn.skip-btn:hover {
   background: none;
   opacity: 1;
+  transform: scale(1.1);
 }
 
 .play-btn {

--- a/client/src/components/player/PlaybackControls.jsx
+++ b/client/src/components/player/PlaybackControls.jsx
@@ -52,7 +52,7 @@ function RewindIcon({ size, strokeWidth = 2 }) {
       <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
       <path d="M3 3v5h5"/>
       {size >= 40 && (
-        <text x="12" y="15.5" fontSize="6" fill="currentColor" textAnchor="middle" fontWeight="100" fontFamily="system-ui, -apple-system, sans-serif">15</text>
+        <text x="12" y="15.5" fontSize="7" fill="currentColor" stroke="none" textAnchor="middle" fontWeight="600" fontFamily="system-ui, -apple-system, sans-serif">15</text>
       )}
     </svg>
   );
@@ -64,7 +64,7 @@ function ForwardIcon({ size, strokeWidth = 2 }) {
       <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/>
       <path d="M21 3v5h-5"/>
       {size >= 40 && (
-        <text x="12" y="15.5" fontSize="6" fill="currentColor" textAnchor="middle" fontWeight="100" fontFamily="system-ui, -apple-system, sans-serif">15</text>
+        <text x="12" y="15.5" fontSize="7" fill="currentColor" stroke="none" textAnchor="middle" fontWeight="600" fontFamily="system-ui, -apple-system, sans-serif">15</text>
       )}
     </svg>
   );


### PR DESCRIPTION
## Summary
- Full player: "15" text inside seek icons was barely readable (fontWeight 100, too small). Changed to fontWeight 600, fontSize 7, and removed stroke interference
- Mini player: skip buttons still had gray button background/padding from `control-btn` class. Now stripped to plain icons with no background

## Test plan
- [ ] Full player seek buttons show clear, readable "15" inside the circular arrow
- [ ] Mini player seek buttons appear as plain icon symbols, not gray boxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)