### PR TITLE
fix: delete handler silent failure + multi-file upload title fallback

### DIFF
--- a/client/src/components/UploadModal.jsx
+++ b/client/src/components/UploadModal.jsx
@@ -116,11 +116,15 @@ export default function UploadModal({ isOpen, onClose }) {
 
     try {
       if (uploadMode === 'folder') {
-        // Folder upload - all files become one multi-file audiobook
-        const folderName = files[0]?.webkitRelativePath?.split('/')[0] || 'Uploaded Book';
+        // Folder upload - all files become one multi-file audiobook.
+        // Only use the folder name as the book title when it actually
+        // exists (webkitRelativePath is set). Otherwise leave it null and
+        // let the server derive the title from the file's ID3/Vorbis tags.
+        const folderName = files[0]?.webkitRelativePath?.split('/')[0] || null;
+        const progressKey = folderName || files[0]?.name || 'Audiobook';
 
         setUploadProgress({
-          [folderName]: { status: 'uploading', current: 0, total: files.length }
+          [progressKey]: { status: 'uploading', current: 0, total: files.length }
         });
 
         try {
@@ -131,7 +135,7 @@ export default function UploadModal({ isOpen, onClose }) {
           const audiobookId = response.data?.audiobook?.id;
 
           setUploadProgress({
-            [folderName]: { status: 'success', current: files.length, total: files.length }
+            [progressKey]: { status: 'success', current: files.length, total: files.length }
           });
 
           setFiles([]);
@@ -146,12 +150,12 @@ export default function UploadModal({ isOpen, onClose }) {
         } catch (err) {
           if (err.name === 'CanceledError' || err.name === 'AbortError') {
             setUploadProgress({
-              [folderName]: { status: 'cancelled' }
+              [progressKey]: { status: 'cancelled' }
             });
             setError('Upload cancelled');
           } else {
             setUploadProgress({
-              [folderName]: { status: 'error', error: err.response?.data?.error || 'Upload failed' }
+              [progressKey]: { status: 'error', error: err.response?.data?.error || 'Upload failed' }
             });
             setError(err.response?.data?.error || 'Upload failed');
           }

--- a/server/routes/audiobooks/crud.js
+++ b/server/routes/audiobooks/crud.js
@@ -275,19 +275,30 @@ function register(router, { db, authenticateToken, requireAdmin, normalizeGenres
 
   // Delete audiobook (admin only)
   router.delete('/:id', authenticateToken, requireAdmin, async (req, res) => {
+    let audiobook;
     try {
-      const audiobook = await getAudiobookById(req.params.id);
+      audiobook = await getAudiobookById(req.params.id);
       if (!audiobook) {
         return res.status(404).json({ error: 'Audiobook not found' });
       }
 
-      // Delete related data first (explicit cleanup ensures no orphans)
+      // Delete related data first (explicit cleanup ensures no orphans).
+      // FK cascades handle the rest (user_ratings, audiobook_tags, etc.).
       await dbRun('DELETE FROM playback_progress WHERE audiobook_id = ?', [req.params.id]);
       await dbRun('DELETE FROM collection_items WHERE audiobook_id = ?', [req.params.id]);
       await dbRun('DELETE FROM audiobooks WHERE id = ?', [req.params.id]);
+    } catch (err) {
+      logger.error({ err, audiobookId: req.params.id }, 'Failed to delete audiobook from database');
+      return res.status(500).json({ error: 'Internal server error' });
+    }
 
-      // Delete audiobook files only if no other entries reference the same directory
-      if (audiobook.file_path) {
+    // DB delete succeeded. File cleanup is best-effort — if it fails (file
+    // locked by an active stream, FUSE/mergerfs quirks, permissions), the
+    // book is already gone from the user's library so we still report
+    // success and just log the filesystem issue for later cleanup.
+    let fileCleanupWarning = null;
+    if (audiobook.file_path) {
+      try {
         const audioDir = path.dirname(audiobook.file_path);
         const othersInSameDir = await dbAll(
           'SELECT id FROM audiobooks WHERE file_path LIKE ? AND id != ?',
@@ -312,12 +323,17 @@ function register(router, { db, authenticateToken, requireAdmin, normalizeGenres
             // Parent not empty or can't remove - that's fine
           }
         }
+      } catch (fsErr) {
+        fileCleanupWarning = fsErr.message;
+        logger.warn({ err: fsErr, audiobookId: req.params.id, filePath: audiobook.file_path },
+          'Audiobook deleted from DB but file cleanup failed');
       }
-
-      res.json({ message: 'Audiobook deleted successfully' });
-    } catch (_err) {
-      res.status(500).json({ error: 'Internal server error' });
     }
+
+    res.json({
+      message: 'Audiobook deleted successfully',
+      ...(fileCleanupWarning ? { fileCleanupWarning } : {}),
+    });
   });
 }
 

--- a/server/routes/upload.js
+++ b/server/routes/upload.js
@@ -208,13 +208,18 @@ router.post('/multifile', uploadLimiter, authenticateToken, upload.array('audiob
     let series = firstFileMetadata.series || null;
     let seriesPosition = firstFileMetadata.series_position || null;
 
-    // If title looks like a chapter/part name, try to get a better title
-    if (isChapterStyleTitle(title)) {
-      // Try to extract from the first file's original path
+    // If title is missing or looks like a chapter/part name, try to derive one
+    if (!title || isChapterStyleTitle(title)) {
       const originalPath = sanitizeFilename(sortedFiles[0].originalname);
       const pathParts = originalPath.split('/');
       if (pathParts.length > 1) {
-        title = pathParts[0]; // Use folder name
+        // Prefer the top-level folder name from the original upload
+        title = pathParts[0];
+      } else if (!title) {
+        // Last resort — derive from the first file's base name so the
+        // book shows up with a reasonable title instead of NULL/empty.
+        // Admin can clean up the metadata afterwards.
+        title = path.basename(originalPath, path.extname(originalPath));
       }
     }
 


### PR DESCRIPTION
## Context
Surfaced from trying to delete and re-upload *IT* on prod.

## Bugs fixed

### 1. Delete reports \"failed to delete\" even when DB delete succeeded
`DELETE /api/audiobooks/:id` wrapped the entire handler in `catch (_err)` and returned a generic 500 with no log. The book *had* been removed from the DB but `fs.rmSync` threw because the file was still held open by a streaming session (FUSE left a `.fuse_hidden*` artifact that blocked the recursive dir delete). The user saw an error; the library was already correct.

- DB delete and filesystem cleanup now run in separate try blocks and both errors are logged
- Filesystem failure no longer rolls back the user-visible success — response includes a `fileCleanupWarning` field when applicable

### 2. Multi-file upload saved as title \"Uploaded Book\"
`UploadModal.jsx:120` defaulted `bookName` to the literal string `'Uploaded Book'` when `files[0].webkitRelativePath` was missing (happens on ad-hoc multi-file selection). That string was sent to the server and persisted verbatim.

- Only send `bookName` when a real folder name exists; otherwise let the server derive the title from the file's own tags
- Server: when neither `bookName` nor the metadata title is usable, fall back to the first file's base name instead of null/empty

### Related observation (not fixed here)
The prod Sappho container has ~20 leaked FDs on the old `IT.m4b` and a few on `The Stand.mp3` — likely range-request streams that never closed. That's what's keeping the `.fuse_hidden` artifact alive. Worth a separate look at the stream cleanup path.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — all 1930 pass
- [ ] Rebuild container, re-try the delete that failed, confirm it succeeds cleanly
- [ ] Try a multi-file upload without selecting a folder, confirm title comes from tags / filename rather than \"Uploaded Book\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)