### PR TITLE
Allow non-expiring API keys

### DIFF
--- a/server/routes/apiKeys.js
+++ b/server/routes/apiKeys.js
@@ -101,16 +101,23 @@ function createApiKeysRouter(deps = {}) {
     const { key, prefix, hash } = generateApiKey();
     const permissionsStr = permissions || 'read';
 
-    // SECURITY: Default and maximum expiration for API keys
+    // Expiration policy:
+    //   - undefined  -> default 90 days (safe default for callers that omit the field)
+    //   - null or 0  -> never expires (explicit opt-in for long-lived integration keys)
+    //   - positive N -> N days, capped at 365
     const DEFAULT_EXPIRY_DAYS = 90;
     const MAX_EXPIRY_DAYS = 365;
 
-    let expiryDays = expires_in_days || DEFAULT_EXPIRY_DAYS;
-    expiryDays = Math.min(Math.max(1, expiryDays), MAX_EXPIRY_DAYS);
-
-    const expiry = new Date();
-    expiry.setDate(expiry.getDate() + expiryDays);
-    const expiresAt = expiry.toISOString();
+    let expiresAt = null;
+    if (expires_in_days === null || expires_in_days === 0) {
+      expiresAt = null;
+    } else {
+      const requested = expires_in_days === undefined ? DEFAULT_EXPIRY_DAYS : expires_in_days;
+      const expiryDays = Math.min(Math.max(1, requested), MAX_EXPIRY_DAYS);
+      const expiry = new Date();
+      expiry.setDate(expiry.getDate() + expiryDays);
+      expiresAt = expiry.toISOString();
+    }
 
     try {
       const { lastID } = await dbRun(

--- a/tests/integration/apiKeys.test.js
+++ b/tests/integration/apiKeys.test.js
@@ -227,20 +227,24 @@ describe('API Keys Routes', () => {
         expect(Math.abs(expiresAt.getTime() - maxDaysFromNow.getTime())).toBeLessThan(60000);
       });
 
-      it('uses default expiration when 0 is passed (0 is falsy)', async () => {
-        // When expires_in_days is 0, it's treated as falsy and uses the default (90 days)
+      it('treats expires_in_days=0 as never expires', async () => {
         const res = await request(app)
           .post('/api/api-keys')
           .set('Authorization', `Bearer ${user1Token}`)
           .send({ name: 'Zero Expiry Key', expires_in_days: 0 })
           .expect(200);
 
-        const expiresAt = new Date(res.body.expires_at);
-        const ninetyDaysFromNow = new Date();
-        ninetyDaysFromNow.setDate(ninetyDaysFromNow.getDate() + 90);
+        expect(res.body.expires_at).toBeNull();
+      });
 
-        // Should be approximately 90 days from now (the default)
-        expect(Math.abs(expiresAt.getTime() - ninetyDaysFromNow.getTime())).toBeLessThan(60000);
+      it('treats expires_in_days=null as never expires', async () => {
+        const res = await request(app)
+          .post('/api/api-keys')
+          .set('Authorization', `Bearer ${user1Token}`)
+          .send({ name: 'Null Expiry Key', expires_in_days: null })
+          .expect(200);
+
+        expect(res.body.expires_at).toBeNull();
       });
     });
   });


### PR DESCRIPTION
## Summary
- Treat `expires_in_days: null` or `0` as an explicit opt-in to a non-expiring API key
- Keep the 90-day default when the field is omitted entirely
- Keep the 365-day cap on positive values
- The Settings UI already advertises *"Leave empty for no expiration"* — that text was inaccurate; this makes it correct

## Why
Long-lived integrations (e.g. OpsDec) had their keys silently capped at 365 days, so the connection between OpsDec and Sappho broke when the key expired with no proactive notification. Allowing a long-lived key for trusted internal integrations avoids that whole class of outage.

## Test plan
- [x] `npm test` — 1934 passed
- [x] `npm run lint` — clean
- [ ] After deploy: create a no-expiry key from the Sappho UI, verify it works for OpsDec

🤖 Generated with [Claude Code](https://claude.com/claude-code)