### PR TITLE
Fix series detail page cover images

### DIFF
--- a/client/src/pages/SeriesDetail.css
+++ b/client/src/pages/SeriesDetail.css
@@ -245,8 +245,7 @@
 .series-books-grid .audiobook-cover img {
   width: 100%;
   height: 100%;
-  object-fit: contain;
-  background: #111827;
+  object-fit: cover;
 }
 
 .series-books-grid .audiobook-cover-placeholder {


### PR DESCRIPTION
Covers were using object-fit: contain in a square container, showing partial images. Changed to cover.