### PR TITLE
Fix duplicate import when organizer moves files during scan

### DIFF
--- a/server/services/fileOrganizer.js
+++ b/server/services/fileOrganizer.js
@@ -10,6 +10,7 @@ const fs = require('fs');
 const path = require('path');
 const db = require('../database');
 const websocketManager = require('./websocketManager');
+const { updatePathCacheEntry } = require('./pathCache');
 
 const audiobooksDir = process.env.AUDIOBOOKS_DIR || path.join(__dirname, '../../data/audiobooks');
 
@@ -339,6 +340,9 @@ async function organizeAudiobook(audiobook) {
         }
       );
     });
+
+    // Update scanner's path cache so a concurrent scan doesn't re-import at the new location
+    updatePathCacheEntry(audiobook.file_path, newFilePath, audiobook.id);
 
     // Clean up empty directories
     cleanupEmptyDirectories(currentDir);


### PR DESCRIPTION
## Summary
- File organizer now updates the scanner's in-memory path cache after moving files
- Prevents duplicate audiobook imports when a user saves metadata (triggering a file move) while a library scan is in progress
- The conversion service already had this same `updatePathCacheEntry` call — the organizer was the only code path missing it

## Test plan
- [ ] Save metadata with series info on a multi-file MP3 audiobook while a scan is running
- [ ] Verify no duplicate entry is created in the library

🤖 Generated with [Claude Code](https://claude.com/claude-code)