### PR TITLE
Remove control-btn class from mobile seek buttons

### DIFF
--- a/client/src/components/AudioPlayer.jsx
+++ b/client/src/components/AudioPlayer.jsx
@@ -942,7 +942,7 @@ const AudioPlayer = forwardRef(({ audiobook, progress, onClose }, ref) => {
               <div className="waveform-bar"></div>
             </div>
           )}
-          <button className="control-btn mobile-seek-btn" onClick={skipBackward} title="Rewind 15s" aria-label="Rewind 15 seconds">
+          <button className="mobile-seek-btn" onClick={skipBackward} title="Rewind 15s" aria-label="Rewind 15 seconds">
             <svg xmlns="http://www.w3.org/2000/svg" width="42" height="42" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="0.6" strokeLinecap="round" strokeLinejoin="round">
               <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"></path>
               <path d="M3 3v5h5"></path>
@@ -965,7 +965,7 @@ const AudioPlayer = forwardRef(({ audiobook, progress, onClose }, ref) => {
               </svg>
             )}
           </button>
-          <button className="control-btn mobile-seek-btn" onClick={skipForward} title="Forward 15s" aria-label="Forward 15 seconds">
+          <button className="mobile-seek-btn" onClick={skipForward} title="Forward 15s" aria-label="Forward 15 seconds">
             <svg xmlns="http://www.w3.org/2000/svg" width="42" height="42" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="0.6" strokeLinecap="round" strokeLinejoin="round">
               <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"></path>
               <path d="M21 3v5h-5"></path>


### PR DESCRIPTION
## Summary
The `.player-mobile-controls .control-btn` CSS rules were overriding `.mobile-seek-btn` styles due to cascade order (same specificity, later rule wins). Removing the `control-btn` class from mobile seek buttons lets the `mobile-seek-btn` plain-icon styles apply cleanly.

## Test plan
- [ ] Mobile mini player: seek buttons should be plain icons with no background/border

🤖 Generated with [Claude Code](https://claude.com/claude-code)