### PR TITLE
chore: bump version to 0.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sappho",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Audiobook server with streaming, metadata scraping, and library management",
   "main": "server/index.js",
   "scripts": {


### PR DESCRIPTION
Release with non-expiring API keys (#521).