### PR TITLE
Reduce waveform visualizer size in mini player

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -2414,40 +2414,40 @@
 .waveform-visualizer {
   display: flex;
   align-items: flex-end;
-  gap: 2.5px;
-  height: 22px;
+  gap: 2px;
+  height: 14px;
   flex-shrink: 0;
 }
 
 .waveform-bar {
-  width: 3px;
+  width: 2.5px;
   border-radius: 1.5px;
   background: linear-gradient(180deg, #34d399 0%, #60a5fa 100%);
   transform-origin: bottom;
 }
 
 .waveform-bar:nth-child(1) {
-  height: 10px;
+  height: 6px;
   animation: waveform1 0.8s ease-in-out infinite;
 }
 
 .waveform-bar:nth-child(2) {
-  height: 16px;
+  height: 10px;
   animation: waveform2 0.6s ease-in-out infinite;
 }
 
 .waveform-bar:nth-child(3) {
-  height: 22px;
+  height: 14px;
   animation: waveform3 0.7s ease-in-out infinite;
 }
 
 .waveform-bar:nth-child(4) {
-  height: 14px;
+  height: 9px;
   animation: waveform4 0.9s ease-in-out infinite;
 }
 
 .waveform-bar:nth-child(5) {
-  height: 18px;
+  height: 11px;
   animation: waveform5 0.75s ease-in-out infinite;
 }
 


### PR DESCRIPTION
## Summary
- Scale down waveform bars from 10-22px to 6-14px heights
- Reduce bar width from 3px to 2.5px, gap from 2.5px to 2px
- More subtle playing indicator that doesn't dominate the mini player

## Test plan
- [ ] Play a book — waveform animation should be smaller but still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)