### PR TITLE
Add animated progress bar and chapter mode default

### DIFF
--- a/client/src/components/AudioPlayer.css
+++ b/client/src/components/AudioPlayer.css
@@ -721,6 +721,17 @@
   transition: width 0.1s ease;
 }
 
+.fullscreen-progress-fill.playing {
+  background: linear-gradient(90deg, #60a5fa, #34d399, #60a5fa);
+  background-size: 200% 100%;
+  animation: fullscreenProgressGradient 2s linear infinite;
+}
+
+@keyframes fullscreenProgressGradient {
+  0% { background-position: 0% 50%; }
+  100% { background-position: 200% 50%; }
+}
+
 .fullscreen-progress.dragging .fullscreen-progress-fill {
   transition: none;
   opacity: 0.5;
@@ -748,6 +759,12 @@
   transform: translate(-50%, -50%);
   pointer-events: none;
   transition: left 0.1s ease;
+}
+
+.fullscreen-progress-thumb.playing {
+  background: #34d399;
+  border-color: #34d399;
+  box-shadow: 0 0 12px rgba(52, 211, 153, 0.6), 0 3px 8px rgba(0, 0, 0, 0.4);
 }
 
 .fullscreen-progress.dragging .fullscreen-progress-thumb {

--- a/client/src/components/AudioPlayer.jsx
+++ b/client/src/components/AudioPlayer.jsx
@@ -28,7 +28,7 @@ const AudioPlayer = forwardRef(({ audiobook, progress, onClose }, ref) => {
   const [playbackSpeed, setPlaybackSpeed] = useState(1);
   const [showSpeedMenu, setShowSpeedMenu] = useState(false);
   const [progressDisplayMode, setProgressDisplayMode] = useState(() => {
-    return localStorage.getItem('progressDisplayMode') || 'book';
+    return localStorage.getItem('progressDisplayMode') || 'chapter';
   });
   const [showFullscreen, setShowFullscreen] = useState(false);
   const [chapters, setChapters] = useState([]);

--- a/client/src/components/player/FullscreenPlayer.jsx
+++ b/client/src/components/player/FullscreenPlayer.jsx
@@ -312,7 +312,7 @@ export default function FullscreenPlayer({
                 style={{ width: `${bufferedPercent}%` }}
               />
               <div
-                className="fullscreen-progress-fill"
+                className={`fullscreen-progress-fill ${playing ? 'playing' : ''}`}
                 style={{ width: `${progressPercent}%` }}
               />
               {isDraggingProgress && seekPreviewTime !== null && (
@@ -322,7 +322,7 @@ export default function FullscreenPlayer({
                 />
               )}
               <div
-                className="fullscreen-progress-thumb"
+                className={`fullscreen-progress-thumb ${playing ? 'playing' : ''}`}
                 style={{ left: isDraggingProgress && seekPreviewTime !== null ? `${seekPreviewPercent}%` : `${progressPercent}%` }}
               />
               {isDraggingProgress && seekPreviewTime !== null && (


### PR DESCRIPTION
## Summary
- Animated gradient shimmer (blue-green) on fullscreen progress bar when playing
- Glowing green thumb when playing
- Chapter progress mode now defaults to on (was 'book')

## Test plan
- [ ] Play an audiobook, open fullscreen player, verify progress bar animates
- [ ] Verify thumb turns green with glow while playing
- [ ] Fresh user defaults to chapter progress mode
- [ ] Paused state shows static blue bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)