### PR TITLE
Fix AddToCollectionModal missing is_public

### DIFF
--- a/client/src/components/AddToCollectionModal.css
+++ b/client/src/components/AddToCollectionModal.css
@@ -100,7 +100,7 @@
   border-radius: 10px;
 }
 
-.create-form input {
+.create-form input[type="text"] {
   width: 100%;
   padding: 0.75rem;
   background: #1f2937;
@@ -111,9 +111,55 @@
   margin-bottom: 0.75rem;
 }
 
-.create-form input:focus {
+.create-form input[type="text"]:focus {
   outline: none;
   border-color: #3b82f6;
+}
+
+.public-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+  margin-bottom: 0.5rem;
+  cursor: pointer;
+  color: #9ca3af;
+  font-size: 0.875rem;
+}
+
+.public-toggle input[type="checkbox"] {
+  display: none;
+}
+
+.toggle-switch {
+  width: 40px;
+  height: 22px;
+  background: #374151;
+  border-radius: 11px;
+  position: relative;
+  transition: background 0.2s;
+  flex-shrink: 0;
+}
+
+.toggle-switch::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  background: #9ca3af;
+  border-radius: 50%;
+  transition: all 0.2s;
+}
+
+.toggle-switch.active {
+  background: #3b82f6;
+}
+
+.toggle-switch.active::after {
+  left: 20px;
+  background: #fff;
 }
 
 .create-actions {

--- a/client/src/components/AddToCollectionModal.jsx
+++ b/client/src/components/AddToCollectionModal.jsx
@@ -9,6 +9,7 @@ export default function AddToCollectionModal({ isOpen, onClose, audiobookId, aud
   const [loading, setLoading] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState('');
+  const [newIsPublic, setNewIsPublic] = useState(false);
   const [creating, setCreating] = useState(false);
 
   useEffect(() => {
@@ -77,7 +78,7 @@ export default function AddToCollectionModal({ isOpen, onClose, audiobookId, aud
 
     setCreating(true);
     try {
-      const response = await createCollection(newName.trim(), '');
+      const response = await createCollection(newName.trim(), '', newIsPublic);
       const newCollection = response.data;
 
       // Add the book to the new collection
@@ -86,6 +87,7 @@ export default function AddToCollectionModal({ isOpen, onClose, audiobookId, aud
       setCollections([newCollection, ...collections]);
       setBookCollections(prev => new Set([...prev, newCollection.id]));
       setNewName('');
+      setNewIsPublic(false);
       setShowCreate(false);
     } catch (error) {
       console.error('Error creating collection:', error);
@@ -119,8 +121,17 @@ export default function AddToCollectionModal({ isOpen, onClose, audiobookId, aud
                     placeholder="Collection name"
                     autoFocus
                   />
+                  <label className="public-toggle">
+                    <span>Public</span>
+                    <input
+                      type="checkbox"
+                      checked={newIsPublic}
+                      onChange={(e) => setNewIsPublic(e.target.checked)}
+                    />
+                    <span className={`toggle-switch ${newIsPublic ? 'active' : ''}`}></span>
+                  </label>
                   <div className="create-actions">
-                    <button type="button" className="btn btn-secondary" onClick={() => setShowCreate(false)}>
+                    <button type="button" className="btn btn-secondary" onClick={() => { setShowCreate(false); setNewIsPublic(false); }}>
                       Cancel
                     </button>
                     <button type="submit" className="btn btn-primary" disabled={!newName.trim() || creating}>


### PR DESCRIPTION
## Summary
- Quick-create form in `AddToCollectionModal` was calling `createCollection(name, '')` without passing `is_public`, so collections created from the modal were always private
- Added a public/private toggle switch to the inline create form
- Styled toggle to match the dark theme

## Test plan
- [ ] Open "Add to Collection" modal, click "New Collection", verify public toggle appears
- [ ] Create collection with toggle ON — verify it's created as public
- [ ] Create collection with toggle OFF — verify it's private
- [ ] Cancel create form — verify toggle resets to OFF

🤖 Generated with [Claude Code](https://claude.com/claude-code)