### PR TITLE
Add privacy policy for App Store submission

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,36 @@
+# Privacy Policy
+
+**Last updated: March 30, 2026**
+
+## Overview
+
+Sappho is a self-hosted audiobook streaming app. Your data stays on your own server — we do not collect, store, or transmit any personal data to third parties.
+
+## Data Collection
+
+Sappho does **not** collect any personal data. All audiobook data, listening progress, and account information is stored exclusively on your self-hosted Sappho server.
+
+The app communicates only with the server URL you configure during login. No data is sent to the developer or any third-party services.
+
+## Data Storage
+
+- **Authentication tokens** are stored securely in the iOS Keychain on your device.
+- **Playback state** (last position, playback speed) is stored locally on your device using standard iOS storage.
+- **Downloaded audiobooks** are stored in the app's local storage on your device.
+- **All other data** (library, progress, ratings, collections) is stored on your self-hosted server.
+
+## Third-Party Services
+
+Sappho does not integrate with any third-party analytics, advertising, or tracking services.
+
+## Children's Privacy
+
+Sappho is not directed at children under 13. The app does not knowingly collect any information from children.
+
+## Changes
+
+We may update this privacy policy from time to time. Changes will be posted to this page.
+
+## Contact
+
+If you have questions about this privacy policy, please open an issue at [github.com/mondominator/sappho](https://github.com/mondominator/sappho).


### PR DESCRIPTION
## Summary
- Adds PRIVACY.md for the App Store Connect privacy policy URL requirement
- States that Sappho is self-hosted, collects no data, and uses no third-party services

🤖 Generated with [Claude Code](https://claude.com/claude-code)