### PR TITLE
Change chapter button to static Chapters label

### DIFF
--- a/client/src/components/AudioPlayer.jsx
+++ b/client/src/components/AudioPlayer.jsx
@@ -906,7 +906,7 @@ const AudioPlayer = forwardRef(({ audiobook, progress, onClose }, ref) => {
                 setShowChapterModal(true);
               }}
             >
-              {chapters[currentChapter]?.title || ''}
+              Chapters
             </button>
           )}
           <div className={`mobile-time-display ${playing ? 'playing' : ''}`}>


### PR DESCRIPTION
## Summary
- Replace dynamic chapter title with static "Chapters" label on player button

## Test plan
- [ ] Verify chapter button shows "Chapters" in fullscreen player

🤖 Generated with [Claude Code](https://claude.com/claude-code)