### PR TITLE
Fix review bubble showing for ratings without review text

### DIFF
--- a/client/src/components/RatingSection.jsx
+++ b/client/src/components/RatingSection.jsx
@@ -180,7 +180,7 @@ export default function RatingSection({ audiobookId }) {
           )}
         </button>
 
-        {reviews.length > 0 && (
+        {allReviewsWithText.length > 0 && (
           <button
             className={`rate-button ${showReviewsList ? 'rated' : ''}`}
             onClick={() => setShowReviewsList(!showReviewsList)}
@@ -189,7 +189,7 @@ export default function RatingSection({ audiobookId }) {
             <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill={showReviewsList ? '#3B82F6' : 'none'} stroke={showReviewsList ? '#3B82F6' : '#9ca3af'} strokeWidth="2">
               <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
             </svg>
-            <span style={{ color: showReviewsList ? '#3B82F6' : '#9ca3af' }}>{reviews.length}</span>
+            <span style={{ color: showReviewsList ? '#3B82F6' : '#9ca3af' }}>{allReviewsWithText.length}</span>
           </button>
         )}
       </div>

--- a/server/routes/ratings.js
+++ b/server/routes/ratings.js
@@ -75,7 +75,7 @@ function createRatingsRouter(deps = {}) {
         `SELECT ur.*, u.username, u.display_name
          FROM user_ratings ur
          JOIN users u ON ur.user_id = u.id
-         WHERE ur.audiobook_id = ?
+         WHERE ur.audiobook_id = ? AND (ur.rating IS NOT NULL OR (ur.review IS NOT NULL AND ur.review != ''))
          ORDER BY ur.updated_at DESC`,
         [req.params.audiobookId]
       );
@@ -122,6 +122,13 @@ function createRatingsRouter(deps = {}) {
       if (isNaN(ratingNum) || ratingNum < 1 || ratingNum > 5) {
         return res.status(400).json({ error: 'Rating must be between 1 and 5' });
       }
+    }
+
+    // Must provide at least a rating or a review
+    const hasRating = rating !== undefined && rating !== null;
+    const hasReview = review && typeof review === 'string' && review.trim() !== '';
+    if (!hasRating && !hasReview) {
+      return res.status(400).json({ error: 'Rating or review is required' });
     }
 
     try {


### PR DESCRIPTION
## Summary
- **Server**: Reject creating empty rating records (null rating + empty review). Filter `/all` endpoint to exclude entries with no rating and no review.
- **Client**: Comment bubble only shows when there are reviews with actual text, not just star-only ratings.

## Test plan
- [ ] Rate a book with stars only (no review text) — bubble should NOT appear
- [ ] Rate a book with review text — bubble shows with correct count
- [ ] Try to POST with null rating and empty review — should get 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)