### PR TITLE
Add test coverage for notifications API and AudioPlayer components

### DIFF
--- a/client/src/__tests__/player/ChapterModal.test.jsx
+++ b/client/src/__tests__/player/ChapterModal.test.jsx
@@ -1,0 +1,168 @@
+/**
+ * Tests for ChapterModal component
+ * Tests chapter list rendering, active chapter, seek behavior, and close behavior
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ChapterModal from '../../components/player/ChapterModal';
+
+const sampleChapters = [
+  { title: 'Introduction', start_time: 0 },
+  { title: 'Chapter 1', start_time: 120 },
+  { title: 'Chapter 2', start_time: 360 },
+  { title: 'Chapter 3', start_time: 600 },
+];
+
+const defaultProps = {
+  chapters: sampleChapters,
+  currentTime: 150, // In Chapter 1
+  duration: 900,
+  onSeek: vi.fn(),
+  onClose: vi.fn(),
+  formatTime: (seconds) => {
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60);
+    return `${m}m ${s}s`;
+  },
+};
+
+function renderModal(overrides = {}) {
+  const props = { ...defaultProps, ...overrides };
+  Object.values(props).forEach(v => {
+    if (typeof v === 'function' && v.mockClear) v.mockClear();
+  });
+  return render(<ChapterModal {...props} />);
+}
+
+describe('ChapterModal', () => {
+  it('renders with Chapters heading', () => {
+    renderModal();
+    expect(screen.getByText('Chapters')).toBeInTheDocument();
+  });
+
+  it('renders all chapter titles', () => {
+    renderModal();
+    expect(screen.getByText('Introduction')).toBeInTheDocument();
+    expect(screen.getByText('Chapter 1')).toBeInTheDocument();
+    expect(screen.getByText('Chapter 2')).toBeInTheDocument();
+    expect(screen.getByText('Chapter 3')).toBeInTheDocument();
+  });
+
+  it('renders formatted start times for each chapter', () => {
+    renderModal();
+    expect(screen.getByText('0m 0s')).toBeInTheDocument(); // Introduction at 0
+    expect(screen.getByText('2m 0s')).toBeInTheDocument(); // Chapter 1 at 120
+    expect(screen.getByText('6m 0s')).toBeInTheDocument(); // Chapter 2 at 360
+    expect(screen.getByText('10m 0s')).toBeInTheDocument(); // Chapter 3 at 600
+  });
+
+  it('marks the current chapter as active', () => {
+    const { container } = renderModal({ currentTime: 150 }); // In Chapter 1
+    const activeItem = container.querySelector('.chapter-modal-item.active');
+    expect(activeItem).toBeInTheDocument();
+    expect(activeItem.textContent).toContain('Chapter 1');
+  });
+
+  it('marks Introduction as active when at time 0', () => {
+    const { container } = renderModal({ currentTime: 0 });
+    const activeItem = container.querySelector('.chapter-modal-item.active');
+    expect(activeItem).toBeInTheDocument();
+    expect(activeItem.textContent).toContain('Introduction');
+  });
+
+  it('marks last chapter as active when near end', () => {
+    const { container } = renderModal({ currentTime: 800 });
+    const activeItem = container.querySelector('.chapter-modal-item.active');
+    expect(activeItem).toBeInTheDocument();
+    expect(activeItem.textContent).toContain('Chapter 3');
+  });
+
+  it('sets aria-current on the active chapter', () => {
+    renderModal({ currentTime: 150 });
+    const activeChapter = screen.getByText('Chapter 1').closest('[role="button"]');
+    expect(activeChapter).toHaveAttribute('aria-current', 'true');
+  });
+
+  it('calls onSeek and onClose when a chapter is clicked', () => {
+    const onSeek = vi.fn();
+    const onClose = vi.fn();
+    renderModal({ onSeek, onClose });
+
+    fireEvent.click(screen.getByText('Chapter 2').closest('[role="button"]'));
+
+    expect(onSeek).toHaveBeenCalledWith(360); // Chapter 2 start_time
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSeek and onClose on Enter key press on a chapter', () => {
+    const onSeek = vi.fn();
+    const onClose = vi.fn();
+    renderModal({ onSeek, onClose });
+
+    const chapter3 = screen.getByText('Chapter 3').closest('[role="button"]');
+    fireEvent.keyDown(chapter3, { key: 'Enter' });
+
+    expect(onSeek).toHaveBeenCalledWith(600);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSeek and onClose on Space key press on a chapter', () => {
+    const onSeek = vi.fn();
+    const onClose = vi.fn();
+    renderModal({ onSeek, onClose });
+
+    const intro = screen.getByText('Introduction').closest('[role="button"]');
+    fireEvent.keyDown(intro, { key: ' ' });
+
+    expect(onSeek).toHaveBeenCalledWith(0);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('chapters are focusable (tabIndex=0)', () => {
+    renderModal();
+    const buttons = screen.getAllByRole('button');
+    // Filter out the close button
+    const chapterButtons = buttons.filter(b => !b.classList.contains('chapter-modal-close'));
+    chapterButtons.forEach(btn => {
+      expect(btn).toHaveAttribute('tabindex', '0');
+    });
+  });
+
+  describe('Close behavior', () => {
+    it('calls onClose when overlay is clicked', () => {
+      const onClose = vi.fn();
+      renderModal({ onClose });
+      fireEvent.click(screen.getByRole('dialog'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose when content area is clicked', () => {
+      const onClose = vi.fn();
+      renderModal({ onClose });
+      fireEvent.click(screen.getByText('Chapters'));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('calls onClose when close button clicked', () => {
+      const onClose = vi.fn();
+      renderModal({ onClose });
+      fireEvent.click(screen.getByLabelText('Close chapters'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose on Escape key press', () => {
+      const onClose = vi.fn();
+      renderModal({ onClose });
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('has proper dialog ARIA attributes', () => {
+    renderModal();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-label', 'Chapters');
+  });
+});

--- a/client/src/__tests__/player/PlaybackControls.test.jsx
+++ b/client/src/__tests__/player/PlaybackControls.test.jsx
@@ -1,0 +1,223 @@
+/**
+ * Tests for PlaybackControls component
+ * Tests both desktop and fullscreen variants, button rendering, and interactions
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PlaybackControls from '../../components/player/PlaybackControls';
+
+const defaultProps = {
+  playing: false,
+  isBuffering: false,
+  chapters: [],
+  currentChapter: 0,
+  onTogglePlay: vi.fn(),
+  onSkipBackward: vi.fn(),
+  onSkipForward: vi.fn(),
+  onSkipToPreviousChapter: vi.fn(),
+  onSkipToNextChapter: vi.fn(),
+  onStop: vi.fn(),
+};
+
+function renderControls(overrides = {}) {
+  const props = { ...defaultProps, ...overrides };
+  // Reset mocks for each render
+  Object.values(props).forEach(v => {
+    if (typeof v === 'function' && v.mockClear) v.mockClear();
+  });
+  return render(<PlaybackControls {...props} />);
+}
+
+describe('PlaybackControls', () => {
+  describe('Desktop variant (default)', () => {
+    it('renders play button when not playing', () => {
+      renderControls({ playing: false });
+      const playBtn = screen.getByLabelText('Play');
+      expect(playBtn).toBeInTheDocument();
+    });
+
+    it('renders pause button when playing', () => {
+      renderControls({ playing: true });
+      const pauseBtn = screen.getByLabelText('Pause');
+      expect(pauseBtn).toBeInTheDocument();
+    });
+
+    it('renders buffering spinner when buffering', () => {
+      renderControls({ isBuffering: true });
+      const playBtn = screen.getByLabelText('Play');
+      expect(playBtn.querySelector('.buffering-spinner')).toBeInTheDocument();
+    });
+
+    it('calls onTogglePlay when play button clicked', () => {
+      const onTogglePlay = vi.fn();
+      renderControls({ onTogglePlay });
+      fireEvent.click(screen.getByLabelText('Play'));
+      expect(onTogglePlay).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onSkipBackward when rewind button clicked', () => {
+      const onSkipBackward = vi.fn();
+      renderControls({ onSkipBackward });
+      fireEvent.click(screen.getByLabelText('Rewind 15 seconds'));
+      expect(onSkipBackward).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onSkipForward when forward button clicked', () => {
+      const onSkipForward = vi.fn();
+      renderControls({ onSkipForward });
+      fireEvent.click(screen.getByLabelText('Forward 15 seconds'));
+      expect(onSkipForward).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders stop button when onStop is provided', () => {
+      renderControls({ onStop: vi.fn() });
+      expect(screen.getByLabelText('Stop playback')).toBeInTheDocument();
+    });
+
+    it('calls onStop when stop button clicked', () => {
+      const onStop = vi.fn();
+      renderControls({ onStop });
+      fireEvent.click(screen.getByLabelText('Stop playback'));
+      expect(onStop).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render stop button when onStop is not provided', () => {
+      renderControls({ onStop: undefined });
+      expect(screen.queryByLabelText('Stop playback')).not.toBeInTheDocument();
+    });
+
+    it('does not render chapter skip buttons when no chapters', () => {
+      renderControls({ chapters: [] });
+      expect(screen.queryByLabelText('Previous chapter')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Next chapter')).not.toBeInTheDocument();
+    });
+
+    it('renders chapter skip buttons when chapters exist', () => {
+      const chapters = [
+        { title: 'Ch 1', start_time: 0 },
+        { title: 'Ch 2', start_time: 300 },
+        { title: 'Ch 3', start_time: 600 },
+      ];
+      renderControls({ chapters, currentChapter: 1 });
+      expect(screen.getByLabelText('Previous chapter')).toBeInTheDocument();
+      expect(screen.getByLabelText('Next chapter')).toBeInTheDocument();
+    });
+
+    it('disables previous chapter button on first chapter', () => {
+      const chapters = [
+        { title: 'Ch 1', start_time: 0 },
+        { title: 'Ch 2', start_time: 300 },
+      ];
+      renderControls({ chapters, currentChapter: 0 });
+      expect(screen.getByLabelText('Previous chapter')).toBeDisabled();
+    });
+
+    it('disables next chapter button on last chapter', () => {
+      const chapters = [
+        { title: 'Ch 1', start_time: 0 },
+        { title: 'Ch 2', start_time: 300 },
+      ];
+      renderControls({ chapters, currentChapter: 1 });
+      expect(screen.getByLabelText('Next chapter')).toBeDisabled();
+    });
+
+    it('calls onSkipToPreviousChapter when previous chapter clicked', () => {
+      const onSkipToPreviousChapter = vi.fn();
+      const chapters = [
+        { title: 'Ch 1', start_time: 0 },
+        { title: 'Ch 2', start_time: 300 },
+      ];
+      renderControls({ chapters, currentChapter: 1, onSkipToPreviousChapter });
+      fireEvent.click(screen.getByLabelText('Previous chapter'));
+      expect(onSkipToPreviousChapter).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onSkipToNextChapter when next chapter clicked', () => {
+      const onSkipToNextChapter = vi.fn();
+      const chapters = [
+        { title: 'Ch 1', start_time: 0 },
+        { title: 'Ch 2', start_time: 300 },
+      ];
+      renderControls({ chapters, currentChapter: 0, onSkipToNextChapter });
+      fireEvent.click(screen.getByLabelText('Next chapter'));
+      expect(onSkipToNextChapter).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows waveform visualizer when playing', () => {
+      const { container } = renderControls({ playing: true });
+      expect(container.querySelector('.waveform-visualizer')).toBeInTheDocument();
+    });
+
+    it('hides waveform visualizer when paused', () => {
+      const { container } = renderControls({ playing: false });
+      expect(container.querySelector('.waveform-visualizer')).not.toBeInTheDocument();
+    });
+
+    it('has proper ARIA group role', () => {
+      renderControls();
+      expect(screen.getByRole('group', { name: 'Playback controls' })).toBeInTheDocument();
+    });
+  });
+
+  describe('Fullscreen variant', () => {
+    it('renders fullscreen controls with correct class', () => {
+      const { container } = renderControls({ variant: 'fullscreen' });
+      expect(container.querySelector('.fullscreen-controls')).toBeInTheDocument();
+    });
+
+    it('renders play/pause in fullscreen variant', () => {
+      renderControls({ variant: 'fullscreen', playing: false });
+      expect(screen.getByLabelText('Play')).toBeInTheDocument();
+    });
+
+    it('renders pause in fullscreen variant when playing', () => {
+      renderControls({ variant: 'fullscreen', playing: true });
+      expect(screen.getByLabelText('Pause')).toBeInTheDocument();
+    });
+
+    it('renders rewind and forward buttons in fullscreen', () => {
+      renderControls({ variant: 'fullscreen' });
+      expect(screen.getByLabelText('Rewind 15 seconds')).toBeInTheDocument();
+      expect(screen.getByLabelText('Forward 15 seconds')).toBeInTheDocument();
+    });
+
+    it('renders chapter buttons in fullscreen when chapters exist', () => {
+      const chapters = [
+        { title: 'Ch 1', start_time: 0 },
+        { title: 'Ch 2', start_time: 300 },
+      ];
+      renderControls({ variant: 'fullscreen', chapters, currentChapter: 0 });
+      expect(screen.getByLabelText('Previous chapter')).toBeInTheDocument();
+      expect(screen.getByLabelText('Next chapter')).toBeInTheDocument();
+    });
+
+    it('does not render chapter buttons in fullscreen when no chapters', () => {
+      renderControls({ variant: 'fullscreen', chapters: [] });
+      expect(screen.queryByLabelText('Previous chapter')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Next chapter')).not.toBeInTheDocument();
+    });
+
+    it('renders buffering spinner in fullscreen', () => {
+      renderControls({ variant: 'fullscreen', isBuffering: true });
+      const playBtn = screen.getByLabelText('Play');
+      expect(playBtn.querySelector('.buffering-spinner')).toBeInTheDocument();
+    });
+
+    it('calls callbacks in fullscreen variant', () => {
+      const onTogglePlay = vi.fn();
+      const onSkipBackward = vi.fn();
+      const onSkipForward = vi.fn();
+      renderControls({ variant: 'fullscreen', onTogglePlay, onSkipBackward, onSkipForward });
+
+      fireEvent.click(screen.getByLabelText('Play'));
+      expect(onTogglePlay).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByLabelText('Rewind 15 seconds'));
+      expect(onSkipBackward).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByLabelText('Forward 15 seconds'));
+      expect(onSkipForward).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/client/src/__tests__/player/SleepTimerMenu.test.jsx
+++ b/client/src/__tests__/player/SleepTimerMenu.test.jsx
@@ -1,0 +1,182 @@
+/**
+ * Tests for SleepTimerMenu component
+ * Tests duration buttons, chapter option, cancel, custom input, and close behavior
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SleepTimerMenu from '../../components/player/SleepTimerMenu';
+
+const defaultProps = {
+  sleepTimer: null,
+  hasChapters: false,
+  onSelect: vi.fn(),
+  onClose: vi.fn(),
+};
+
+function renderMenu(overrides = {}) {
+  const props = { ...defaultProps, ...overrides };
+  Object.values(props).forEach(v => {
+    if (typeof v === 'function' && v.mockClear) v.mockClear();
+  });
+  return render(<SleepTimerMenu {...props} />);
+}
+
+describe('SleepTimerMenu', () => {
+  it('renders with Sleep Timer heading', () => {
+    renderMenu();
+    expect(screen.getByText('Sleep Timer')).toBeInTheDocument();
+  });
+
+  it('renders all preset duration buttons', () => {
+    renderMenu();
+    expect(screen.getByText('5 minutes')).toBeInTheDocument();
+    expect(screen.getByText('10 minutes')).toBeInTheDocument();
+    expect(screen.getByText('15 minutes')).toBeInTheDocument();
+    expect(screen.getByText('30 minutes')).toBeInTheDocument();
+    expect(screen.getByText('45 minutes')).toBeInTheDocument();
+    expect(screen.getByText('1 hour')).toBeInTheDocument();
+    expect(screen.getByText('1.5 hours')).toBeInTheDocument();
+    expect(screen.getByText('2 hours')).toBeInTheDocument();
+  });
+
+  it('calls onSelect with duration when a preset is clicked', () => {
+    const onSelect = vi.fn();
+    renderMenu({ onSelect });
+    fireEvent.click(screen.getByText('30 minutes'));
+    expect(onSelect).toHaveBeenCalledWith(30);
+  });
+
+  it('does not show cancel button when no timer is active', () => {
+    renderMenu({ sleepTimer: null });
+    expect(screen.queryByText('Cancel Timer')).not.toBeInTheDocument();
+  });
+
+  it('shows cancel button when a timer is active', () => {
+    renderMenu({ sleepTimer: 30 });
+    expect(screen.getByText('Cancel Timer')).toBeInTheDocument();
+  });
+
+  it('calls onSelect with null when cancel is clicked', () => {
+    const onSelect = vi.fn();
+    renderMenu({ sleepTimer: 30, onSelect });
+    fireEvent.click(screen.getByText('Cancel Timer'));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('does not show "End of chapter" option when no chapters', () => {
+    renderMenu({ hasChapters: false });
+    expect(screen.queryByText('End of chapter')).not.toBeInTheDocument();
+  });
+
+  it('shows "End of chapter" option when chapters exist', () => {
+    renderMenu({ hasChapters: true });
+    expect(screen.getByText('End of chapter')).toBeInTheDocument();
+  });
+
+  it('calls onSelect with "chapter" when end-of-chapter clicked', () => {
+    const onSelect = vi.fn();
+    renderMenu({ hasChapters: true, onSelect });
+    fireEvent.click(screen.getByText('End of chapter'));
+    expect(onSelect).toHaveBeenCalledWith('chapter');
+  });
+
+  it('marks active duration as active', () => {
+    renderMenu({ sleepTimer: 15 });
+    const activeBtn = screen.getByText('15 minutes');
+    expect(activeBtn.className).toContain('active');
+  });
+
+  it('marks chapter option as active when sleepTimer is "chapter"', () => {
+    renderMenu({ hasChapters: true, sleepTimer: 'chapter' });
+    const chapterBtn = screen.getByText('End of chapter');
+    expect(chapterBtn.className).toContain('active');
+  });
+
+  describe('Custom timer input', () => {
+    it('renders custom minutes input', () => {
+      renderMenu();
+      expect(screen.getByLabelText('Custom timer in minutes')).toBeInTheDocument();
+    });
+
+    it('renders Set button for custom input', () => {
+      renderMenu();
+      expect(screen.getByLabelText('Set custom timer')).toBeInTheDocument();
+    });
+
+    it('Set button is disabled when input is empty', () => {
+      renderMenu();
+      expect(screen.getByLabelText('Set custom timer')).toBeDisabled();
+    });
+
+    it('calls onSelect with custom value when Set is clicked', () => {
+      const onSelect = vi.fn();
+      renderMenu({ onSelect });
+
+      const input = screen.getByLabelText('Custom timer in minutes');
+      fireEvent.change(input, { target: { value: '25' } });
+
+      fireEvent.click(screen.getByLabelText('Set custom timer'));
+      expect(onSelect).toHaveBeenCalledWith(25);
+    });
+
+    it('submits custom value on Enter key', () => {
+      const onSelect = vi.fn();
+      renderMenu({ onSelect });
+
+      const input = screen.getByLabelText('Custom timer in minutes');
+      fireEvent.change(input, { target: { value: '45' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      expect(onSelect).toHaveBeenCalledWith(45);
+    });
+
+    it('does not submit invalid custom value (zero)', () => {
+      const onSelect = vi.fn();
+      renderMenu({ onSelect });
+
+      const input = screen.getByLabelText('Custom timer in minutes');
+      fireEvent.change(input, { target: { value: '0' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Close behavior', () => {
+    it('calls onClose when overlay is clicked', () => {
+      const onClose = vi.fn();
+      renderMenu({ onClose });
+      fireEvent.click(screen.getByRole('dialog'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose when content area is clicked', () => {
+      const onClose = vi.fn();
+      renderMenu({ onClose });
+      fireEvent.click(screen.getByText('Sleep Timer'));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('calls onClose when close button clicked', () => {
+      const onClose = vi.fn();
+      renderMenu({ onClose });
+      fireEvent.click(screen.getByLabelText('Close sleep timer menu'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose on Escape key press', () => {
+      const onClose = vi.fn();
+      renderMenu({ onClose });
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('has proper dialog ARIA attributes', () => {
+    renderMenu();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-label', 'Sleep timer');
+  });
+});

--- a/client/src/__tests__/player/SpeedMenu.test.jsx
+++ b/client/src/__tests__/player/SpeedMenu.test.jsx
@@ -1,0 +1,121 @@
+/**
+ * Tests for SpeedMenu component
+ * Tests preset buttons, slider interaction, and close behavior
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SpeedMenu from '../../components/player/SpeedMenu';
+
+const defaultProps = {
+  currentSpeed: 1,
+  onSelect: vi.fn(),
+  onClose: vi.fn(),
+};
+
+function renderMenu(overrides = {}) {
+  const props = { ...defaultProps, ...overrides };
+  Object.values(props).forEach(v => {
+    if (typeof v === 'function' && v.mockClear) v.mockClear();
+  });
+  return render(<SpeedMenu {...props} />);
+}
+
+describe('SpeedMenu', () => {
+  it('renders with Playback Speed heading', () => {
+    renderMenu();
+    expect(screen.getByText('Playback Speed')).toBeInTheDocument();
+  });
+
+  it('renders all preset speed buttons', () => {
+    renderMenu();
+    const presets = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3];
+    for (const preset of presets) {
+      expect(screen.getByLabelText(`${preset}x speed`)).toBeInTheDocument();
+    }
+  });
+
+  it('marks current speed preset as active', () => {
+    renderMenu({ currentSpeed: 1.5 });
+    const activeBtn = screen.getByLabelText('1.5x speed');
+    expect(activeBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('calls onSelect when a preset is clicked', () => {
+    const onSelect = vi.fn();
+    renderMenu({ onSelect });
+    fireEvent.click(screen.getByLabelText('2x speed'));
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+
+  it('displays current speed value in the header display', () => {
+    const { container } = renderMenu({ currentSpeed: 1.5 });
+    const display = container.querySelector('.speed-current-value');
+    expect(display).toBeInTheDocument();
+    expect(display.textContent).toBe('1.5x');
+  });
+
+  it('displays formatted speed with trailing zero for whole numbers', () => {
+    const { container } = renderMenu({ currentSpeed: 2 });
+    const display = container.querySelector('.speed-current-value');
+    expect(display.textContent).toBe('2.0x');
+  });
+
+  it('renders a speed slider', () => {
+    renderMenu();
+    expect(screen.getByLabelText('Playback speed slider')).toBeInTheDocument();
+  });
+
+  it('slider has correct min, max, and step', () => {
+    renderMenu();
+    const slider = screen.getByLabelText('Playback speed slider');
+    expect(slider).toHaveAttribute('min', '0.5');
+    expect(slider).toHaveAttribute('max', '3.0');
+    expect(slider).toHaveAttribute('step', '0.05');
+  });
+
+  it('calls onSelect when slider changes', () => {
+    const onSelect = vi.fn();
+    renderMenu({ onSelect });
+    const slider = screen.getByLabelText('Playback speed slider');
+    fireEvent.change(slider, { target: { value: '1.75' } });
+    expect(onSelect).toHaveBeenCalledWith(1.75);
+  });
+
+  it('calls onClose when overlay is clicked', () => {
+    const onClose = vi.fn();
+    renderMenu({ onClose });
+    const overlay = screen.getByRole('dialog');
+    fireEvent.click(overlay);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClose when content area is clicked', () => {
+    const onClose = vi.fn();
+    renderMenu({ onClose });
+    // Click the heading inside the content area
+    fireEvent.click(screen.getByText('Playback Speed'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn();
+    renderMenu({ onClose });
+    fireEvent.click(screen.getByLabelText('Close speed menu'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose on Escape key press', () => {
+    const onClose = vi.fn();
+    renderMenu({ onClose });
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('has proper dialog ARIA attributes', () => {
+    renderMenu();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-label', 'Playback speed');
+  });
+});

--- a/tests/integration/notifications.routes.test.js
+++ b/tests/integration/notifications.routes.test.js
@@ -1,0 +1,449 @@
+/**
+ * Integration tests for Notifications Routes
+ * Tests: list notifications, unread count, mark read, mark all read
+ */
+
+const request = require('supertest');
+const {
+  createTestDatabase,
+  createTestUser,
+  generateTestToken,
+  createTestApp
+} = require('./testApp');
+
+describe('Notifications Routes', () => {
+  let db;
+  let app;
+  let user1, user2;
+  let user1Token, user2Token;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    app = createTestApp(db);
+
+    user1 = await createTestUser(db, { username: 'notifuser1', password: 'Pass123!' });
+    user2 = await createTestUser(db, { username: 'notifuser2', password: 'Pass123!' });
+
+    user1Token = generateTestToken(user1);
+    user2Token = generateTestToken(user2);
+  });
+
+  afterEach((done) => {
+    db.close(done);
+  });
+
+  /**
+   * Helper: insert a notification into the database
+   */
+  function insertNotification({ type = 'info', title = 'Test', message = 'Test message', metadata = null }) {
+    return new Promise((resolve, reject) => {
+      db.run(
+        'INSERT INTO notifications (type, title, message, metadata) VALUES (?, ?, ?, ?)',
+        [type, title, message, metadata],
+        function (err) {
+          if (err) return reject(err);
+          resolve({ id: this.lastID, type, title, message, metadata });
+        }
+      );
+    });
+  }
+
+  /**
+   * Helper: mark a notification as read for a user
+   */
+  function markAsRead(userId, notificationId) {
+    return new Promise((resolve, reject) => {
+      db.run(
+        'INSERT OR IGNORE INTO user_notification_reads (user_id, notification_id) VALUES (?, ?)',
+        [userId, notificationId],
+        (err) => { if (err) reject(err); else resolve(); }
+      );
+    });
+  }
+
+  // ============================================
+  // LIST NOTIFICATIONS
+  // ============================================
+  describe('GET /api/notifications', () => {
+    it('returns 401 without authentication', async () => {
+      const res = await request(app).get('/api/notifications');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns empty array when no notifications exist', async () => {
+      const res = await request(app)
+        .get('/api/notifications')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    it('returns all notifications', async () => {
+      await insertNotification({ title: 'First', message: 'First message' });
+      await insertNotification({ title: 'Second', message: 'Second message' });
+      await insertNotification({ title: 'Third', message: 'Third message' });
+
+      const res = await request(app)
+        .get('/api/notifications')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(3);
+      // All notifications are returned
+      const titles = res.body.map(n => n.title);
+      expect(titles).toContain('First');
+      expect(titles).toContain('Second');
+      expect(titles).toContain('Third');
+    });
+
+    it('includes is_read status for each notification', async () => {
+      const n1 = await insertNotification({ title: 'Read', message: 'Read notification' });
+      await insertNotification({ title: 'Unread', message: 'Unread notification' });
+
+      // Mark n1 as read for user1
+      await markAsRead(user1.id, n1.id);
+
+      const res = await request(app)
+        .get('/api/notifications')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(2);
+
+      const readNotif = res.body.find(n => n.id === n1.id);
+      const unreadNotif = res.body.find(n => n.title === 'Unread');
+
+      expect(readNotif.is_read).toBe(1);
+      expect(unreadNotif.is_read).toBe(0);
+    });
+
+    it('is_read status is per-user', async () => {
+      const n1 = await insertNotification({ title: 'Shared', message: 'Shared notification' });
+
+      // Mark as read only for user1
+      await markAsRead(user1.id, n1.id);
+
+      // user1 sees it as read
+      const res1 = await request(app)
+        .get('/api/notifications')
+        .set('Authorization', `Bearer ${user1Token}`);
+      expect(res1.body[0].is_read).toBe(1);
+
+      // user2 sees it as unread
+      const res2 = await request(app)
+        .get('/api/notifications')
+        .set('Authorization', `Bearer ${user2Token}`);
+      expect(res2.body[0].is_read).toBe(0);
+    });
+
+    it('respects limit parameter', async () => {
+      for (let i = 0; i < 5; i++) {
+        await insertNotification({ title: `Notification ${i}`, message: `Message ${i}` });
+      }
+
+      const res = await request(app)
+        .get('/api/notifications?limit=2')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(2);
+    });
+
+    it('respects offset parameter', async () => {
+      for (let i = 0; i < 5; i++) {
+        await insertNotification({ title: `Notification ${i}`, message: `Message ${i}` });
+      }
+
+      const res = await request(app)
+        .get('/api/notifications?limit=2&offset=3')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(2);
+    });
+
+    it('clamps limit to max 100', async () => {
+      for (let i = 0; i < 3; i++) {
+        await insertNotification({ title: `Notification ${i}`, message: `Message ${i}` });
+      }
+
+      const res = await request(app)
+        .get('/api/notifications?limit=200')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(3);
+    });
+
+    it('defaults limit to 50 and offset to 0', async () => {
+      const res = await request(app)
+        .get('/api/notifications')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+  });
+
+  // ============================================
+  // UNREAD COUNT
+  // ============================================
+  describe('GET /api/notifications/unread-count', () => {
+    it('returns 401 without authentication', async () => {
+      const res = await request(app).get('/api/notifications/unread-count');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 0 when no notifications exist', async () => {
+      const res = await request(app)
+        .get('/api/notifications/unread-count')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ count: 0 });
+    });
+
+    it('returns count of unread notifications', async () => {
+      const n1 = await insertNotification({ title: 'Read', message: 'Read' });
+      await insertNotification({ title: 'Unread 1', message: 'Unread' });
+      await insertNotification({ title: 'Unread 2', message: 'Unread' });
+
+      // Mark one as read
+      await markAsRead(user1.id, n1.id);
+
+      const res = await request(app)
+        .get('/api/notifications/unread-count')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.count).toBe(2);
+    });
+
+    it('unread count is per-user', async () => {
+      const n1 = await insertNotification({ title: 'Notif 1', message: 'Message' });
+      const n2 = await insertNotification({ title: 'Notif 2', message: 'Message' });
+      await insertNotification({ title: 'Notif 3', message: 'Message' });
+
+      // user1 reads 2 notifications
+      await markAsRead(user1.id, n1.id);
+      await markAsRead(user1.id, n2.id);
+
+      // user2 reads 1 notification
+      await markAsRead(user2.id, n1.id);
+
+      const res1 = await request(app)
+        .get('/api/notifications/unread-count')
+        .set('Authorization', `Bearer ${user1Token}`);
+      expect(res1.body.count).toBe(1);
+
+      const res2 = await request(app)
+        .get('/api/notifications/unread-count')
+        .set('Authorization', `Bearer ${user2Token}`);
+      expect(res2.body.count).toBe(2);
+    });
+  });
+
+  // ============================================
+  // MARK SINGLE NOTIFICATION AS READ
+  // ============================================
+  describe('POST /api/notifications/:id/read', () => {
+    it('returns 401 without authentication', async () => {
+      const res = await request(app).post('/api/notifications/1/read');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 400 for invalid notification ID', async () => {
+      const res = await request(app)
+        .post('/api/notifications/abc/read')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Invalid notification ID');
+    });
+
+    it('returns 404 for non-existent notification', async () => {
+      const res = await request(app)
+        .post('/api/notifications/99999/read')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Notification not found');
+    });
+
+    it('marks a notification as read', async () => {
+      const n1 = await insertNotification({ title: 'To Read', message: 'Mark me read' });
+
+      const res = await request(app)
+        .post(`/api/notifications/${n1.id}/read`)
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+
+      // Verify via unread count
+      const countRes = await request(app)
+        .get('/api/notifications/unread-count')
+        .set('Authorization', `Bearer ${user1Token}`);
+      expect(countRes.body.count).toBe(0);
+    });
+
+    it('is idempotent - marking already-read notification succeeds', async () => {
+      const n1 = await insertNotification({ title: 'Already Read', message: 'Already marked' });
+
+      // Mark read twice
+      await request(app)
+        .post(`/api/notifications/${n1.id}/read`)
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      const res = await request(app)
+        .post(`/api/notifications/${n1.id}/read`)
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+
+    it('only marks for the requesting user', async () => {
+      const n1 = await insertNotification({ title: 'Per User', message: 'Only for one' });
+
+      // user1 marks as read
+      await request(app)
+        .post(`/api/notifications/${n1.id}/read`)
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      // user2 still sees it as unread
+      const countRes = await request(app)
+        .get('/api/notifications/unread-count')
+        .set('Authorization', `Bearer ${user2Token}`);
+      expect(countRes.body.count).toBe(1);
+    });
+  });
+
+  // ============================================
+  // MARK ALL NOTIFICATIONS AS READ
+  // ============================================
+  describe('POST /api/notifications/read-all', () => {
+    it('returns 401 without authentication', async () => {
+      const res = await request(app).post('/api/notifications/read-all');
+      expect(res.status).toBe(401);
+    });
+
+    it('marks all notifications as read', async () => {
+      await insertNotification({ title: 'Notif 1', message: 'Message 1' });
+      await insertNotification({ title: 'Notif 2', message: 'Message 2' });
+      await insertNotification({ title: 'Notif 3', message: 'Message 3' });
+
+      const res = await request(app)
+        .post('/api/notifications/read-all')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+
+      // Verify all are read
+      const countRes = await request(app)
+        .get('/api/notifications/unread-count')
+        .set('Authorization', `Bearer ${user1Token}`);
+      expect(countRes.body.count).toBe(0);
+    });
+
+    it('only marks for the requesting user', async () => {
+      await insertNotification({ title: 'Notif 1', message: 'Message 1' });
+      await insertNotification({ title: 'Notif 2', message: 'Message 2' });
+
+      // user1 marks all as read
+      await request(app)
+        .post('/api/notifications/read-all')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      // user2 still sees them as unread
+      const countRes = await request(app)
+        .get('/api/notifications/unread-count')
+        .set('Authorization', `Bearer ${user2Token}`);
+      expect(countRes.body.count).toBe(2);
+    });
+
+    it('succeeds when no notifications exist (no-op)', async () => {
+      const res = await request(app)
+        .post('/api/notifications/read-all')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+
+    it('does not re-mark already-read notifications (idempotent)', async () => {
+      const n1 = await insertNotification({ title: 'Already Read', message: 'Already' });
+      await insertNotification({ title: 'New Notif', message: 'New' });
+
+      // Mark n1 as read individually
+      await markAsRead(user1.id, n1.id);
+
+      // Then mark all as read
+      const res = await request(app)
+        .post('/api/notifications/read-all')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+
+      // All should be read
+      const countRes = await request(app)
+        .get('/api/notifications/unread-count')
+        .set('Authorization', `Bearer ${user1Token}`);
+      expect(countRes.body.count).toBe(0);
+    });
+  });
+
+  // ============================================
+  // EDGE CASES
+  // ============================================
+  describe('Edge cases', () => {
+    it('notification list includes all fields', async () => {
+      await insertNotification({
+        type: 'new_book',
+        title: 'New Audiobook Added',
+        message: 'A new audiobook has been added to the library',
+        metadata: JSON.stringify({ audiobook_id: 42 })
+      });
+
+      const res = await request(app)
+        .get('/api/notifications')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      const notif = res.body[0];
+      expect(notif).toHaveProperty('id');
+      expect(notif).toHaveProperty('type', 'new_book');
+      expect(notif).toHaveProperty('title', 'New Audiobook Added');
+      expect(notif).toHaveProperty('message', 'A new audiobook has been added to the library');
+      expect(notif).toHaveProperty('metadata');
+      expect(notif).toHaveProperty('created_at');
+      expect(notif).toHaveProperty('is_read', 0);
+    });
+
+    it('handles negative offset gracefully (clamps to 0)', async () => {
+      await insertNotification({ title: 'Test', message: 'Test' });
+
+      const res = await request(app)
+        .get('/api/notifications?offset=-5')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+    });
+
+    it('handles zero limit gracefully (falls back to default 50)', async () => {
+      await insertNotification({ title: 'Test 1', message: 'Msg 1' });
+      await insertNotification({ title: 'Test 2', message: 'Msg 2' });
+
+      const res = await request(app)
+        .get('/api/notifications?limit=0')
+        .set('Authorization', `Bearer ${user1Token}`);
+
+      expect(res.status).toBe(200);
+      // 0 is falsy, so parseInt(0) || 50 defaults to 50
+      expect(res.body).toHaveLength(2);
+    });
+  });
+});

--- a/tests/integration/testApp.js
+++ b/tests/integration/testApp.js
@@ -49,6 +49,7 @@ const { createSettingsRouter } = require('../../server/routes/settings');
 const { createUploadRouter } = require('../../server/routes/upload');
 const { createUsersRouter } = require('../../server/routes/users');
 const { createMaintenanceRouter } = require('../../server/routes/maintenance');
+const { createNotificationsRouter } = require('../../server/routes/notifications');
 
 // Create in-memory database
 function createTestDatabase() {
@@ -287,6 +288,30 @@ function createTestDatabase() {
             used_at DATETIME,
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+          )
+        `);
+
+        // Notifications table
+        db.run(`
+          CREATE TABLE IF NOT EXISTS notifications (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            type TEXT NOT NULL,
+            title TEXT NOT NULL,
+            message TEXT NOT NULL,
+            metadata TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+          )
+        `);
+
+        // User notification reads table
+        db.run(`
+          CREATE TABLE IF NOT EXISTS user_notification_reads (
+            user_id INTEGER NOT NULL,
+            notification_id INTEGER NOT NULL,
+            read_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (user_id, notification_id),
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            FOREIGN KEY (notification_id) REFERENCES notifications(id) ON DELETE CASCADE
           )
         `, (err) => {
           if (err) return reject(err);
@@ -774,6 +799,8 @@ function createTestApp(db) {
     mfaService: mockMfaService,
     bcrypt,
   }));
+
+  app.use('/api/notifications', createNotificationsRouter(baseDeps));
 
   app.use('/api/email', createEmailRouter({
     ...baseDeps,


### PR DESCRIPTION
## Summary
- **Notifications routes** (27 new integration tests): Covers all 4 endpoints (`GET /api/notifications`, `GET /api/notifications/unread-count`, `POST /api/notifications/:id/read`, `POST /api/notifications/read-all`) which previously had zero test coverage. Tests auth, pagination, per-user read tracking, idempotency, and edge cases.
- **AudioPlayer subcomponents** (78 new client tests): Adds tests for `PlaybackControls`, `SpeedMenu`, `SleepTimerMenu`, and `ChapterModal` -- the core player UI components that previously had no test coverage.
- Adds notifications tables and router to the test infrastructure (`testApp.js`) so the notifications route factory can be exercised in integration tests.

**No source code was modified** -- only test files added and test infrastructure updated.

### Test count changes
- Server tests: 1827 -> 1854 (+27)
- Client tests: 41 -> 119 (+78)
- Total new tests: **105**

## Test plan
- [x] `npm test` passes (all 1854 server tests)
- [x] `npm run test:client` passes (all 119 client tests)
- [x] No existing tests broken

Closes #431, closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)