### PR TITLE
ci: add GitLab CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -142,6 +142,10 @@ lockfile-lint:
         --path package-lock.json
         --type npm
         --validate-package-names
+        --allowed-package-name-aliases
+            "string-width-cjs:string-width"
+            "strip-ansi-cjs:strip-ansi"
+            "wrap-ansi-cjs:wrap-ansi"
         --allowed-hosts npm
         --allowed-schemes "https:"
         --empty-hostname false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,10 +39,12 @@ default:
       - node_modules/
   before_script:
     # sqlite3 prebuilt binaries target a glibc newer than bookworm-slim ships
-    # (GLIBC_2.38 vs 2.36), so build from source. Needs build-essential
-    # + python for node-gyp.
+    # (GLIBC_2.38 vs 2.36). Rebuild ONLY sqlite3 from source; `sharp` and
+    # friends still need their prebuilts because building them from source
+    # requires libvips/etc.
     - apt-get update && apt-get install -y --no-install-recommends python3 make g++ ca-certificates
-    - npm ci --build-from-source=sqlite3
+    - npm ci
+    - npm rebuild sqlite3 --build-from-source
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: $CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,11 @@ default:
     paths:
       - node_modules/
   before_script:
-    - npm ci
+    # sqlite3 prebuilt binaries target a glibc newer than bookworm-slim ships
+    # (GLIBC_2.38 vs 2.36), so build from source. Needs build-essential
+    # + python for node-gyp.
+    - apt-get update && apt-get install -y --no-install-recommends python3 make g++ ca-certificates
+    - npm ci --build-from-source=sqlite3
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: $CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,234 @@
+# Sappho CI/CD
+#
+# Stages:
+#   test    — lint, unit/integration/docker tests, coverage (MRs + main)
+#   audit   — npm audit (server + client), lockfile-lint, gitleaks
+#   owasp   — OWASP API2:2023 broken-authentication scanner
+#   build   — Docker build, push to registry.gitlab.com/bitworx/sappho
+#   scan    — Trivy scans the freshly built image
+#
+# Deploy stage will be added once an SSH key is provisioned on the Unraid
+# host and registered as a CI/CD file variable (mirrors opsdec's pattern).
+
+stages:
+  - test
+  - audit
+  - owasp
+  - build
+  - scan
+
+variables:
+  IMAGE: $CI_REGISTRY_IMAGE
+  NODE_IMAGE: node:20-bookworm-slim
+  TRIVY_IMAGE: aquasec/trivy:0.61.1
+
+default:
+  tags:
+    - bitworx
+
+# ---------------------------------------------------------------------------
+# Shared template for Node-based jobs
+# ---------------------------------------------------------------------------
+.node:
+  image: $NODE_IMAGE
+  cache:
+    key:
+      files:
+        - package-lock.json
+    paths:
+      - node_modules/
+  before_script:
+    - npm ci
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+
+# ---------------------------------------------------------------------------
+# Test stage — runs in parallel
+# ---------------------------------------------------------------------------
+lint:
+  extends: .node
+  stage: test
+  script:
+    - npm run lint
+
+unit-tests:
+  extends: .node
+  stage: test
+  script:
+    - npm run test:unit
+
+integration-tests:
+  extends: .node
+  stage: test
+  variables:
+    JWT_SECRET: test-secret-for-ci-only-not-used-anywhere-else-32chars
+    ENCRYPTION_KEY: test-encryption-key-for-ci-only-32-characters-minimum
+  script:
+    - npm run test:integration
+
+docker-validation:
+  extends: .node
+  stage: test
+  script:
+    - npm run test:docker
+
+coverage:
+  extends: .node
+  stage: test
+  variables:
+    JWT_SECRET: test-secret-for-ci-only-not-used-anywhere-else-32chars
+    ENCRYPTION_KEY: test-encryption-key-for-ci-only-32-characters-minimum
+  script:
+    - npm run test:all
+  artifacts:
+    when: always
+    paths:
+      - coverage/
+    expire_in: 7 days
+    reports:
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage/cobertura-coverage.xml
+
+# ---------------------------------------------------------------------------
+# Audit stage — supply-chain and secret scanning
+# ---------------------------------------------------------------------------
+audit-server:
+  extends: .node
+  stage: audit
+  allow_failure: true
+  script:
+    - npm audit --audit-level=high
+
+audit-client:
+  image: $NODE_IMAGE
+  stage: audit
+  allow_failure: true
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  cache:
+    key:
+      files:
+        - client/package-lock.json
+    paths:
+      - client/node_modules/
+  before_script:
+    - cd client && npm ci
+  script:
+    - npm audit --audit-level=high
+
+# Lockfile integrity — no http URLs, only npm registry, all packages have
+# integrity hashes. Catches typosquatting and lockfile-poisoning attempts.
+lockfile-lint:
+  image: $NODE_IMAGE
+  stage: audit
+  allow_failure: true
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - npx --yes lockfile-lint@4
+        --path package-lock.json
+        --type npm
+        --validate-package-names
+        --allowed-hosts npm
+        --allowed-schemes "https:"
+        --empty-hostname false
+
+gitleaks:
+  image:
+    name: zricethezav/gitleaks:latest
+    entrypoint: [""]
+  stage: audit
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - gitleaks detect --source . --redact --verbose --config=.gitleaks.toml
+
+# ---------------------------------------------------------------------------
+# OWASP API2:2023 — broken-authentication scanner
+# ---------------------------------------------------------------------------
+owasp-api2:
+  extends: .node
+  stage: owasp
+  script:
+    - node .github/scripts/owasp-api2-scanner.js
+  artifacts:
+    when: always
+    paths:
+      - .security-reports/
+    expire_in: 30 days
+
+# ---------------------------------------------------------------------------
+# Build stage — Docker image
+# ---------------------------------------------------------------------------
+build:
+  stage: build
+  image: docker:cli
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - echo "$CI_REGISTRY_PASSWORD" | docker login -u "$CI_REGISTRY_USER" --password-stdin "$CI_REGISTRY"
+    - |
+      # Always include :sha-<short> so the scan stage has a stable reference,
+      # then add release / branch / MR tags on top.
+      SHA_TAG="$IMAGE:sha-$CI_COMMIT_SHORT_SHA"
+      TAGS=""
+      if [ -n "$CI_COMMIT_TAG" ]; then
+        VER=${CI_COMMIT_TAG#v}
+        MAJOR=${VER%%.*}
+        MAJORMINOR=${VER%.*}
+        TAGS="-t $IMAGE:$VER -t $IMAGE:$MAJORMINOR -t $IMAGE:$MAJOR -t $IMAGE:latest -t $SHA_TAG"
+        APP_VERSION="$VER"
+      elif [ "$CI_COMMIT_BRANCH" = "$CI_DEFAULT_BRANCH" ]; then
+        DATE=$(date -u +%Y%m%d)
+        TAGS="-t $IMAGE:latest -t $IMAGE:main -t $SHA_TAG -t $IMAGE:$DATE"
+        APP_VERSION=$(node -p "require('./package.json').version" 2>/dev/null || echo "dev")
+      else
+        TAGS="-t $IMAGE:mr-$CI_MERGE_REQUEST_IID -t $SHA_TAG"
+        APP_VERSION=$(node -p "require('./package.json').version" 2>/dev/null || echo "dev")
+      fi
+
+      docker build --build-arg APP_VERSION="$APP_VERSION" $TAGS .
+
+      # MRs verify the Dockerfile but don't publish.
+      if [ "$CI_PIPELINE_SOURCE" != "merge_request_event" ]; then
+        echo "$TAGS" | tr ' ' '\n' | grep '^' | grep -v '^-t$' | grep -v '^$' | while read -r t; do
+          docker push "$t"
+        done
+      fi
+
+# ---------------------------------------------------------------------------
+# Scan stage — Trivy on the freshly built image
+# ---------------------------------------------------------------------------
+trivy:
+  stage: scan
+  image:
+    name: $TRIVY_IMAGE
+    entrypoint: [""]
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/
+  variables:
+    TRIVY_NO_PROGRESS: "true"
+    TRIVY_CACHE_DIR: ".trivycache/"
+  script:
+    - trivy --version
+    - trivy image
+        --severity HIGH,CRITICAL
+        --exit-code 0
+        --ignore-unfixed
+        "$IMAGE:sha-$CI_COMMIT_SHORT_SHA"
+  cache:
+    paths:
+      - .trivycache/
+  allow_failure: true

--- a/tests/unit/externalMetadata.test.js
+++ b/tests/unit/externalMetadata.test.js
@@ -188,18 +188,18 @@ describe('readTextFile', () => {
     expect(readTextFile(path.join(tmpDir, 'whitespace.txt'))).toBeNull();
   });
 
-  // chmod-based unreadable checks don't apply to root (CI containers run as
-  // root by default), so skip when EUID===0.
-  const skipIfRoot = process.getuid && process.getuid() === 0 ? test.skip : test;
-
-  skipIfRoot('returns null when fs.readFileSync throws (e.g., permission error)', () => {
+  test('returns null when fs.readFileSync throws', () => {
     tmpDir = createTempDir({ 'noperm.txt': 'content' });
     const filePath = path.join(tmpDir, 'noperm.txt');
-    // Make the file unreadable
-    fs.chmodSync(filePath, 0o000);
-    expect(readTextFile(filePath)).toBeNull();
-    // Restore permissions for cleanup
-    fs.chmodSync(filePath, 0o644);
+    // Mock instead of chmod so the test works regardless of EUID (CI runs as root).
+    const spy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+    try {
+      expect(readTextFile(filePath)).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 
@@ -239,20 +239,18 @@ describe('findOpfFile', () => {
     expect(findOpfFile('/nonexistent/directory')).toBeNull();
   });
 
-  const skipIfRoot = process.getuid && process.getuid() === 0 ? test.skip : test;
-
-  skipIfRoot('returns null when directory is not readable', () => {
+  test('returns null when fs.readdirSync throws', () => {
     tmpDir = createTempDir({ 'book.opf': '<package/>' });
-    // Make directory unreadable (but we need it to exist and not have metadata.opf)
-    // Rename the opf file to something else first, then make unreadable
-    const noMetaDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sappho-noperm-'));
-    fs.writeFileSync(path.join(noMetaDir, 'book.opf'), '<package/>');
-    fs.chmodSync(noMetaDir, 0o000);
-    expect(findOpfFile(noMetaDir)).toBeNull();
-    // Restore permissions for cleanup
-    fs.chmodSync(noMetaDir, 0o755);
-    fs.unlinkSync(path.join(noMetaDir, 'book.opf'));
-    fs.rmdirSync(noMetaDir);
+    // Mock instead of chmod — chmod doesn't restrict root, so CI containers
+    // (run as root) would still successfully read the dir.
+    const spy = jest.spyOn(fs, 'readdirSync').mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+    try {
+      expect(findOpfFile(tmpDir)).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 

--- a/tests/unit/externalMetadata.test.js
+++ b/tests/unit/externalMetadata.test.js
@@ -188,7 +188,11 @@ describe('readTextFile', () => {
     expect(readTextFile(path.join(tmpDir, 'whitespace.txt'))).toBeNull();
   });
 
-  test('returns null when fs.readFileSync throws (e.g., permission error)', () => {
+  // chmod-based unreadable checks don't apply to root (CI containers run as
+  // root by default), so skip when EUID===0.
+  const skipIfRoot = process.getuid && process.getuid() === 0 ? test.skip : test;
+
+  skipIfRoot('returns null when fs.readFileSync throws (e.g., permission error)', () => {
     tmpDir = createTempDir({ 'noperm.txt': 'content' });
     const filePath = path.join(tmpDir, 'noperm.txt');
     // Make the file unreadable
@@ -235,7 +239,9 @@ describe('findOpfFile', () => {
     expect(findOpfFile('/nonexistent/directory')).toBeNull();
   });
 
-  test('returns null when directory is not readable', () => {
+  const skipIfRoot = process.getuid && process.getuid() === 0 ? test.skip : test;
+
+  skipIfRoot('returns null when directory is not readable', () => {
     tmpDir = createTempDir({ 'book.opf': '<package/>' });
     // Make directory unreadable (but we need it to exist and not have metadata.opf)
     // Rename the opf file to something else first, then make unreadable


### PR DESCRIPTION
Adds .gitlab-ci.yml mirroring the GitHub Actions workflows. Required for the GitHub → GitLab migration. GitHub workflows stay live; prod continues to pull from GHCR until the cutover.

Stages: test (lint/unit/integration/docker/coverage) → audit (server+client npm audit, lockfile-lint, gitleaks) → owasp (API2 scanner) → build (registry push) → scan (Trivy).

Deploy stage omitted until Unraid SSH key is provisioned as a GitLab CI/CD file variable.

🤖 Generated with [Claude Code](https://claude.ai/code)