### PR TITLE
chore: bump version to 0.8.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sappho",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sappho",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sappho",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Audiobook server with streaming, metadata scraping, and library management",
   "main": "server/index.js",
   "scripts": {


### PR DESCRIPTION
Cuts over Sappho prod to registry.gitlab.com/bitworx/sappho:0.8.6 once tagged. Unraid Sappho template has been pre-updated with ENCRYPTION_KEY (same value as Sappho-Dev, both managed personally — no shared production tenancy) and Repository → :0.8.6.

🤖 Generated with [Claude Code](https://claude.ai/code)