### PR TITLE
Blend fetched external rating into community average

### DIFF
--- a/client/src/components/EditMetadataModal.jsx
+++ b/client/src/components/EditMetadataModal.jsx
@@ -25,6 +25,7 @@ export default function EditMetadataModal({ isOpen, onClose, audiobook, onSave }
     asin: '',
     language: '',
     rating: '',
+    rating_count: '',
     abridged: false,
     cover_url: '',  // URL to download new cover from
   });
@@ -65,6 +66,7 @@ export default function EditMetadataModal({ isOpen, onClose, audiobook, onSave }
         asin: audiobook.asin || '',
         language: audiobook.language || '',
         rating: audiobook.rating || '',
+        rating_count: audiobook.rating_count ?? '',
         abridged: !!audiobook.abridged,  // Convert 0/1 to boolean properly
         cover_url: '',  // Reset cover URL when audiobook changes
       });
@@ -220,6 +222,8 @@ export default function EditMetadataModal({ isOpen, onClose, audiobook, onSave }
       asin: selectedFields.asin ? (pendingResult.asin ?? prev.asin) : prev.asin,
       language: selectedFields.language ? (pendingResult.language ?? prev.language) : prev.language,
       rating: selectedFields.rating ? (pendingResult.rating ?? prev.rating) : prev.rating,
+      // rating_count travels with rating — can't be selected independently
+      rating_count: selectedFields.rating ? (pendingResult.rating_count ?? prev.rating_count) : prev.rating_count,
       abridged: selectedFields.abridged ? (pendingResult.abridged !== undefined ? !!pendingResult.abridged : prev.abridged) : prev.abridged,
       cover_url: selectedFields.cover ? (pendingResult.image || prev.cover_url) : prev.cover_url,
     }));
@@ -280,6 +284,9 @@ export default function EditMetadataModal({ isOpen, onClose, audiobook, onSave }
         series_position: formData.series_position ? parseFloat(formData.series_position) : null,
         published_year: formData.published_year ? parseInt(formData.published_year) : null,
         copyright_year: formData.copyright_year ? parseInt(formData.copyright_year) : null,
+        rating_count: formData.rating_count === '' || formData.rating_count == null
+          ? null
+          : parseInt(formData.rating_count),
         abridged: formData.abridged ? 1 : 0,
       });
 
@@ -321,6 +328,9 @@ export default function EditMetadataModal({ isOpen, onClose, audiobook, onSave }
         series_position: formData.series_position ? parseFloat(formData.series_position) : null,
         published_year: formData.published_year ? parseInt(formData.published_year) : null,
         copyright_year: formData.copyright_year ? parseInt(formData.copyright_year) : null,
+        rating_count: formData.rating_count === '' || formData.rating_count == null
+          ? null
+          : parseInt(formData.rating_count),
         abridged: formData.abridged ? 1 : 0,
       });
 

