### PR TITLE
chore: remove dead waveform visualizer stub

### DIFF
--- a/client/src/__tests__/player/PlaybackControls.test.jsx
+++ b/client/src/__tests__/player/PlaybackControls.test.jsx
@@ -144,16 +144,6 @@ describe('PlaybackControls', () => {
       expect(onSkipToNextChapter).toHaveBeenCalledTimes(1);
     });
 
-    it('shows waveform visualizer when playing', () => {
-      const { container } = renderControls({ playing: true });
-      expect(container.querySelector('.waveform-visualizer')).toBeInTheDocument();
-    });
-
-    it('hides waveform visualizer when paused', () => {
-      const { container } = renderControls({ playing: false });
-      expect(container.querySelector('.waveform-visualizer')).not.toBeInTheDocument();
-    });
-
     it('has proper ARIA group role', () => {
       renderControls();
       expect(screen.getByRole('group', { name: 'Playback controls' })).toBeInTheDocument();

--- a/client/src/components/AudioPlayer.jsx
+++ b/client/src/components/AudioPlayer.jsx
@@ -956,13 +956,6 @@ const AudioPlayer = forwardRef(({ audiobook, progress, onClose }, ref) => {
               </button>
             </>
           )}
-          {playing && (
-            <div className="waveform-visualizer">
-              <div className="waveform-bar"></div>
-              <div className="waveform-bar"></div>
-              <div className="waveform-bar"></div>
-            </div>
-          )}
           <button className="mobile-seek-btn" onClick={skipBackward} title="Rewind 15s" aria-label="Rewind 15 seconds">
             <svg xmlns="http://www.w3.org/2000/svg" width="42" height="42" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="0.6" strokeLinecap="round" strokeLinejoin="round">
               <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"></path>


### PR DESCRIPTION
The mini player's waveform was three empty `<div>` elements referencing CSS classes (`.waveform-visualizer`, `.waveform-bar`) that were never defined in any stylesheet — they rendered with zero size and were invisible to users. The matching test in `PlaybackControls.test.jsx` was on the failing list during the audit (preexisting on main).

Not worth wiring up for real:
- Sappho is an audiobook app. Speech sits in a single mid-frequency band, so a real Web Audio API visualizer would have all bars bouncing in unison.
- iOS and Android don't have a visualizer at all, so removing the web stub brings the three clients into matching behavior.
- The stub had no CSS to fall back on, so deleting it is a pure no-op visually.

## Removed

- 7 lines of dead JSX in `AudioPlayer.jsx`
- 2 obsolete tests in `PlaybackControls.test.jsx`

## Test plan

- [x] `cd client && npm test` — 117/117 pass (was 118/119 with that one preexisting failure — now 117/117 with no failures)
- [x] `cd client && npm run build` — clean
- [x] `npm test` (backend) — 1930/1930 pass