### PR TITLE
Fix review text cleared after submitting rating

### DIFF
--- a/client/src/components/RatingSection.jsx
+++ b/client/src/components/RatingSection.jsx
@@ -127,7 +127,6 @@ export default function RatingSection({ audiobookId }) {
     try {
       await apiSetRating(audiobookId, userRating, reviewText || null);
       setUserReview(reviewText);
-      setReviewText('');
       // Reload the user's own rating data
       const ratingRes = await getRating(audiobookId).catch(() => ({ data: null }));
       setUserRatingData(ratingRes.data);


### PR DESCRIPTION
## Summary
- Stopped clearing `reviewText` state after submit so text persists when rating picker is reopened

## Test plan
- [ ] Rate a book and write a review, submit
- [ ] Close and reopen the rating picker — review text should still be there

🤖 Generated with [Claude Code](https://claude.com/claude-code)