### PR TITLE
History button teal color

### DIFF
--- a/client/src/components/player/FullscreenPlayer.jsx
+++ b/client/src/components/player/FullscreenPlayer.jsx
@@ -394,16 +394,16 @@ export default function FullscreenPlayer({
         </button>
 
         <button
-          className="fullscreen-bottom-btn"
+          className="fullscreen-bottom-btn history-btn"
           onClick={() => setShowHistory(true)}
           aria-label="Listening history"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#06b6d4" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
             <path d="M3 3v5h5"/>
             <path d="M12 7v5l4 2"/>
           </svg>
-          <span>History</span>
+          <span style={{color: '#06b6d4'}}>History</span>
         </button>
       </div>
 


### PR DESCRIPTION
Changes history button to teal (#06B6D4) to be distinct from chapters (blue), speed (purple), and sleep (amber)