### PR TITLE
Fix mobile seek buttons and notification clearing

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -1474,32 +1474,23 @@
     display: none !important;
   }
 
-  /* Show mobile seek buttons */
+  /* Show mobile seek buttons as plain icons */
   .player-mobile-controls .mobile-seek-btn {
     display: flex !important;
-    width: 40px;
-    height: 40px;
-    background: rgba(55, 65, 81, 0.5);
-    backdrop-filter: blur(8px);
+    background: none;
     color: #e5e7eb;
-    border: 1px solid rgba(75, 85, 99, 0.3);
-    border-radius: 12px;
+    border: none;
     padding: 0;
     align-items: center;
     justify-content: center;
-    transition: all 0.2s;
-  }
-
-  /* Remove custom margins on seek buttons - let gap handle spacing */
-  .player-mobile-controls .mobile-seek-btn {
+    transition: opacity 0.2s;
+    opacity: 0.8;
     margin-left: 0 !important;
     margin-right: 0 !important;
   }
 
   .player-mobile-controls .mobile-seek-btn:active {
-    color: #fff;
-    background: rgba(75, 85, 99, 0.7);
-    border-color: rgba(59, 130, 246, 0.5);
+    opacity: 1;
     transform: scale(0.95);
   }
 

--- a/client/src/components/AudioPlayer.jsx
+++ b/client/src/components/AudioPlayer.jsx
@@ -946,7 +946,7 @@ const AudioPlayer = forwardRef(({ audiobook, progress, onClose }, ref) => {
             <svg xmlns="http://www.w3.org/2000/svg" width="42" height="42" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="0.6" strokeLinecap="round" strokeLinejoin="round">
               <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"></path>
               <path d="M3 3v5h5"></path>
-              <text x="12" y="15.5" fontSize="6" fill="currentColor" textAnchor="middle" fontWeight="100" fontFamily="system-ui, -apple-system, sans-serif">15</text>
+              <text x="12" y="15.5" fontSize="7" fill="currentColor" stroke="none" textAnchor="middle" fontWeight="500" fontFamily="system-ui, -apple-system, sans-serif">15</text>
             </svg>
           </button>
           <button className={`control-btn play-btn mobile-play-btn ${playing ? 'playing' : ''} ${isBuffering ? 'buffering' : ''}`} onClick={togglePlay} title={playing ? 'Pause' : 'Play'} aria-label={playing ? 'Pause' : 'Play'}>
@@ -969,7 +969,7 @@ const AudioPlayer = forwardRef(({ audiobook, progress, onClose }, ref) => {
             <svg xmlns="http://www.w3.org/2000/svg" width="42" height="42" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="0.6" strokeLinecap="round" strokeLinejoin="round">
               <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"></path>
               <path d="M21 3v5h-5"></path>
-              <text x="12" y="15.5" fontSize="6" fill="currentColor" textAnchor="middle" fontWeight="100" fontFamily="system-ui, -apple-system, sans-serif">15</text>
+              <text x="12" y="15.5" fontSize="7" fill="currentColor" stroke="none" textAnchor="middle" fontWeight="500" fontFamily="system-ui, -apple-system, sans-serif">15</text>
             </svg>
           </button>
         </div>

--- a/client/src/components/NotificationPanel.jsx
+++ b/client/src/components/NotificationPanel.jsx
@@ -109,13 +109,13 @@ export default function NotificationPanel({ notifications, onClose, onNotificati
     }
   };
 
-  const hasUnread = notifications.some(n => !n.is_read);
+  const unreadNotifications = notifications.filter(n => !n.is_read);
 
   return (
     <div className="notification-panel">
       <div className="notification-panel-header">
         <span className="notification-panel-title">Notifications</span>
-        {hasUnread && (
+        {unreadNotifications.length > 0 && (
           <button
             className="notification-mark-all-read"
             onClick={handleMarkAllRead}
@@ -126,19 +126,19 @@ export default function NotificationPanel({ notifications, onClose, onNotificati
       </div>
 
       <div className="notification-panel-list">
-        {notifications.length === 0 ? (
+        {unreadNotifications.length === 0 ? (
           <div className="notification-empty">
             <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
               <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
             </svg>
-            <span>No notifications yet</span>
+            <span>No new notifications</span>
           </div>
         ) : (
-          notifications.map(notification => (
+          unreadNotifications.map(notification => (
             <button
               key={notification.id}
-              className={`notification-item ${!notification.is_read ? 'unread' : ''}`}
+              className="notification-item unread"
               onClick={() => handleNotificationClick(notification)}
             >
               <div className="notification-item-icon">


### PR DESCRIPTION
## Summary
- **Mobile seek buttons**: Stripped background, border, and border-radius from `.mobile-seek-btn` so they render as plain icons (like iOS). Also fixed SVG text with `stroke="none"` and readable font weight.
- **Notifications**: Panel now only shows unread notifications. Read notifications disappear immediately when marked read instead of requiring a page refresh.

## Test plan
- [ ] Mobile mini player: seek buttons should be plain icons, no button background/border
- [ ] Mobile mini player: "15" text inside seek icons should be readable
- [ ] Click a notification — it should disappear from the panel
- [ ] Click "Mark all read" — all notifications should disappear, showing "No new notifications"

🤖 Generated with [Claude Code](https://claude.com/claude-code)