--- a/server/database.js
+++ b/server/database.js
@@ -139,6 +139,7 @@ function initializeDatabase() {
         genre TEXT,
         tags TEXT,
         rating TEXT,
+        rating_count INTEGER,
         abridged INTEGER DEFAULT 0,
         series TEXT,
         series_position REAL,
@@ -165,6 +166,7 @@ function initializeDatabase() {
     addColumnIfMissing('audiobooks', 'is_multi_file', 'INTEGER DEFAULT 0');
     addColumnIfMissing('audiobooks', 'copyright_year', 'INTEGER');
     addColumnIfMissing('audiobooks', 'rating', 'TEXT');
+    addColumnIfMissing('audiobooks', 'rating_count', 'INTEGER');
     addColumnIfMissing('audiobooks', 'abridged', 'INTEGER DEFAULT 0');
     addColumnIfMissing('audiobooks', 'tags', 'TEXT');
     addColumnIfMissing('audiobooks', 'content_hash', 'VARCHAR(16)');

--- a/server/routes/audiobooks/metadata.js
+++ b/server/routes/audiobooks/metadata.js
@@ -627,7 +627,7 @@ function register(router, { db, authenticateToken, requireAdmin, normalizeGenres
     const {
       title, subtitle, author: rawAuthor, narrator, description, genre, tags,
       series: rawSeries, series_position, published_year, copyright_year,
-      publisher, isbn, asin, language, rating, abridged, cover_url
+      publisher, isbn, asin, language, rating, rating_count, abridged, cover_url
     } = req.body;
     const author = normalizeAuthor(rawAuthor);
 
@@ -674,14 +674,16 @@ function register(router, { db, authenticateToken, requireAdmin, normalizeGenres
         `UPDATE audiobooks
          SET title = ?, subtitle = ?, author = ?, narrator = ?, description = ?, genre = ?, tags = ?,
              series = ?, series_position = ?, published_year = ?, copyright_year = ?,
-             publisher = ?, isbn = ?, asin = ?, language = ?, rating = ?, abridged = ?,
+             publisher = ?, isbn = ?, asin = ?, language = ?, rating = ?, rating_count = ?, abridged = ?,
              cover_path = ?, cover_image = ?,
              updated_at = CURRENT_TIMESTAMP
          WHERE id = ?`,
         [
           title, subtitle, author, narrator, sanitizeHtml(description), genre, tags,
           series, series_position, published_year, copyright_year,
-          publisher, isbn, asin, language, rating, abridged ? 1 : 0,
+          publisher, isbn, asin, language, rating,
+          Number.isFinite(rating_count) ? rating_count : null,
+          abridged ? 1 : 0,
           newCoverPath, newCoverImage,
           id
         ]

--- a/server/routes/ratings.js
+++ b/server/routes/ratings.js
@@ -87,21 +87,51 @@ function createRatingsRouter(deps = {}) {
 
   /**
    * GET /api/ratings/audiobook/:audiobookId/average
-   * Get average rating for an audiobook
+   * Get community average rating for an audiobook, blended with the
+   * external source rating (Audible/Google) weighted by its ratings count.
+   * When the external source didn't provide a count, we use a modest
+   * prior (EXTERNAL_PRIOR_WEIGHT) so one aggregated rating doesn't wash
+   * out a handful of local user ratings.
    */
   router.get('/audiobook/:audiobookId/average', ratingLimiter, authenticateToken, async (req, res) => {
+    const EXTERNAL_PRIOR_WEIGHT = 10;
     try {
-      const result = await dbGet(
-        `SELECT
-           AVG(rating) as average_rating,
-           COUNT(*) as rating_count
-         FROM user_ratings
-         WHERE audiobook_id = ? AND rating IS NOT NULL`,
-        [req.params.audiobookId]
-      );
+      const [userResult, bookResult] = await Promise.all([
+        dbGet(
+          `SELECT COALESCE(SUM(rating), 0) as rating_sum,
+                  COUNT(*) as rating_count
+           FROM user_ratings
+           WHERE audiobook_id = ? AND rating IS NOT NULL`,
+          [req.params.audiobookId]
+        ),
+        dbGet(
+          'SELECT rating, rating_count FROM audiobooks WHERE id = ?',
+          [req.params.audiobookId]
+        ),
+      ]);
+
+      const userSum = Number(userResult?.rating_sum) || 0;
+      const userCount = Number(userResult?.rating_count) || 0;
+
+      const extRating = bookResult?.rating !== null && bookResult?.rating !== undefined
+        ? parseFloat(bookResult.rating)
+        : NaN;
+      const extCountRaw = Number(bookResult?.rating_count);
+      const hasExternal = Number.isFinite(extRating) && extRating > 0;
+      const extWeight = hasExternal
+        ? (Number.isFinite(extCountRaw) && extCountRaw > 0 ? extCountRaw : EXTERNAL_PRIOR_WEIGHT)
+        : 0;
+
+      const totalWeight = userCount + extWeight;
+      const blended = totalWeight > 0
+        ? (userSum + (hasExternal ? extRating * extWeight : 0)) / totalWeight
+        : null;
+
       res.json({
-        average: result.average_rating ? Math.round(result.average_rating * 10) / 10 : null,
-        count: result.rating_count || 0
+        average: blended !== null ? Math.round(blended * 10) / 10 : null,
+        count: userCount + (hasExternal ? extWeight : 0),
+        user_count: userCount,
+        external_count: hasExternal ? extWeight : 0,
       });
     } catch (_err) {
       res.status(500).json({ error: 'Internal server error' });

--- a/server/services/metadataSearch.js
+++ b/server/services/metadataSearch.js
@@ -87,6 +87,7 @@ async function searchAudible(title, author, asin, normalizeGenres) {
             genre: normalizeGenres(genres.join(', ')) || null,
             tags: tags.join(', ') || null,
             rating: book.rating || null,
+            rating_count: Number.isFinite(book.ratingCount) ? book.ratingCount : null,
             image: book.image || null,
             hasChapters: true,
           });
@@ -162,6 +163,7 @@ async function searchGoogleBooks(title, author, normalizeGenres) {
             language: vol.language || null,
             genre: normalizeGenres(vol.categories?.join(', ')) || null,
             rating: vol.averageRating?.toString() || null,
+            rating_count: Number.isFinite(vol.ratingsCount) ? vol.ratingsCount : null,
             image: vol.imageLinks?.thumbnail?.replace('http:', 'https:') || null,
             hasChapters: false,
           });

--- a/tests/integration/ratings.test.js
+++ b/tests/integration/ratings.test.js
@@ -195,6 +195,64 @@ describe('Ratings Routes', () => {
         const decimalPlaces = (res.body.average.toString().split('.')[1] || '').length;
         expect(decimalPlaces).toBeLessThanOrEqual(1);
       });
+
+      describe('blends in external (Audible/Google) rating', () => {
+        const runSql = (sql, params = []) => new Promise((resolve, reject) => {
+          db.run(sql, params, function (err) { return err ? reject(err) : resolve(this); });
+        });
+
+        it('returns external rating alone when no user ratings exist', async () => {
+          const book = await createTestAudiobook(db, { title: 'External Only' });
+          await runSql('UPDATE audiobooks SET rating = ?, rating_count = ? WHERE id = ?', [4.6, 500, book.id]);
+
+          const res = await request(app)
+            .get(`/api/ratings/audiobook/${book.id}/average`)
+            .set('Authorization', `Bearer ${user1Token}`)
+            .expect(200);
+
+          expect(res.body.average).toBeCloseTo(4.6, 1);
+          expect(res.body.user_count).toBe(0);
+          expect(res.body.external_count).toBe(500);
+        });
+
+        it('weights external rating by its ratings_count', async () => {
+          const book = await createTestAudiobook(db, { title: 'Weighted Blend' });
+          // External: 4.5 stars from 100 ratings, one local 1-star → heavily pulled toward 4.5
+          await runSql('UPDATE audiobooks SET rating = ?, rating_count = ? WHERE id = ?', [4.5, 100, book.id]);
+          await request(app)
+            .post(`/api/ratings/audiobook/${book.id}`)
+            .set('Authorization', `Bearer ${user1Token}`)
+            .send({ rating: 1 });
+
+          const res = await request(app)
+            .get(`/api/ratings/audiobook/${book.id}/average`)
+            .set('Authorization', `Bearer ${user1Token}`)
+            .expect(200);
+
+          // (1 + 4.5*100) / 101 ≈ 4.47 → rounds to 4.5
+          expect(res.body.average).toBeCloseTo(4.5, 1);
+          expect(res.body.user_count).toBe(1);
+          expect(res.body.external_count).toBe(100);
+        });
+
+        it('falls back to prior weight of 10 when source did not supply a count', async () => {
+          const book = await createTestAudiobook(db, { title: 'No Count' });
+          await runSql('UPDATE audiobooks SET rating = ?, rating_count = NULL WHERE id = ?', [5, book.id]);
+          await request(app)
+            .post(`/api/ratings/audiobook/${book.id}`)
+            .set('Authorization', `Bearer ${user1Token}`)
+            .send({ rating: 1 });
+
+          const res = await request(app)
+            .get(`/api/ratings/audiobook/${book.id}/average`)
+            .set('Authorization', `Bearer ${user1Token}`)
+            .expect(200);
+
+          // (1 + 5*10) / 11 ≈ 4.6
+          expect(res.body.average).toBeCloseTo(4.6, 1);
+          expect(res.body.external_count).toBe(10);
+        });
+      });
     });
   });
 

--- a/tests/integration/realTestApp.js
+++ b/tests/integration/realTestApp.js
@@ -70,6 +70,8 @@ function createTestDatabase() {
             isbn TEXT,
             asin TEXT,
             year INTEGER,
+            rating REAL,
+            rating_count INTEGER,
             content_hash TEXT,
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             updated_at DATETIME DEFAULT CURRENT_TIMESTAMP

--- a/tests/integration/testApp.js
+++ b/tests/integration/testApp.js
@@ -111,6 +111,7 @@ function createTestDatabase() {
             publisher TEXT,
             copyright_year INTEGER,
             rating REAL,
+            rating_count INTEGER,
             abridged INTEGER DEFAULT 0,
             subtitle TEXT,
             added_by INTEGER,


### PR DESCRIPTION
## Summary
- When metadata is imported from Audible/Google Books, their rating (and ratings count, when available) now flows into the existing community average endpoint
- No iOS/Android client changes needed — `/api/ratings/audiobook/:id/average` returns the same shape, just with the external signal blended in
- Reviews list stays user-only (no fake review cards)

## How the blend works
Weighted / Bayesian-style average:

```
(sum_user_ratings + ext_rating * ext_weight) / (count_user + ext_weight)
```

- `ext_weight` is the source's ratings count when provided (Audible's 500 votes vote 500 times, keeping popular titles honest)
- When the source doesn't provide a count, we use a prior weight of `10` so one aggregated rating doesn't get equal footing with a single local review

## Changes
- `server/database.js` — new `audiobooks.rating_count` column (additive)
- `server/services/metadataSearch.js` — captures `ratingCount` (Audible) and `ratingsCount` (Google Books)
- `server/routes/audiobooks/metadata.js` — persists `rating_count` in PUT
- `server/routes/ratings.js` — blends into `/average`; response adds `user_count` + `external_count` for transparency
- `client/src/components/EditMetadataModal.jsx` — carries `rating_count` alongside `rating` through load/apply/save
- tests: 3 new cases covering external-only, popular-external-dominates-single-user, prior-fallback

## Test plan
- [x] `npm run lint` — passes
- [x] `npm test` — all 1933 tests pass (3 new)
- [ ] Rebuild container, fetch metadata for a book, confirm rating is persisted and community average reflects the blended value
- [ ] Check iOS/Android apps still render the community rating correctly with no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)